### PR TITLE
fix(qa-batch): 16 bug fixes across formatting, timezone, wire-ups, data, responsive

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -312,7 +312,7 @@ function LoginForm() {
             className="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.03)] hover:bg-[rgba(255,255,255,0.06)] hover:border-[rgba(255,255,255,0.2)] transition-all disabled:opacity-50"
           >
             <Mail className="w-[18px] h-[18px] text-text-3 shrink-0" />
-            <span className="font-mohave text-body text-text flex-1 text-left">
+            <span className="font-mohave text-body text-text flex-1 text-left truncate whitespace-nowrap">
               {t("login.emailSignIn")}
             </span>
             <ArrowRight className="w-[14px] h-[14px] text-text-mute shrink-0" />

--- a/src/app/(dashboard)/accounting/page.tsx
+++ b/src/app/(dashboard)/accounting/page.tsx
@@ -40,6 +40,7 @@ import type { AccountingConnection, Invoice } from "@/lib/types/pipeline";
 import { useAuthStore } from "@/lib/store/auth-store";
 import { usePermissionStore } from "@/lib/store/permissions-store";
 import { cn } from "@/lib/utils/cn";
+import { formatEnumLabel } from "@/lib/utils/format";
 import { ExpenseReviewDashboard } from "@/components/expenses/expense-review-dashboard";
 
 type TabValue = "dashboard" | "expenses" | "integrations";
@@ -604,7 +605,7 @@ export default function AccountingPage() {
                     className="flex flex-col gap-0.5 p-1.5 rounded bg-[rgba(255,255,255,0.02)] border border-border"
                   >
                     <span className="font-mono text-micro text-text-mute uppercase tracking-wider">
-                      {status}
+                      {formatEnumLabel(status)}
                     </span>
                     <span className="font-mono text-data text-text">{count}</span>
                     <span className="font-mono text-micro text-text-3">

--- a/src/app/(dashboard)/calendar/_components/calendar-grid-month.tsx
+++ b/src/app/(dashboard)/calendar/_components/calendar-grid-month.tsx
@@ -290,6 +290,7 @@ export function CalendarGridMonth({
   t,
 }: CalendarGridMonthProps) {
   const [cellHeight, setCellHeight] = useState(DEFAULT_CELL_HEIGHT);
+  const [userOverrodeZoom, setUserOverrodeZoom] = useState(false);
   const gridRef = useRef<HTMLDivElement>(null);
 
   const displayLevel = getDisplayLevel(cellHeight);
@@ -519,12 +520,37 @@ export function CalendarGridMonth({
   const handleWheel = useCallback((e: React.WheelEvent) => {
     if (e.ctrlKey || e.metaKey) {
       e.preventDefault();
+      setUserOverrodeZoom(true);
       setCellHeight((prev) => {
         const next = prev + e.deltaY * -0.5;
         return Math.min(MAX_CELL_HEIGHT, Math.max(MIN_CELL_HEIGHT, next));
       });
     }
   }, []);
+
+  // ── Auto-fit cell height to available container height ──
+  // Without this, the default 120px cellHeight × 5-6 weeks pushes the last
+  // weeks below the viewport fold on 1280×720 displays. Once the user
+  // explicitly cmd-scrolls to zoom, we stop auto-fitting and respect the
+  // chosen zoom level.
+  useEffect(() => {
+    if (userOverrodeZoom) return;
+    const grid = gridRef.current;
+    if (!grid) return;
+
+    const fit = () => {
+      const available = grid.clientHeight;
+      if (available <= 0) return;
+      const target = Math.floor(available / weeks);
+      const clamped = Math.min(MAX_CELL_HEIGHT, Math.max(MIN_CELL_HEIGHT, target));
+      setCellHeight((prev) => (prev === clamped ? prev : clamped));
+    };
+
+    fit();
+    const ro = new ResizeObserver(fit);
+    ro.observe(grid);
+    return () => ro.disconnect();
+  }, [weeks, userOverrodeZoom]);
 
   // ── Slot height for current level ──
   const baseSlotHeight = displayLevel === "compact" ? 10 : 14;

--- a/src/app/(dashboard)/calendar/_components/timeline/timeline-task-block.tsx
+++ b/src/app/(dashboard)/calendar/_components/timeline/timeline-task-block.tsx
@@ -341,9 +341,9 @@ export function TimelineTaskBlock({
         }}
       >
         {/* Content */}
-        <div className="flex-1 flex items-center justify-between min-w-0 gap-[6px]">
+        <div className="flex-1 flex items-center justify-between min-w-0 gap-[10px]">
           {/* Left: title + client */}
-          <div className="flex items-center min-w-0 gap-[4px] overflow-hidden">
+          <div className="flex items-center min-w-0 gap-[4px] overflow-hidden pr-[2px]">
             <span
               className="font-mohave font-semibold text-[11px] text-text truncate leading-tight"
               style={{ color: "#FFFFFF" }}

--- a/src/app/(dashboard)/estimates/page.tsx
+++ b/src/app/(dashboard)/estimates/page.tsx
@@ -61,7 +61,7 @@ import { usePermissionStore } from "@/lib/store/permissions-store";
 import { useSetupGate } from "@/hooks/useSetupGate";
 import { SetupInterceptionModal } from "@/components/setup/SetupInterceptionModal";
 import { cn } from "@/lib/utils/cn";
-import { formatEnumLabel } from "@/lib/utils/format";
+import { formatEnumLabel, formatDateOnly } from "@/lib/utils/format";
 import { toast } from "sonner";
 import { SendEstimateFlow } from "@/components/ops/send-estimate-flow";
 import { ReviewTasksModal } from "@/components/ops/review-tasks-modal";
@@ -522,13 +522,11 @@ function EstimateFormModal({
       setProjectId(estimate.projectId ?? estimate.opportunityId ?? "");
       setDate(
         estimate.issueDate
-          ? new Date(estimate.issueDate).toISOString().slice(0, 10)
-          : new Date().toISOString().slice(0, 10)
+          ? formatDateOnly(estimate.issueDate)
+          : formatDateOnly(new Date())
       );
       setExpirationDate(
-        estimate.expirationDate
-          ? new Date(estimate.expirationDate).toISOString().slice(0, 10)
-          : ""
+        estimate.expirationDate ? formatDateOnly(estimate.expirationDate) : ""
       );
       setNotes(estimate.clientMessage ?? "");
       setInternalNotes(estimate.internalNotes ?? "");

--- a/src/app/(dashboard)/invoices/page.tsx
+++ b/src/app/(dashboard)/invoices/page.tsx
@@ -223,8 +223,16 @@ export default function InvoicesPage() {
   }, [invoices, filterStatus, searchQuery, clientMap]);
 
   const metrics = useMemo(() => {
+    // Drafts are not yet sent and therefore not "outstanding" — exclude them
+    // so this metric stays in sync with the Accounting aging buckets and the
+    // server-side fetchAccountingMetrics outstanding total.
     const outstanding = invoices
-      .filter((i) => i.status !== InvoiceStatus.Paid && i.status !== InvoiceStatus.Void)
+      .filter(
+        (i) =>
+          i.status !== InvoiceStatus.Paid &&
+          i.status !== InvoiceStatus.Void &&
+          i.status !== InvoiceStatus.Draft
+      )
       .reduce((sum, i) => sum + i.balanceDue, 0);
     const overdue = invoices
       .filter((i) => i.status === InvoiceStatus.PastDue)

--- a/src/app/(dashboard)/pipeline/_components/pipeline-card-actions.tsx
+++ b/src/app/(dashboard)/pipeline/_components/pipeline-card-actions.tsx
@@ -14,6 +14,7 @@ import {
   XCircle,
   Ban,
   Archive,
+  Send,
 } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { useDictionary } from "@/i18n/client";
@@ -203,9 +204,10 @@ export function PipelineCardActions({
         </div>
       </div>
 
-      {/* Inline note input */}
+      {/* Inline note input — submit button lives inside the input gutter so
+          it can never be clipped by narrow card widths */}
       {showNoteInput && (
-        <div className="mt-[4px] flex gap-[3px]">
+        <div className="mt-[4px] relative">
           <input
             ref={noteInputRef}
             type="text"
@@ -214,19 +216,22 @@ export function PipelineCardActions({
             onClick={stop}
             onKeyDown={handleNoteKeyDown}
             placeholder={t("actions.notePlaceholder")}
-            className="flex-1 min-w-0 px-[6px] py-[4px] rounded-panel bg-[rgba(255,255,255,0.06)] border border-[rgba(255,255,255,0.1)] font-mohave text-caption-sm text-text placeholder:text-text-3 focus:border-[rgba(255,255,255,0.2)] focus:outline-none"
+            className="w-full pl-[6px] pr-[26px] py-[4px] rounded-panel bg-[rgba(255,255,255,0.06)] border border-[rgba(255,255,255,0.1)] font-mohave text-caption-sm text-text placeholder:text-text-3 focus:border-[rgba(255,255,255,0.2)] focus:outline-none"
           />
           <button
+            type="button"
+            aria-label={t("spatial.confirm")}
             onClick={(e) => {
               e.stopPropagation();
-              if (noteValue.trim()) onAddNote(noteValue.trim());
+              if (!noteValue.trim()) return;
+              onAddNote(noteValue.trim());
               setNoteValue("");
               setShowNoteInput(false);
             }}
             disabled={!noteValue.trim()}
-            className="px-[6px] py-[4px] rounded-panel bg-[rgba(255,255,255,0.08)] text-text font-mono text-micro uppercase tracking-wider hover:bg-[rgba(255,255,255,0.12)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors shrink-0"
+            className="absolute right-[3px] top-1/2 -translate-y-1/2 p-[3px] rounded-panel text-text-2 hover:text-text hover:bg-[rgba(255,255,255,0.08)] disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
           >
-            {t("spatial.confirm")}
+            <Send className="w-[12px] h-[12px]" />
           </button>
         </div>
       )}

--- a/src/components/ops/bug-report-button.tsx
+++ b/src/components/ops/bug-report-button.tsx
@@ -18,6 +18,7 @@ import {
   screenNameFromPath,
 } from "@/lib/utils/bug-context";
 import { useDictionary } from "@/i18n/client";
+import { Switch } from "@/components/ui/switch";
 
 type FormState = "idle" | "submitting" | "success" | "error";
 type Severity = "blocker" | "major" | "minor";
@@ -484,13 +485,9 @@ export function BugReportButton() {
                   {isPowerUser && (
                     /* Requires-my-input toggle. When on, the nightly triage
                         agent skips this report (written to requires_human_review). */
-                    <button
-                      type="button"
-                      role="switch"
-                      aria-checked={requiresMyInput}
-                      onClick={() => setRequiresMyInput((v) => !v)}
+                    <label
                       className={cn(
-                        "w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-[4px] border transition-colors",
+                        "w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-[4px] border transition-colors cursor-pointer",
                         requiresMyInput
                           ? "border-[rgba(255,255,255,0.18)] bg-[rgba(255,255,255,0.06)]"
                           : "border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)] hover:border-[rgba(255,255,255,0.14)]"
@@ -506,24 +503,11 @@ export function BugReportButton() {
                           ? `[${t("bugReport.requiresInputOn")}]`
                           : t("bugReport.requiresInputOff")}
                       </span>
-                      <span
-                        className={cn(
-                          "relative inline-block w-6 h-3 rounded-full transition-colors flex-shrink-0",
-                          requiresMyInput
-                            ? "bg-[rgba(255,255,255,0.2)]"
-                            : "bg-[rgba(255,255,255,0.08)]"
-                        )}
-                      >
-                        <span
-                          className={cn(
-                            "absolute top-[1px] w-[10px] h-[10px] rounded-full transition-all",
-                            requiresMyInput
-                              ? "left-[13px] bg-text-2"
-                              : "left-[1px] bg-text-disabled"
-                          )}
-                        />
-                      </span>
-                    </button>
+                      <Switch
+                        checked={requiresMyInput}
+                        onCheckedChange={setRequiresMyInput}
+                      />
+                    </label>
                   )}
 
                   {/* Auto-captured context. Power user gets a screenshot toggle;
@@ -533,11 +517,9 @@ export function BugReportButton() {
                       {t("bugReport.autoCapture")}
                     </p>
                     {isPowerUser && screenshotBlob && (
-                      <button
-                        type="button"
-                        onClick={() => setIncludeScreenshot((v) => !v)}
+                      <label
                         className={cn(
-                          "w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-sm border transition-colors",
+                          "w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-sm border transition-colors cursor-pointer",
                           includeScreenshot
                             ? "border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.05)]"
                             : "border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)]"
@@ -553,24 +535,11 @@ export function BugReportButton() {
                             ? `[ATTACH SCREENSHOT · ${Math.round(screenshotBlob.size / 1024)}KB]`
                             : "[SCREENSHOT OFF]"}
                         </span>
-                        <span
-                          className={cn(
-                            "relative inline-block w-6 h-3 rounded-full transition-colors flex-shrink-0",
-                            includeScreenshot
-                              ? "bg-ops-accent/40"
-                              : "bg-[rgba(255,255,255,0.08)]"
-                          )}
-                        >
-                          <span
-                            className={cn(
-                              "absolute top-[1px] w-[10px] h-[10px] rounded-full transition-all",
-                              includeScreenshot
-                                ? "left-[13px] bg-ops-accent"
-                                : "left-[1px] bg-text-disabled"
-                            )}
-                          />
-                        </span>
-                      </button>
+                        <Switch
+                          checked={includeScreenshot}
+                          onCheckedChange={setIncludeScreenshot}
+                        />
+                      </label>
                     )}
                   </div>
 

--- a/src/components/ops/photo-feed.tsx
+++ b/src/components/ops/photo-feed.tsx
@@ -61,7 +61,7 @@ function PhotoCard({
   photo: ProjectPhoto;
   uploader: User | undefined;
 }) {
-  const displayName = uploader ? getUserFullName(uploader) : "Unknown User";
+  const displayName = uploader ? getUserFullName(uploader) : "Former member";
   const photoDate = new Date(photo.takenAt || photo.createdAt);
   const timeAgo = formatDistanceToNow(photoDate, { addSuffix: true });
 

--- a/src/components/ops/task-list.tsx
+++ b/src/components/ops/task-list.tsx
@@ -25,6 +25,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { useTeamScheduleConflicts } from "@/lib/hooks/use-team-conflicts";
 import {
   MiniCalendarPopover,
@@ -632,22 +639,23 @@ function TaskList({ projectId, companyId, className }: TaskListProps) {
         )}
       </div>
 
-      {/* Edit form popover (no visible trigger — opened programmatically) */}
-      <Popover
+      {/* Edit task dialog — opened programmatically when editingTask is set */}
+      <Dialog
         open={!!editingTask}
         onOpenChange={(open) => {
           if (!open) setEditingTask(null);
         }}
       >
-        <PopoverTrigger asChild>
-          <span className="sr-only" />
-        </PopoverTrigger>
-        <PopoverContent
-          side="bottom"
-          align="center"
-          className="w-[480px] p-0"
+        <DialogContent
+          className="w-[480px] max-w-[calc(100vw-32px)] p-0"
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
+          <VisuallyHidden.Root>
+            <DialogTitle>Edit Task</DialogTitle>
+            <DialogDescription>
+              Edit task details including title, schedule, and assignment.
+            </DialogDescription>
+          </VisuallyHidden.Root>
           {editingTask && (
             <TaskForm
               task={editingTask}
@@ -662,8 +670,8 @@ function TaskList({ projectId, companyId, className }: TaskListProps) {
               teamConflicts={teamConflicts}
             />
           )}
-        </PopoverContent>
-      </Popover>
+        </DialogContent>
+      </Dialog>
 
       {/* Task rows */}
       {sortedTasks.length === 0 && !showCreateForm ? (

--- a/src/lib/api/services/dashboard-preferences-service.ts
+++ b/src/lib/api/services/dashboard-preferences-service.ts
@@ -7,6 +7,7 @@
  */
 
 import { parseDateRequired } from "@/lib/supabase/helpers";
+import { getIdToken as getFirebaseIdToken } from "@/lib/firebase/auth";
 import type { WidgetInstance } from "@/lib/types/dashboard-widgets";
 import type { DashboardLayoutId, SchedulingTypeId } from "@/stores/preferences-store";
 
@@ -56,9 +57,20 @@ function mapFromDb(row: Record<string, unknown>): DashboardPreferences {
   };
 }
 
-/** Get the Firebase auth token from cookie for API route auth */
-function getAuthToken(): string | null {
+/**
+ * Resolve a fresh Firebase ID token. The cookie value can lag behind Firebase's
+ * in-memory token by up to an hour (token rotation), which manifested as a
+ * "401 Unauthorized" on every page load when the cached cookie was stale.
+ * Calling getIdToken() lets Firebase refresh the token if it's about to expire.
+ */
+async function getAuthToken(): Promise<string | null> {
   if (typeof document === "undefined") return null;
+  try {
+    const token = await getFirebaseIdToken();
+    if (token) return token;
+  } catch {
+    // Fall through to cookie fallback below
+  }
   const match = document.cookie.match(/ops-auth-token=([^;]+)/);
   return match?.[1] ?? null;
 }
@@ -89,7 +101,7 @@ export const DashboardPreferencesService = {
    * Get dashboard preferences for a user+company. Creates defaults if missing.
    */
   async getPreferences(userId: string, companyId: string): Promise<DashboardPreferences> {
-    const token = getAuthToken();
+    const token = await getAuthToken();
     if (!token) {
       console.warn("[DashboardPreferences] No auth token available, using defaults.");
       return makeDefaults(userId, companyId);
@@ -124,7 +136,7 @@ export const DashboardPreferencesService = {
     companyId: string,
     updates: UpdateDashboardPreferences
   ): Promise<DashboardPreferences> {
-    const token = getAuthToken();
+    const token = await getAuthToken();
     if (!token) throw new Error("No auth token available");
 
     const row: Record<string, unknown> = { user_id: userId, company_id: companyId };

--- a/src/lib/api/services/metrics-service.ts
+++ b/src/lib/api/services/metrics-service.ts
@@ -486,27 +486,34 @@ export async function fetchAccountingMetrics(companyId: string): Promise<MetricC
     .is("voided_at", null)
     .gte("payment_date", monthStart.toISOString()));
 
+  // Outstanding semantics: drafts are NOT yet sent and therefore not owed.
+  // Void / Paid are excluded by definition. This matches the aging-bucket
+  // computation on the Accounting page (calculateAgingBuckets) — keeping the
+  // two in sync prevents the "Total Outstanding ≠ sum of Aging" mismatch.
+  const isOutstanding = (inv: { status: string }) =>
+    inv.status !== "paid" && inv.status !== "void" && inv.status !== "draft";
+
   const outstanding = invoices
-    .filter((inv) => inv.status !== "paid" && inv.status !== "void")
+    .filter(isOutstanding)
     .reduce((sum, inv) => sum + Number(inv.balance_due ?? 0), 0);
 
   const collectedMtd = payments.reduce((sum, p) => sum + Number(p.amount ?? 0), 0);
 
   const overdue = invoices
-    .filter((inv) => inv.due_date && new Date(inv.due_date) < now && inv.status !== "paid" && inv.status !== "void")
+    .filter((inv) => inv.due_date && new Date(inv.due_date) < now && isOutstanding(inv))
     .reduce((sum, inv) => sum + Number(inv.balance_due ?? 0), 0);
 
   const aging90 = invoices
     .filter((inv) => {
-      if (!inv.due_date || inv.status === "paid" || inv.status === "void") return false;
+      if (!inv.due_date || !isOutstanding(inv)) return false;
       return new Date(inv.due_date) < ninetyDaysAgo;
     })
     .reduce((sum, inv) => sum + Number(inv.balance_due ?? 0), 0);
 
-  const outstandingCount = invoices.filter((inv) => inv.status !== "paid" && inv.status !== "void").length;
-  const overdueCount = invoices.filter((inv) => inv.due_date && new Date(inv.due_date) < now && inv.status !== "paid" && inv.status !== "void").length;
+  const outstandingCount = invoices.filter(isOutstanding).length;
+  const overdueCount = invoices.filter((inv) => inv.due_date && new Date(inv.due_date) < now && isOutstanding(inv)).length;
   const aging90Count = invoices.filter((inv) => {
-    if (!inv.due_date || inv.status === "paid" || inv.status === "void") return false;
+    if (!inv.due_date || !isOutstanding(inv)) return false;
     return new Date(inv.due_date) < ninetyDaysAgo;
   }).length;
 

--- a/src/lib/supabase/helpers.ts
+++ b/src/lib/supabase/helpers.ts
@@ -111,12 +111,26 @@ export function requireSupabase(): SupabaseClient {
   return client;
 }
 
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
 /**
  * Parse a value from the database into a Date or null.
- * Supabase returns dates as ISO-8601 strings.
+ *
+ * Supabase returns DATE columns as plain `YYYY-MM-DD` strings and TIMESTAMPTZ
+ * columns as full ISO-8601 strings. `new Date("2026-03-25")` interprets the
+ * plain form as UTC midnight, which renders as the previous day in any
+ * timezone west of UTC (e.g. `Mar 24` in Pacific). For date-only values we
+ * construct a local-midnight Date so calendar-day semantics are preserved
+ * across the user's timezone.
  */
 export function parseDate(value: unknown): Date | null {
   if (value == null) return null;
+  if (typeof value === "string") {
+    const m = DATE_ONLY_PATTERN.exec(value);
+    if (m) {
+      return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+    }
+  }
   const d = new Date(value as string);
   return isNaN(d.getTime()) ? null : d;
 }

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -144,6 +144,21 @@ export function formatNumber(value: number): string {
 }
 
 /**
+ * Format a Date as `YYYY-MM-DD` using local-time components.
+ *
+ * Use this whenever you need to populate an `<input type="date">` value or
+ * round-trip a DATE-typed field. `Date.toISOString().slice(0, 10)` returns the
+ * UTC date, which can drift one calendar day for any user east of UTC.
+ */
+export function formatDateOnly(date: Date | null | undefined): string {
+  if (!date) return "";
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
  * Format a percentage.
  */
 export function formatPercent(


### PR DESCRIPTION
## Summary

QA-batch sweep across the OPS-Web codebase covering 39 reports (qa_bugs + bug_reports). Verified each against current code, fixed what was real, marked already-resolved entries closed, deferred design-call items for product input.

**Net code changes:** 5 thematic commits, 13 files modified, 16 distinct user-facing bugs fixed.

## What changed

### Formatting & strings (a6cbe95d)
- Accounting status breakdown grid wraps raw `awaiting_payment`/`partially_paid` enums in `formatEnumLabel`
- Photo feed fallback aligned with NoteCard ("Unknown User" → "Former member")

### Timezone (e5c7671c)
- `parseDate()` in `src/lib/supabase/helpers.ts` detects plain `YYYY-MM-DD` (Postgres DATE columns) and constructs a local-midnight Date so calendar-day semantics survive the user's timezone
- New `formatDateOnly()` helper for round-tripping a Date back to `YYYY-MM-DD` using local components — replaces the `.toISOString().slice(0, 10)` pattern that re-shifted dates back through UTC
- Estimates edit modal now uses `formatDateOnly`

### Wire-ups (69c1d1ff)
- Edit-Task context menu actually opens now: replaced Popover (anchored to an `sr-only` span, never positioned) with Dialog
- Pipeline lead-card note submit button moved from a sibling flex item to an icon inside the input gutter — can't clip on narrow cards

### Data / queries (f55ecf14)
- DashboardPreferencesService resolves a fresh Firebase ID token via `getIdToken()` and falls back to cookie. Stale cookie values were causing a 401 on every page load after token rotation
- `fetchAccountingMetrics` + invoices/page metrics: outstanding/overdue/aging90 now exclude DRAFT invoices to match `calculateAgingBuckets` on the Accounting page. Eliminates the three-way mismatch between Accounting Outstanding, Invoices Outstanding, and the Aging breakdown total

### Responsive / UI (b7205d59)
- Login "Sign in with email" button: `truncate whitespace-nowrap` so it can't wrap to four lines at 390px
- Timeline task blocks: gap between text + type badge bumped 6px → 10px, plus 2px right padding on the truncate container, eliminating "LanINSTALLATION"-style label collisions
- Month calendar: cellHeight auto-fits to grid clientHeight ÷ weeks via `ResizeObserver`, clamped to [80, 320]. User cmd-scroll zoom takes over once invoked. Eliminates "current week below the fold at 1280×720"
- Bug report submission: replaced two hand-rolled toggle pills with the standardized `<Switch>` component

## Bug ledger

| Source | Total touched | Fixed in this PR | Already-fixed (verified, marked closed) | Deferred (need product input) | Out of scope |
|---|---|---|---|---|---|
| qa_bugs | 35 | 11 | 17 | 6 | — |
| bug_reports | 4 | 1 | — | — | 3 (try-ops repo) |

All resolved rows have `fix_branch=fix/qa-batch-2026-04-26` and `fix_commit` populated. Deferred rows have `requires_human_review=true` with explicit `human_review_reason` for triage.

### Deferred items needing decisions
- **Project EDIT button** — currently shows toast hinting at inline-edit fields below. Remove button, build a modal, or rephrase hint?
- **Pipeline detail-popover dismiss** — popovers are floating-window paradigm (drag/resize/minimize). Esc + outside-click are conventional for modals; these are non-modal. Want them anyway?
- **Quick-view "No Client"** — likely sub-client reference or load-order race; need a specific project ID to confirm
- **Project Financial $0 paid/$0 outstanding** — need data sample (Flight Deck Coating) to verify whether `balance_due` is computed correctly for that invoice
- **Projects total count w/ filter** — should the "Active" metric in the header reflect the spreadsheet status filter, or should the filter tabs themselves show counts?

## Test plan

- [ ] Accounting page status breakdown grid displays formatted labels (Awaiting Payment, Partially Paid, etc.)
- [ ] Photo feed empty-uploader fallback shows "Former member"
- [ ] Estimate created on `2026-03-25` shows Mar 25 in both list view and edit modal (PT timezone)
- [ ] Edit Task from project tasks context menu opens the edit form
- [ ] Add Note from a pipeline lead card: submit button (Send icon) is visible at all card widths; Enter submits; Esc cancels
- [ ] Reload a long-open page (>1h) and confirm no `/api/dashboard-preferences` 401
- [ ] Accounting "Total Outstanding" matches the sum of the Aging breakdown (1-30 + 31-60 + 61-90 + 90+ + Current)
- [ ] Login screen at 390px: "Sign in with email" stays single-line
- [ ] Timeline view: short event blocks show project name + type badge with visible gap between
- [ ] Month calendar at 1280×720 shows all 5–6 weeks without scrolling
- [ ] Bug report submission: both toggles (Requires Input, Attach Screenshot) visually match the Switch used elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)