### PR TITLE
fix(qa-round-2): edit modals, financial predicate, photo upload, map drawer, observability, brand loader

### DIFF
--- a/docs/brand/logo-audit-2026-04-26.md
+++ b/docs/brand/logo-audit-2026-04-26.md
@@ -1,0 +1,62 @@
+# OPS Logo Placement Audit — 2026-04-26
+
+Snapshot of every OPS brand-mark render in OPS-Web at the time of Round 2
+QA-batch fixes. Used to derive `docs/brand/logo-system.md`. Re-run on every
+significant brand or layout overhaul.
+
+## Methodology
+
+- `grep -rn "OpsLockup\\|OpsMark\\|OpsLogomark\\|BrandMark" src --include="*.tsx"`
+- `grep -rn "ops-logo\\|ops-mark\\|opslogo\\|opsmark" src public`
+- Manual scan of every `loading.tsx` segment file
+- Captured at SHA = current branch tip
+
+## Results
+
+| File | Line | Variant | Context | Animated? | Notes |
+|---|---|---|---|---|---|
+| `src/app/(dashboard)/layout.tsx` | 73 | vertical-stack | Dashboard auth-gate loading | `animate-pulse-live` (3s) | **Replaced with `<LogoLoader />` in Round 2.** |
+| `src/app/(dashboard)/error.tsx` | 100 | horizontal | Error boundary footer | static | 12px height, opacity 30% — OK |
+| `src/components/layouts/sidebar.tsx` | 362 | mark-only | Sidebar version label | static | 16px, opacity 40% — OK |
+| `src/components/layouts/dashboard-layout.tsx` | 172 | vertical-stack | Onboarding-gate loading | `animate-pulse-live` (3s) | **Replaced with `<LogoLoader />` in Round 2.** |
+| `src/app/(auth)/layout.tsx` | 42 | vertical-stack | Auth-gate loading | `animate-pulse-live` (3s) | **Replaced with `<LogoLoader />` in Round 2.** |
+| `src/app/(auth)/layout.tsx` | 143 | horizontal | Auth-hero corner | static | 32px tall — OK |
+| `src/app/(auth)/login/page.tsx` | 240 | horizontal | Mobile login header | static | 24px — OK |
+| `src/app/(auth)/register/page.tsx` | 220 | horizontal | Mobile register header | static | 24px — OK |
+| `src/app/(auth)/join/page.tsx` | 345 | horizontal | Join footer | static | 24px — OK |
+| `src/app/(auth)/join/welcome/page.tsx` | 54 | horizontal | Welcome header | static | 28px — OK |
+| `src/app/(auth)/pin/page.tsx` | 87 | vertical-stack | PIN hero | static | 80px — OK (full-screen hero) |
+| `src/app/(auth)/locked/page.tsx` | 129 | vertical-stack | Locked hero | static | 96px — OK (full-screen hero) |
+| `src/app/(onboarding)/setup/page.tsx` | 483 | vertical-stack | Setup loading | `animate-pulse` (Tailwind) | **Replaced with `<LogoLoader />` in Round 2.** |
+| `src/app/(onboarding)/setup/page.tsx` | 634 | vertical-stack | Setup form splash | static | **Switched to horizontal in Round 2** per qa_bug `7fdf86b1`. |
+| `src/app/(onboarding)/employee-setup/page.tsx` | 298 | vertical-stack | Employee-setup loading | `animate-pulse` (Tailwind) | **Replaced with `<LogoLoader />` in Round 2.** |
+| `src/app/(onboarding)/employee-setup/page.tsx` | 309 | vertical-stack | Employee-setup form splash | static | OK as full-screen hero, but consider matching the setup-page horizontal switch in a follow-up. |
+| `src/app/(portal)/portal/verify/page.tsx` | 101 | horizontal | "Powered by OPS" footer | static | **Sub-spec sizing**: `h-2.5` (10px) — recommended bump to `h-3.5`. Not changed in Round 2. |
+| `src/app/blog/page.tsx` | 37 | horizontal | Blog index header | static | 40px — OK |
+
+## Variant distribution at audit time
+
+- Horizontal lockup: 9 placements
+- Vertical stack: 9 placements (5 of which were loading-state pulses, now LogoLoader)
+- Mark only: 1 placement
+- LogoLoader (post-Round 2): 5 placements
+
+## Round 2 changes
+
+1. **Loading states (5 sites)** — replaced `animate-pulse(-live) + OpsLockup`
+   pairs with `<LogoLoader size={120|140} />` from
+   `@/components/brand/logo-loader`. Resolves the inconsistency between
+   `animate-pulse-live` (custom, 3s ease-in-out) and Tailwind `animate-pulse`
+   (~2s) that was visible across dashboard vs onboarding loaders.
+2. **Setup splash** (line 634) — vertical → horizontal per the QA bug.
+   `h-24` → `h-16` to match the rest of the in-flow horizontal placements.
+3. **Logo ruleset** — codified at `docs/brand/logo-system.md`.
+
+## Follow-ups (not in Round 2 scope)
+
+- Bump portal verify footer logo from `h-2.5` to `h-3.5` (legibility).
+- Consider switching employee-setup splash (line 309) to horizontal to
+  match `/setup`'s splash. Currently still vertical — no QA bug filed.
+- Audit error boundary opacity: `opacity-30` reads as "broken" rather than
+  "subtle." Consider `opacity-50`.
+- Marketing site (try-ops, ops-site) audit — out of scope for this repo.

--- a/docs/brand/logo-system.md
+++ b/docs/brand/logo-system.md
@@ -1,0 +1,90 @@
+# OPS Logo System
+
+Authoritative ruleset for OPS brand-mark placement and animation in OPS-Web.
+Cross-references the canonical visual spec at
+`ops-design-system-v2/project/colors_and_type.css` and the chevron-split
+loader animation at `ops-design-system-v2/project/logo-loader.jsx`.
+
+## Variants
+
+There are three lockup variants. Pick the one that matches the context, never
+the one that "fits the slot."
+
+| Variant | Component | Aspect | Use for |
+|---|---|---|---|
+| Mark only | `<OpsMark />` | 1:1 | Tight nav/sidebar/footer slots, version markers, dim brand presence |
+| Horizontal lockup | `<OpsLockup orientation="horizontal" />` | ~1.59:1 | Headers, auth screens, setup wizards, marketing footers, any in-flow brand placement |
+| Vertical stack | `<OpsLockup orientation="vertical" />` | 1:1 | Full-screen heroes, lockout, PIN, /locked — the only contexts where the wordmark sits centered below the mark with breathing room |
+
+## Animation: `<LogoLoader />`
+
+Loading screens, splash states, and slow page-transition boundaries MUST use
+the animated `<LogoLoader />` component (`@/components/brand/logo-loader`).
+
+- Pure SVG + Framer Motion, no canvas, no Three.js
+- Chevrons translate ±X only (no Y, no rotation)
+- OPS letters revealed via SVG clip-path as the chevrons separate
+- Single ease curve `[0.22, 1, 0.36, 1]` — no spring/bounce
+- 4.2s default cycle; `loop` prop defaults to `true`
+- `prefers-reduced-motion`: collapses to a static centered horizontal lockup
+  with a 600ms opacity fade-in (same Entry/Arrival emotional beat, different
+  motion). Verified accessible.
+
+```tsx
+import { LogoLoader } from "@/components/brand";
+
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center h-screen bg-background">
+      <LogoLoader size={120} />
+    </div>
+  );
+}
+```
+
+DO NOT pair the LogoLoader with a separate `animate-pulse` wrapper — the
+chevron-split is the animation; layered pulses muddy the intent.
+
+## Placement ruleset
+
+| Context | Variant | Sizing notes |
+|---|---|---|
+| App header (sidebar collapsed) | Mark only | 16–24px, monochrome inherit `currentColor` |
+| App header (sidebar expanded) | Horizontal | 28–32px tall, left-aligned |
+| Sidebar version footer | Mark only | 16px, opacity 0.4 — utilitarian |
+| Login / Register / Join / Welcome | Horizontal | 24–28px on mobile header, 32px on auth-hero corner |
+| /locked, /pin, lockout overlays | Vertical stack | 80–96px centered |
+| Setup wizard splash (in-flow) | Horizontal | 64px (`h-16`) — never vertical |
+| Onboarding loading (auth/employee gate) | `<LogoLoader />` | 120–140px |
+| Dashboard loading (auth + onboarding gates) | `<LogoLoader />` | 120px |
+| Auth layout loading | `<LogoLoader />` | 120px |
+| Empty states (no projects/invoices/etc) | Mark only | 48px, opacity 0.4 |
+| Footer (marketing + portal) | Horizontal | 24px |
+| Email templates | Horizontal | Light-bg-safe asset; 28px |
+| Error / 404 boundary footer | Horizontal | 12–14px, opacity 0.4 |
+
+### Hard rules
+
+1. **Never** use a vertical-stack in a non-hero context. The 1:1 aspect
+   wastes space and reads as "splash" semantically — only correct when the
+   surrounding screen is also a splash.
+2. **Never** apply rotation, Y-translation, or spring physics to any logo
+   render. The brand has zero tolerance for bouncy motion.
+3. **Never** layer two animations (e.g. `animate-pulse` wrapping
+   `<LogoLoader />`). One animation per render.
+4. **Never** drop below 11px of legible mark in any rendering — see the
+   audit's note on the portal verify footer's `h-2.5` placement; bump to
+   `h-3.5` minimum.
+5. The mark is monochrome and inherits `currentColor`. If you need a
+   different colour, set the parent's `color`, not a `fill` prop.
+
+## Migration history
+
+- 2026-04-26 (Round 2 batch PR): Setup splash switched from vertical-stack
+  to horizontal per the QA bug `7fdf86b1`. The five loading-state placements
+  (auth gate, dashboard gate, auth layout, setup, employee-setup) were
+  switched from `animate-pulse(-live)` + `OpsLockup` to `<LogoLoader />`.
+  See `docs/brand/logo-audit-2026-04-26.md` for the full audit.
+- Pre-2026-04-26: ad-hoc placement; some loading screens used Tailwind
+  `animate-pulse`, others used a custom `animate-pulse-live`. Standardised
+  to `<LogoLoader />`.

--- a/public/v2-loader/animations.jsx
+++ b/public/v2-loader/animations.jsx
@@ -1,0 +1,673 @@
+
+// animations.jsx
+// Reusable animation starter: Stage, Timeline, Sprite, easing helpers.
+// Usage (in an HTML file that loads React + Babel):
+//
+//   <Stage width={1280} height={720} duration={10} background="#f6f4ef">
+//     <MyScene />
+//   </Stage>
+//
+// Inside <Stage>, any child can call useTime() to read the current
+// playhead (seconds). Or wrap content in <Sprite start={1} end={4}>...</Sprite>
+// to only render during that window -- children receive a `localTime` and
+// `progress` via the useSprite() hook.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Easing functions (hand-rolled, Popmotion-style) ─────────────────────────
+// All easings take t ∈ [0,1] and return eased t ∈ [0,1] (may overshoot for back/elastic).
+const Easing = {
+  linear: (t) => t,
+
+  // Quad
+  easeInQuad:    (t) => t * t,
+  easeOutQuad:   (t) => t * (2 - t),
+  easeInOutQuad: (t) => (t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t),
+
+  // Cubic
+  easeInCubic:    (t) => t * t * t,
+  easeOutCubic:   (t) => (--t) * t * t + 1,
+  easeInOutCubic: (t) => (t < 0.5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1),
+
+  // Quart
+  easeInQuart:    (t) => t * t * t * t,
+  easeOutQuart:   (t) => 1 - (--t) * t * t * t,
+  easeInOutQuart: (t) => (t < 0.5 ? 8 * t * t * t * t : 1 - 8 * (--t) * t * t * t),
+
+  // Expo
+  easeInExpo:  (t) => (t === 0 ? 0 : Math.pow(2, 10 * (t - 1))),
+  easeOutExpo: (t) => (t === 1 ? 1 : 1 - Math.pow(2, -10 * t)),
+  easeInOutExpo: (t) => {
+    if (t === 0) return 0;
+    if (t === 1) return 1;
+    if (t < 0.5) return 0.5 * Math.pow(2, 20 * t - 10);
+    return 1 - 0.5 * Math.pow(2, -20 * t + 10);
+  },
+
+  // Sine
+  easeInSine:    (t) => 1 - Math.cos((t * Math.PI) / 2),
+  easeOutSine:   (t) => Math.sin((t * Math.PI) / 2),
+  easeInOutSine: (t) => -(Math.cos(Math.PI * t) - 1) / 2,
+
+  // Back (overshoot)
+  easeOutBack: (t) => {
+    const c1 = 1.70158, c3 = c1 + 1;
+    return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+  },
+  easeInBack: (t) => {
+    const c1 = 1.70158, c3 = c1 + 1;
+    return c3 * t * t * t - c1 * t * t;
+  },
+  easeInOutBack: (t) => {
+    const c1 = 1.70158, c2 = c1 * 1.525;
+    return t < 0.5
+      ? (Math.pow(2 * t, 2) * ((c2 + 1) * 2 * t - c2)) / 2
+      : (Math.pow(2 * t - 2, 2) * ((c2 + 1) * (t * 2 - 2) + c2) + 2) / 2;
+  },
+
+  // Elastic
+  easeOutElastic: (t) => {
+    const c4 = (2 * Math.PI) / 3;
+    if (t === 0) return 0;
+    if (t === 1) return 1;
+    return Math.pow(2, -10 * t) * Math.sin((t * 10 - 0.75) * c4) + 1;
+  },
+};
+
+// ── Core interpolation helpers ──────────────────────────────────────────────
+
+// Clamp a value to [min, max]
+const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+
+// interpolate([0, 0.5, 1], [0, 100, 50], ease?) -> fn(t)
+// Popmotion-style: linearly maps t across input keyframes to output values,
+// with optional easing per segment (single fn or array of fns).
+function interpolate(input, output, ease = Easing.linear) {
+  return (t) => {
+    if (t <= input[0]) return output[0];
+    if (t >= input[input.length - 1]) return output[output.length - 1];
+    for (let i = 0; i < input.length - 1; i++) {
+      if (t >= input[i] && t <= input[i + 1]) {
+        const span = input[i + 1] - input[i];
+        const local = span === 0 ? 0 : (t - input[i]) / span;
+        const easeFn = Array.isArray(ease) ? (ease[i] || Easing.linear) : ease;
+        const eased = easeFn(local);
+        return output[i] + (output[i + 1] - output[i]) * eased;
+      }
+    }
+    return output[output.length - 1];
+  };
+}
+
+// animate({from, to, start, end, ease})(t) — simpler single-segment tween.
+// Returns `from` before `start`, `to` after `end`.
+function animate({ from = 0, to = 1, start = 0, end = 1, ease = Easing.easeInOutCubic }) {
+  return (t) => {
+    if (t <= start) return from;
+    if (t >= end) return to;
+    const local = (t - start) / (end - start);
+    return from + (to - from) * ease(local);
+  };
+}
+
+// ── Timeline context ────────────────────────────────────────────────────────
+
+const TimelineContext = React.createContext({ time: 0, duration: 10, playing: false });
+
+const useTime = () => React.useContext(TimelineContext).time;
+const useTimeline = () => React.useContext(TimelineContext);
+
+// ── Sprite ──────────────────────────────────────────────────────────────────
+// Renders children only when the playhead is inside [start, end]. Provides
+// a sub-context with `localTime` (seconds since start) and `progress` (0..1).
+//
+//   <Sprite start={2} end={5}>
+//     {({ localTime, progress }) => <Thing x={progress * 100} />}
+//   </Sprite>
+//
+// Or as a plain wrapper — children can call useSprite() themselves.
+
+const SpriteContext = React.createContext({ localTime: 0, progress: 0, duration: 0 });
+const useSprite = () => React.useContext(SpriteContext);
+
+function Sprite({ start = 0, end = Infinity, children, keepMounted = false }) {
+  const { time } = useTimeline();
+  const visible = time >= start && time <= end;
+  if (!visible && !keepMounted) return null;
+
+  const duration = end - start;
+  const localTime = Math.max(0, time - start);
+  const progress = duration > 0 && isFinite(duration)
+    ? clamp(localTime / duration, 0, 1)
+    : 0;
+
+  const value = { localTime, progress, duration, visible };
+
+  return (
+    <SpriteContext.Provider value={value}>
+      {typeof children === 'function' ? children(value) : children}
+    </SpriteContext.Provider>
+  );
+}
+
+// ── Sample sprite components ────────────────────────────────────────────────
+
+// TextSprite: fades/slides text in on entry, holds, then fades out on exit.
+// Props: text, x, y, size, color, font, entryDur, exitDur, align
+function TextSprite({
+  text,
+  x = 0, y = 0,
+  size = 48,
+  color = '#111',
+  font = 'Inter, system-ui, sans-serif',
+  weight = 600,
+  entryDur = 0.45,
+  exitDur = 0.35,
+  entryEase = Easing.easeOutBack,
+  exitEase = Easing.easeInCubic,
+  align = 'left',
+  letterSpacing = '-0.01em',
+}) {
+  const { localTime, duration } = useSprite();
+  const exitStart = Math.max(0, duration - exitDur);
+
+  let opacity = 1;
+  let ty = 0;
+
+  if (localTime < entryDur) {
+    const t = entryEase(clamp(localTime / entryDur, 0, 1));
+    opacity = t;
+    ty = (1 - t) * 16;
+  } else if (localTime > exitStart) {
+    const t = exitEase(clamp((localTime - exitStart) / exitDur, 0, 1));
+    opacity = 1 - t;
+    ty = -t * 8;
+  }
+
+  const translateX = align === 'center' ? '-50%' : align === 'right' ? '-100%' : '0';
+
+  return (
+    <div style={{
+      position: 'absolute',
+      left: x, top: y,
+      transform: `translate(${translateX}, ${ty}px)`,
+      opacity,
+      fontFamily: font,
+      fontSize: size,
+      fontWeight: weight,
+      color,
+      letterSpacing,
+      whiteSpace: 'pre',
+      lineHeight: 1.1,
+      willChange: 'transform, opacity',
+    }}>
+      {text}
+    </div>
+  );
+}
+
+// ImageSprite: scales + fades in; optional Ken Burns drift during hold.
+function ImageSprite({
+  src,
+  x = 0, y = 0,
+  width = 400, height = 300,
+  entryDur = 0.6,
+  exitDur = 0.4,
+  kenBurns = false,
+  kenBurnsScale = 1.08,
+  radius = 12,
+  fit = 'cover',
+  placeholder = null, // {label: string} for striped placeholder
+}) {
+  const { localTime, duration } = useSprite();
+  const exitStart = Math.max(0, duration - exitDur);
+
+  let opacity = 1;
+  let scale = 1;
+
+  if (localTime < entryDur) {
+    const t = Easing.easeOutCubic(clamp(localTime / entryDur, 0, 1));
+    opacity = t;
+    scale = 0.96 + 0.04 * t;
+  } else if (localTime > exitStart) {
+    const t = Easing.easeInCubic(clamp((localTime - exitStart) / exitDur, 0, 1));
+    opacity = 1 - t;
+    scale = (kenBurns ? kenBurnsScale : 1) + 0.02 * t;
+  } else if (kenBurns) {
+    const holdSpan = exitStart - entryDur;
+    const holdT = holdSpan > 0 ? (localTime - entryDur) / holdSpan : 0;
+    scale = 1 + (kenBurnsScale - 1) * holdT;
+  }
+
+  const content = placeholder ? (
+    <div style={{
+      width: '100%', height: '100%',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: 'repeating-linear-gradient(135deg, #e9e6df 0 10px, #dcd8cf 10px 20px)',
+      color: '#6b6458',
+      fontFamily: 'JetBrains Mono, ui-monospace, monospace',
+      fontSize: 13,
+      letterSpacing: '0.04em',
+      textTransform: 'uppercase',
+    }}>
+      {placeholder.label || 'image'}
+    </div>
+  ) : (
+    <img src={src} alt="" style={{ width: '100%', height: '100%', objectFit: fit, display: 'block' }} />
+  );
+
+  return (
+    <div style={{
+      position: 'absolute',
+      left: x, top: y,
+      width, height,
+      opacity,
+      transform: `scale(${scale})`,
+      transformOrigin: 'center',
+      borderRadius: radius,
+      overflow: 'hidden',
+      willChange: 'transform, opacity',
+    }}>
+      {content}
+    </div>
+  );
+}
+
+// RectSprite: simple rectangle that animates position/size/color via props.
+// Useful demo primitive — takes a `render` fn for per-frame customization.
+function RectSprite({
+  x = 0, y = 0,
+  width = 100, height = 100,
+  color = '#111',
+  radius = 8,
+  entryDur = 0.4,
+  exitDur = 0.3,
+  render, // optional: (ctx) => style overrides
+}) {
+  const spriteCtx = useSprite();
+  const { localTime, duration } = spriteCtx;
+  const exitStart = Math.max(0, duration - exitDur);
+
+  let opacity = 1;
+  let scale = 1;
+
+  if (localTime < entryDur) {
+    const t = Easing.easeOutBack(clamp(localTime / entryDur, 0, 1));
+    opacity = clamp(localTime / entryDur, 0, 1);
+    scale = 0.4 + 0.6 * t;
+  } else if (localTime > exitStart) {
+    const t = Easing.easeInQuad(clamp((localTime - exitStart) / exitDur, 0, 1));
+    opacity = 1 - t;
+    scale = 1 - 0.15 * t;
+  }
+
+  const overrides = render ? render(spriteCtx) : {};
+
+  return (
+    <div style={{
+      position: 'absolute',
+      left: x, top: y,
+      width, height,
+      background: color,
+      borderRadius: radius,
+      opacity,
+      transform: `scale(${scale})`,
+      transformOrigin: 'center',
+      willChange: 'transform, opacity',
+      ...overrides,
+    }} />
+  );
+}
+
+
+function Stage({
+  width = 1280,
+  height = 720,
+  duration = 10,
+  background = '#f6f4ef',
+  fps = 60,
+  loop = true,
+  autoplay = true,
+  persistKey = 'animstage',
+  children,
+}) {
+  const [time, setTime] = React.useState(() => {
+    try {
+      const v = parseFloat(localStorage.getItem(persistKey + ':t') || '0');
+      return isFinite(v) ? clamp(v, 0, duration) : 0;
+    } catch { return 0; }
+  });
+  const [playing, setPlaying] = React.useState(autoplay);
+  const [hoverTime, setHoverTime] = React.useState(null);
+  const [scale, setScale] = React.useState(1);
+
+  const stageRef = React.useRef(null);
+  const canvasRef = React.useRef(null);
+  const rafRef = React.useRef(null);
+  const lastTsRef = React.useRef(null);
+
+  // Persist playhead
+  React.useEffect(() => {
+    try { localStorage.setItem(persistKey + ':t', String(time)); } catch {}
+  }, [time, persistKey]);
+
+  // Auto-scale to fit viewport
+  React.useEffect(() => {
+    if (!stageRef.current) return;
+    const el = stageRef.current;
+    const measure = () => {
+      const barH = 44; // playback bar height
+      const s = Math.min(
+        el.clientWidth / width,
+        (el.clientHeight - barH) / height
+      );
+      setScale(Math.max(0.05, s));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    window.addEventListener('resize', measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, [width, height]);
+
+  // Animation loop
+  React.useEffect(() => {
+    if (!playing) {
+      lastTsRef.current = null;
+      return;
+    }
+    const step = (ts) => {
+      if (lastTsRef.current == null) lastTsRef.current = ts;
+      const dt = (ts - lastTsRef.current) / 1000;
+      lastTsRef.current = ts;
+      setTime((t) => {
+        let next = t + dt;
+        if (next >= duration) {
+          if (loop) next = next % duration;
+          else { next = duration; setPlaying(false); }
+        }
+        return next;
+      });
+      rafRef.current = requestAnimationFrame(step);
+    };
+    rafRef.current = requestAnimationFrame(step);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      lastTsRef.current = null;
+    };
+  }, [playing, duration, loop]);
+
+  // Keyboard: space = play/pause, ← → = seek
+  React.useEffect(() => {
+    const onKey = (e) => {
+      if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA')) return;
+      if (e.code === 'Space') {
+        e.preventDefault();
+        setPlaying(p => !p);
+      } else if (e.code === 'ArrowLeft') {
+        setTime(t => clamp(t - (e.shiftKey ? 1 : 0.1), 0, duration));
+      } else if (e.code === 'ArrowRight') {
+        setTime(t => clamp(t + (e.shiftKey ? 1 : 0.1), 0, duration));
+      } else if (e.key === '0' || e.code === 'Home') {
+        setTime(0);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [duration]);
+
+  const displayTime = hoverTime != null ? hoverTime : time;
+
+  const ctxValue = React.useMemo(
+    () => ({ time: displayTime, duration, playing, setTime, setPlaying }),
+    [displayTime, duration, playing]
+  );
+
+  return (
+    <div
+      ref={stageRef}
+      style={{
+        position: 'absolute', inset: 0,
+        display: 'flex', flexDirection: 'column',
+        alignItems: 'center',
+        background: '#0a0a0a',
+        fontFamily: 'Inter, system-ui, sans-serif',
+      }}
+    >
+      {/* Canvas area — vertically centered in remaining space */}
+      <div style={{
+        flex: 1,
+        width: '100%',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        overflow: 'hidden',
+        minHeight: 0,
+      }}>
+        <div
+          ref={canvasRef}
+          style={{
+            width, height,
+            background,
+            position: 'relative',
+            transform: `scale(${scale})`,
+            transformOrigin: 'center',
+            flexShrink: 0,
+            boxShadow: '0 20px 60px rgba(0,0,0,0.4)',
+            overflow: 'hidden',
+          }}
+        >
+          <TimelineContext.Provider value={ctxValue}>
+            {children}
+          </TimelineContext.Provider>
+        </div>
+      </div>
+
+      {/* Playback bar — stacked below canvas, never overlapping */}
+      <PlaybackBar
+        time={displayTime}
+        actualTime={time}
+        duration={duration}
+        playing={playing}
+        onPlayPause={() => setPlaying(p => !p)}
+        onReset={() => { setTime(0); }}
+        onSeek={(t) => setTime(t)}
+        onHover={(t) => setHoverTime(t)}
+      />
+    </div>
+  );
+}
+
+// ── Playback bar ────────────────────────────────────────────────────────────
+// Play/pause, return-to-begin, scrub track, time display.
+// Uses fixed-width time fields so layout doesn't thrash.
+
+function PlaybackBar({ time, duration, playing, onPlayPause, onReset, onSeek, onHover }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+
+  const timeFromEvent = React.useCallback((e) => {
+    const rect = trackRef.current.getBoundingClientRect();
+    const x = clamp((e.clientX - rect.left) / rect.width, 0, 1);
+    return x * duration;
+  }, [duration]);
+
+  const onTrackMove = (e) => {
+    if (!trackRef.current) return;
+    const t = timeFromEvent(e);
+    if (dragging) {
+      onSeek(t);
+    } else {
+      onHover(t);
+    }
+  };
+
+  const onTrackLeave = () => {
+    if (!dragging) onHover(null);
+  };
+
+  const onTrackDown = (e) => {
+    setDragging(true);
+    const t = timeFromEvent(e);
+    onSeek(t);
+    onHover(null);
+  };
+
+  React.useEffect(() => {
+    if (!dragging) return;
+    const onUp = () => setDragging(false);
+    const onMove = (e) => {
+      if (!trackRef.current) return;
+      const t = timeFromEvent(e);
+      onSeek(t);
+    };
+    window.addEventListener('mouseup', onUp);
+    window.addEventListener('mousemove', onMove);
+    return () => {
+      window.removeEventListener('mouseup', onUp);
+      window.removeEventListener('mousemove', onMove);
+    };
+  }, [dragging, timeFromEvent, onSeek]);
+
+  const pct = duration > 0 ? (time / duration) * 100 : 0;
+  const fmt = (t) => {
+    const total = Math.max(0, t);
+    const m = Math.floor(total / 60);
+    const s = Math.floor(total % 60);
+    const cs = Math.floor((total * 100) % 100);
+    return `${String(m).padStart(1, '0')}:${String(s).padStart(2, '0')}.${String(cs).padStart(2, '0')}`;
+  };
+
+  const mono = 'JetBrains Mono, ui-monospace, SFMono-Regular, monospace';
+
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 12,
+      padding: '8px 16px',
+      background: 'rgba(20,20,20,0.92)',
+      borderTop: '1px solid rgba(255,255,255,0.08)',
+      width: '100%',
+      maxWidth: 680,
+      alignSelf: 'center',
+
+      borderRadius: 8,
+      color: '#f6f4ef',
+      fontFamily: 'Inter, system-ui, sans-serif',
+      userSelect: 'none',
+      flexShrink: 0,
+    }}>
+      <IconButton onClick={onReset} title="Return to start (0)">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path d="M3 2v10M12 2L5 7l7 5V2z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round"/>
+        </svg>
+      </IconButton>
+      <IconButton onClick={onPlayPause} title="Play/pause (space)">
+        {playing ? (
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <rect x="3" y="2" width="3" height="10" fill="currentColor"/>
+            <rect x="8" y="2" width="3" height="10" fill="currentColor"/>
+          </svg>
+        ) : (
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path d="M3 2l9 5-9 5V2z" fill="currentColor"/>
+          </svg>
+        )}
+      </IconButton>
+
+      {/* Current time: fixed width so it doesn't thrash */}
+      <div style={{
+        fontFamily: mono,
+        fontSize: 12,
+        fontVariantNumeric: 'tabular-nums',
+        width: 64, textAlign: 'right',
+        color: '#f6f4ef',
+      }}>
+        {fmt(time)}
+      </div>
+
+      {/* Scrub track */}
+      <div
+        ref={trackRef}
+        onMouseMove={onTrackMove}
+        onMouseLeave={onTrackLeave}
+        onMouseDown={onTrackDown}
+        style={{
+          flex: 1,
+          height: 22,
+          position: 'relative',
+          cursor: 'pointer',
+          display: 'flex', alignItems: 'center',
+        }}
+      >
+        <div style={{
+          position: 'absolute',
+          left: 0, right: 0, height: 4,
+          background: 'rgba(255,255,255,0.12)',
+          borderRadius: 2,
+        }}/>
+        <div style={{
+          position: 'absolute',
+          left: 0, width: `${pct}%`, height: 4,
+          background: 'oklch(72% 0.12 250)',
+          borderRadius: 2,
+        }}/>
+        <div style={{
+          position: 'absolute',
+          left: `${pct}%`, top: '50%',
+          width: 12, height: 12,
+          marginLeft: -6, marginTop: -6,
+          background: '#fff',
+          borderRadius: 6,
+          boxShadow: '0 2px 4px rgba(0,0,0,0.4)',
+        }}/>
+      </div>
+
+      {/* Duration: fixed width */}
+      <div style={{
+        fontFamily: mono,
+        fontSize: 12,
+        fontVariantNumeric: 'tabular-nums',
+        width: 64, textAlign: 'left',
+        color: 'rgba(246,244,239,0.55)',
+      }}>
+        {fmt(duration)}
+      </div>
+    </div>
+  );
+}
+
+function IconButton({ children, onClick, title }) {
+  const [hover, setHover] = React.useState(false);
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        width: 28, height: 28,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        background: hover ? 'rgba(255,255,255,0.12)' : 'rgba(255,255,255,0.04)',
+        border: '1px solid rgba(255,255,255,0.1)',
+        borderRadius: 6,
+        color: '#f6f4ef',
+        cursor: 'pointer',
+        padding: 0,
+        transition: 'background 120ms',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+
+Object.assign(window, {
+  Easing, interpolate, animate, clamp,
+  TimelineContext, useTime, useTimeline,
+  Sprite, SpriteContext, useSprite,
+  TextSprite, ImageSprite, RectSprite,
+  Stage, PlaybackBar,
+});
+

--- a/public/v2-loader/index.html
+++ b/public/v2-loader/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>OPS · Logo Loader</title>
+<style>
+  html, body { margin: 0; padding: 0; background: transparent; height: 100%; overflow: hidden; }
+  #root { position: fixed; inset: 0; }
+  /* Suppress the controls layer baked into the v2 Stage component
+     (PlaybackBar etc). The loader is meant to run autoplay+loop only. */
+  .stage-controls, .twk-panel, .twk-tab { display: none !important; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" crossorigin="anonymous"></script>
+
+<!-- v2 design-system files copied verbatim from
+     /Users/jacksonsweet/Projects/OPS/ops-design-system-v2/project/.
+     Do not edit here — re-copy from the design-system folder if it
+     evolves there. -->
+<script type="text/babel" src="animations.jsx"></script>
+<script type="text/babel" src="logo-loader.jsx"></script>
+
+<script type="text/babel">
+  // Match the LOADER_DEFAULTS object in logo-loader.jsx verbatim. The const
+  // is not exposed on window, so we mirror it here. Sync if the v2 source
+  // changes.
+  const LOADER_DEFAULTS = {
+    "mode": "OPS",
+    "duration": 4.2,
+    "holdIn": 0.35,
+    "sepEnd": 1.10,
+    "typeStart": 0.85,
+    "opsTypeSpeed": 0.09,
+    "longTypeSpeed": 0.085,
+    "holdOut": 3.20,
+    "colEnd": 3.95,
+    "openGap": 820,
+    "longOpenGap": 1500,
+    "chevronColor": "#EDEDED",
+    "markScale": 1.0,
+    "showCaret": true,
+  };
+
+  // Allow the host to override config via URL query params, e.g.
+  // ?mode=LONG&chevronColor=%236F94B0
+  const url = new URL(location.href);
+  for (const key of Object.keys(LOADER_DEFAULTS)) {
+    if (url.searchParams.has(key)) {
+      const raw = url.searchParams.get(key);
+      const orig = LOADER_DEFAULTS[key];
+      if (typeof orig === "number") LOADER_DEFAULTS[key] = parseFloat(raw);
+      else if (typeof orig === "boolean") LOADER_DEFAULTS[key] = raw !== "false";
+      else LOADER_DEFAULTS[key] = raw;
+    }
+  }
+
+  function Loader() {
+    return (
+      <Stage
+        width={1280}
+        height={720}
+        duration={LOADER_DEFAULTS.duration}
+        background="transparent"
+        loop
+        autoplay
+      >
+        <LogoLoaderScene cfg={LOADER_DEFAULTS} />
+      </Stage>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')).render(<Loader />);
+</script>
+</body>
+</html>

--- a/public/v2-loader/index.html
+++ b/public/v2-loader/index.html
@@ -59,18 +59,37 @@
     }
   }
 
+  // Headless timeline. We bypass the v2 <Stage> component because Stage
+  // bakes in a PlaybackBar + 0a0a0a backdrop + box-shadow that we don't want
+  // on a real loading screen. LogoLoaderScene only depends on TimelineContext
+  // (via useTime), which we recreate here with a minimal requestAnimationFrame
+  // loop driving `time` from 0 → duration → loop.
+  function HeadlessTimeline({ duration, children }) {
+    const [time, setTime] = React.useState(0);
+    React.useEffect(() => {
+      let raf = 0;
+      const start = performance.now();
+      const tick = (now) => {
+        const elapsed = (now - start) / 1000;
+        setTime(elapsed % duration);
+        raf = requestAnimationFrame(tick);
+      };
+      raf = requestAnimationFrame(tick);
+      return () => cancelAnimationFrame(raf);
+    }, [duration]);
+
+    return (
+      <TimelineContext.Provider value={{ time, duration, playing: true }}>
+        {children}
+      </TimelineContext.Provider>
+    );
+  }
+
   function Loader() {
     return (
-      <Stage
-        width={1280}
-        height={720}
-        duration={LOADER_DEFAULTS.duration}
-        background="transparent"
-        loop
-        autoplay
-      >
+      <HeadlessTimeline duration={LOADER_DEFAULTS.duration}>
         <LogoLoaderScene cfg={LOADER_DEFAULTS} />
-      </Stage>
+      </HeadlessTimeline>
     );
   }
 

--- a/public/v2-loader/logo-loader.jsx
+++ b/public/v2-loader/logo-loader.jsx
@@ -1,0 +1,329 @@
+/* OPS · Logo Loader — pure-X split.
+ *
+ * Two chevrons from the mark. Upper chevron translates RIGHT, lower chevron
+ * translates LEFT. Text types in between, clipped to the opening gap so the
+ * collapse happens at the same pace as the chevrons return.
+ *
+ * Two modes:
+ *   • "OPS"                — canonical mark wordmark (SVG paths)
+ *   • "OPS JOB MANAGEMENT" — longer line typed in Cake Mono at a natural
+ *                            keystroke cadence (not linear)
+ *
+ * Rules for every mode:
+ *   - NO rotation
+ *   - NO Y translation
+ *   - Only X translation on the chevrons
+ *   - No opacity / colour fades on the text — the chevrons clip it
+ */
+
+// ── Canonical paths from the OPS lockup ────────────────────────────────────
+const CHEV_UPPER = "M826.84,778.71v-350.91l-233.86-116.97-175.42,87.71.1.05,292.23,146.15v292.4l116.92-58.46Z";
+const CHEV_LOWER = "M707.58,1119.3v-.06l-292.32-146.2-.08-292.37-116.75,58.48-.2,350.79.09.05,233.89,116.97,175.37-87.66Z";
+const OPS_O = "M1129.61,931.61v-344.67c0-69.09,41-97.18,110.84-97.18h74.4c69.84,0,110.84,28.09,110.84,97.18v344.67c0,69.09-41,97.18-110.84,97.18h-74.4c-69.84,0-110.84-28.09-110.84-97.18ZM1308.78,974.13c44.03,0,55.42-13.67,55.42-56.18v-317.34c0-42.51-11.39-56.18-55.42-56.18h-62.25c-44.03,0-55.42,13.67-55.42,56.18v317.34c0,42.51,11.39,56.18,55.42,56.18h62.25Z";
+const OPS_P = "M1503.12,494.32h164.74c70.6,0,110.84,28.09,110.84,97.18v129.06c0,69.09-40.24,97.18-110.84,97.18h-103.25v208.02h-61.49V494.32ZM1663.31,763.83c40.24,0,54.66-15.18,54.66-53.9v-107.8c0-38.72-14.42-53.9-54.66-53.9h-98.69v215.61h98.69Z";
+const OPS_S = "M1820.46,931.61v-70.6h61.49v56.94c0,42.51,11.39,56.18,55.42,56.18h53.14c44.03,0,55.42-13.67,55.42-56.18v-33.4c0-27.33-9.11-41.75-27.33-55.42l-139.69-94.9c-33.4-22.02-50.87-48.59-50.87-95.66v-51.62c0-69.09,40.24-97.18,110.84-97.18h51.62c69.85,0,110.84,28.09,110.84,97.18v70.6h-61.49v-56.94c0-42.51-11.39-56.18-55.42-56.18h-39.48c-44.03,0-56.18,13.67-56.18,56.18v31.13c0,27.33,9.11,41.76,28.09,54.66l138.93,94.9c33.4,22.78,51.62,49.35,51.62,96.42v53.9c0,69.09-41,97.18-110.84,97.18h-65.29c-69.85,0-110.84-28.09-110.84-97.18Z";
+
+// ── Natural-cadence keystroke timing ───────────────────────────────────────
+// Per-char delays in seconds. Humans type in bursts: common letter pairs fast,
+// boundaries slower, occasional micro-pauses. Returns an array of cumulative
+// timestamps (when each char appears) given a `baseSpeed` (seconds per char).
+function naturalKeystrokes(text, baseSpeed) {
+  const ts = [];
+  let t = 0;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    const prev = text[i - 1];
+    // Per-char delay factor (multiplier on baseSpeed).
+    let f = 1.0;
+    if (ch === ' ') {
+      // Space itself is quick, but the NEXT letter gets a thinking-pause.
+      f = 0.55;
+    } else if (prev === ' ') {
+      // First letter of a new word — small lead-in delay.
+      f = 1.45;
+    } else if (/[AEIOU]/i.test(ch)) {
+      f = 0.85;  // vowels tend to be quicker
+    } else if (ch === prev) {
+      f = 0.70;  // double letters are fast
+    }
+    // Deterministic pseudo-jitter so it doesn't feel mechanical.
+    const jitter = 0.85 + 0.3 * ((Math.sin(i * 12.9898) * 43758.5453) % 1 + 1) % 1;
+    t += baseSpeed * f * jitter;
+    ts.push(t);
+  }
+  return ts;
+}
+
+// ── Tweakable defaults ─────────────────────────────────────────────────────
+
+const LOADER_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "mode": "OPS",
+  "duration": 4.2,
+  "holdIn": 0.35,
+  "sepEnd": 1.10,
+  "typeStart": 0.85,
+  "opsTypeSpeed": 0.09,
+  "longTypeSpeed": 0.085,
+  "holdOut": 3.20,
+  "colEnd": 3.95,
+  "openGap": 820,
+  "longOpenGap": 1500,
+  "chevronColor": "#EDEDED",
+  "markScale": 1.0,
+  "showCaret": true
+}/*EDITMODE-END*/;
+
+// ── Scene ──────────────────────────────────────────────────────────────────
+
+function LogoLoaderScene({ cfg }) {
+  const t = useTime();
+
+  const isLong = cfg.mode === 'LONG';
+  const longText = 'OPS JOB MANAGEMENT';
+
+  // Type timestamps (cumulative, seconds from typeStart)
+  const longTs = React.useMemo(
+    () => naturalKeystrokes(longText, cfg.longTypeSpeed),
+    [cfg.longTypeSpeed]
+  );
+  const opsTs = React.useMemo(() => {
+    // Short wordmark: three quick, slightly varied keystrokes.
+    const speed = cfg.opsTypeSpeed;
+    return [speed * 1.0, speed * 1.0 + speed * 0.75, speed * 1.0 + speed * 0.75 + speed * 0.85];
+  }, [cfg.opsTypeSpeed]);
+
+  const typeTs = isLong ? longTs : opsTs;
+  const typeEnd = cfg.typeStart + typeTs[typeTs.length - 1];
+
+  // Separation progress
+  const openGap = isLong ? cfg.longOpenGap : cfg.openGap;
+  const sep = (() => {
+    if (t <= cfg.holdIn) return 0;
+    if (t < cfg.sepEnd) {
+      return Easing.easeInOutCubic((t - cfg.holdIn) / (cfg.sepEnd - cfg.holdIn));
+    }
+    if (t < cfg.holdOut) return 1;
+    if (t < cfg.colEnd) {
+      return 1 - Easing.easeInOutCubic((t - cfg.holdOut) / (cfg.colEnd - cfg.holdOut));
+    }
+    return 0;
+  })();
+  const dx = openGap * sep;
+
+  // How many chars are visible
+  const visibleCount = (() => {
+    if (t < cfg.typeStart) return 0;
+    const elapsed = t - cfg.typeStart;
+    let n = 0;
+    for (let i = 0; i < typeTs.length; i++) {
+      if (elapsed >= typeTs[i]) n = i + 1; else break;
+    }
+    return n;
+  })();
+
+  const textColor = cfg.chevronColor;
+
+  // ── Layout ──────────────────────────────────────────────────────────────
+  const CHEV_CX = 562.20;
+  const CHEV_CY = 802.00;
+  const OPS_CX = 1612.95;
+  const OPS_CY = 761.55;
+  const opsShiftX = CHEV_CX - OPS_CX;   // ≈ -1050.75
+  const opsShiftY = CHEV_CY - OPS_CY;   // ≈  40.45
+
+  const vbPad = isLong ? 1800 : 1100;
+  const vbX = CHEV_CX - (2405.66 / 2) - vbPad;
+  const vbW = 2405.66 + vbPad * 2;
+  const vbH = 1511.21;
+
+  return (
+    <div style={{
+      position: 'absolute', inset: 0,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: '#000',
+    }}>
+      <svg
+        viewBox={`${vbX} 0 ${vbW} ${vbH}`}
+        style={{
+          width: `${cfg.markScale * (isLong ? 88 : 72)}%`,
+          maxWidth: isLong ? 1500 : 1200,
+          height: 'auto',
+          overflow: 'visible',
+        }}
+      >
+        {/* Clip the text layer to the opening gap between the chevrons. */}
+        <defs>
+          <clipPath id="ops-gap-clip">
+            <rect
+              x={CHEV_CX - dx}
+              y={-200}
+              width={2 * dx}
+              height={vbH + 400}
+            />
+          </clipPath>
+        </defs>
+
+        <g clipPath="url(#ops-gap-clip)">
+          {isLong ? (
+            <LongText
+              text={longText}
+              visibleCount={visibleCount}
+              totalCount={typeTs.length}
+              color={textColor}
+              centerX={CHEV_CX}
+              centerY={CHEV_CY}
+              showCaret={cfg.showCaret}
+              t={t}
+              typingDone={t >= typeEnd}
+              afterHold={t >= cfg.holdOut}
+            />
+          ) : (
+            <OpsMarkText
+              visibleCount={visibleCount}
+              color={textColor}
+              opsShiftX={opsShiftX}
+              opsShiftY={opsShiftY}
+              showCaret={cfg.showCaret}
+              t={t}
+              typingDone={t >= typeEnd}
+              afterHold={t >= cfg.holdOut}
+            />
+          )}
+        </g>
+
+        {/* UPPER chevron — slides RIGHT. Pure X. */}
+        <path d={CHEV_UPPER} fill={cfg.chevronColor} transform={`translate(${dx}, 0)`} />
+        {/* LOWER chevron — slides LEFT. Pure X. */}
+        <path d={CHEV_LOWER} fill={cfg.chevronColor} transform={`translate(${-dx}, 0)`} />
+      </svg>
+    </div>
+  );
+}
+
+// ── OPS mark wordmark (SVG paths) ─────────────────────────────────────────
+function OpsMarkText({ visibleCount, color, opsShiftX, opsShiftY, showCaret, t, typingDone, afterHold }) {
+  const caretXs = [1129.61, 1503.12, 1820.46];
+  const caretActive = showCaret && !afterHold && visibleCount < 3;
+  return (
+    <g fill={color} transform={`translate(${opsShiftX}, ${opsShiftY})`}>
+      {visibleCount >= 1 && <path d={OPS_O} />}
+      {visibleCount >= 2 && <path d={OPS_P} />}
+      {visibleCount >= 3 && <path d={OPS_S} />}
+      {caretActive && (() => {
+        const caretX = caretXs[visibleCount];
+        const blink = (Math.floor(t * 3) % 2 === 0) ? 1 : 0.25;
+        return (
+          <rect x={caretX} y={1040} width={250} height={40}
+            fill={color} opacity={blink * 0.85} />
+        );
+      })()}
+    </g>
+  );
+}
+
+// ── "OPS JOB MANAGEMENT" — typed in Cake Mono ─────────────────────────────
+function LongText({ text, visibleCount, totalCount, color, centerX, centerY, showCaret, t, typingDone, afterHold }) {
+  // Pick a size that fits comfortably within the gap's vertical extent.
+  // Chevron pair spans y ≈ [427, 1177] → 750u tall. Use ~400u letters.
+  const fontSize = 400;
+  // Monospace → estimate advance. Cake Mono ~0.60em. We'll let the browser
+  // do real layout and just show N chars of the string.
+  const shown = text.slice(0, visibleCount);
+  const caretChar = '_';
+  const caretActive = showCaret && !afterHold && visibleCount < totalCount;
+  const blink = (Math.floor(t * 3) % 2 === 0) ? 1 : 0.35;
+
+  return (
+    <g>
+      <text
+        x={centerX}
+        y={centerY}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill={color}
+        style={{
+          fontFamily: '"Cake Mono", "JetBrains Mono", ui-monospace, monospace',
+          fontWeight: 400,
+          fontSize: `${fontSize}px`,
+          letterSpacing: '0.02em',
+          whiteSpace: 'pre',
+        }}
+      >
+        {shown}
+        {caretActive && (
+          <tspan style={{ opacity: blink }}>{caretChar}</tspan>
+        )}
+      </text>
+    </g>
+  );
+}
+
+function App() {
+  const [cfg, setCfg] = useTweaks(LOADER_DEFAULTS);
+
+  return (
+    <>
+      <Stage
+        width={1280}
+        height={720}
+        duration={cfg.duration}
+        background="#000000"
+        loop
+        autoplay
+      >
+        <LogoLoaderScene cfg={cfg} />
+      </Stage>
+
+      <TweaksPanel title="Tweaks">
+        <TweakSection title="Variant">
+          <TweakRadio
+            label="Wordmark"
+            value={cfg.mode}
+            options={[
+              { value: 'OPS', label: 'OPS (mark)' },
+              { value: 'LONG', label: 'OPS JOB MANAGEMENT' },
+            ]}
+            onChange={(v) => setCfg({ mode: v })}
+          />
+        </TweakSection>
+
+        <TweakSection title="Timing">
+          <TweakSlider label="Total duration" value={cfg.duration} min={2} max={8} step={0.1}
+            onChange={(v) => setCfg({ duration: v })} format={(v) => `${v.toFixed(1)}s`} />
+          <TweakSlider label="Hold in (rest)" value={cfg.holdIn} min={0} max={1.5} step={0.05}
+            onChange={(v) => setCfg({ holdIn: v })} format={(v) => `${v.toFixed(2)}s`} />
+          <TweakSlider label="Separation end" value={cfg.sepEnd} min={0.2} max={2.5} step={0.05}
+            onChange={(v) => setCfg({ sepEnd: v })} format={(v) => `${v.toFixed(2)}s`} />
+          <TweakSlider label="Type start" value={cfg.typeStart} min={0.2} max={3} step={0.05}
+            onChange={(v) => setCfg({ typeStart: v })} format={(v) => `${v.toFixed(2)}s`} />
+          <TweakSlider label="OPS keystroke speed" value={cfg.opsTypeSpeed} min={0.04} max={0.3} step={0.01}
+            onChange={(v) => setCfg({ opsTypeSpeed: v })} format={(v) => `${v.toFixed(2)}s/ch`} />
+          <TweakSlider label="Long keystroke speed" value={cfg.longTypeSpeed} min={0.04} max={0.2} step={0.005}
+            onChange={(v) => setCfg({ longTypeSpeed: v })} format={(v) => `${v.toFixed(3)}s/ch`} />
+          <TweakSlider label="Hold out (steady)" value={cfg.holdOut} min={1} max={7} step={0.05}
+            onChange={(v) => setCfg({ holdOut: v })} format={(v) => `${v.toFixed(2)}s`} />
+          <TweakSlider label="Collapse end" value={cfg.colEnd} min={1.5} max={8} step={0.05}
+            onChange={(v) => setCfg({ colEnd: v })} format={(v) => `${v.toFixed(2)}s`} />
+        </TweakSection>
+
+        <TweakSection title="Layout">
+          <TweakSlider label="OPS chevron travel" value={cfg.openGap} min={0} max={1600} step={10}
+            onChange={(v) => setCfg({ openGap: v })} format={(v) => `${v}u`} />
+          <TweakSlider label="Long chevron travel" value={cfg.longOpenGap} min={400} max={2400} step={10}
+            onChange={(v) => setCfg({ longOpenGap: v })} format={(v) => `${v}u`} />
+          <TweakSlider label="Mark scale" value={cfg.markScale} min={0.4} max={1.4} step={0.05}
+            onChange={(v) => setCfg({ markScale: v })} format={(v) => `${(v*100).toFixed(0)}%`} />
+          <TweakToggle label="Typewriter caret" value={cfg.showCaret}
+            onChange={(v) => setCfg({ showCaret: v })} />
+        </TweakSection>
+
+        <TweakSection title="Colour">
+          <TweakColor label="Chevrons & text" value={cfg.chevronColor}
+            onChange={(v) => setCfg({ chevronColor: v })} />
+        </TweakSection>
+      </TweaksPanel>
+    </>
+  );
+}
+
+Object.assign(window, { App, LogoLoaderScene });

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -5,7 +5,7 @@ import { useRouter, usePathname } from "next/navigation";
 import { useAuthStore } from "@/lib/store/auth-store";
 import { AuthProvider } from "@/components/providers/auth-provider";
 import { useDictionary } from "@/i18n/client";
-import { OpsLockup } from "@/components/brand";
+import { OpsLockup, LogoLoader } from "@/components/brand";
 
 // Routes within (auth) group that authenticated users CAN access
 const authenticatedAllowedRoutes = ["/locked", "/join", "/account-type"];
@@ -38,9 +38,7 @@ function AuthRouteGate({ children }: { children: React.ReactNode }) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-screen bg-background">
-        <div className="flex flex-col items-center gap-2 animate-pulse-live text-text">
-          <OpsLockup orientation="vertical" className="h-16 w-auto" />
-        </div>
+        <LogoLoader size={120} />
       </div>
     );
   }

--- a/src/app/(dashboard)/clients/[id]/page.tsx
+++ b/src/app/(dashboard)/clients/[id]/page.tsx
@@ -34,6 +34,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useGeolocationAddress } from "@/lib/hooks/use-geolocation-address";
 import { Badge } from "@/components/ui/badge";
 import { ConfirmDialog } from "@/components/ops/confirm-dialog";
+import { EditClientModal } from "@/components/ops/edit-client-modal";
 import { toast } from "sonner";
 import {
   useClient,
@@ -219,6 +220,7 @@ export default function ClientDetailPage() {
 
   const { getAddress, loading: locating } = useGeolocationAddress();
   const [isEditing, setIsEditing] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showAddSubClient, setShowAddSubClient] = useState(false);
 
@@ -443,7 +445,7 @@ export default function ClientDetailPage() {
                   variant="secondary"
                   size="sm"
                   className="gap-[6px]"
-                  onClick={() => setIsEditing(true)}
+                  onClick={() => setShowEditModal(true)}
                 >
                   <Edit3 className="w-[14px] h-[14px]" />
                   Edit
@@ -842,6 +844,13 @@ export default function ClientDetailPage() {
           )}
         </div>
       </div>
+
+      {/* Edit Client Modal */}
+      <EditClientModal
+        open={showEditModal}
+        onOpenChange={setShowEditModal}
+        client={clientData}
+      />
 
       {/* Delete Confirmation Dialog */}
       <ConfirmDialog

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -8,7 +8,7 @@ import { useFeatureFlagsStore, selectFlagsReady } from "@/lib/store/feature-flag
 import { AuthProvider } from "@/components/providers/auth-provider";
 import { AnalyticsProvider } from "@/components/providers/analytics-provider";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
-import { OpsLockup } from "@/components/brand";
+import { LogoLoader } from "@/components/brand";
 import { LockoutOverlay } from "@/components/ops/lockout-overlay";
 import { useDictionary } from "@/i18n/client";
 
@@ -69,9 +69,7 @@ function DashboardAuthGate({ children }: { children: React.ReactNode }) {
     return (
       <div className="flex items-center justify-center h-screen bg-background">
         <div className="flex flex-col items-center gap-3">
-          <div className="animate-pulse-live text-text">
-            <OpsLockup orientation="vertical" className="h-16 w-auto" />
-          </div>
+          <LogoLoader size={120} />
           <span className="font-mono text-caption-sm text-text-mute uppercase tracking-widest">
             [preparing your dashboard]
           </span>

--- a/src/app/(dashboard)/map/page.tsx
+++ b/src/app/(dashboard)/map/page.tsx
@@ -10,7 +10,6 @@ import {
   ExternalLink,
   ChevronRight,
   Loader2,
-  List,
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
@@ -186,12 +185,17 @@ export default function MapPage() {
       <div className="px-3 pt-3">
         <MetricsHeader variant="compact" tabId="map" title="Map" metrics={mapMetrics} isLoading={mapMetricsLoading} />
       </div>
-      <div className="flex flex-1 min-h-0 relative">
-      {/* Sidebar */}
+      <div className="flex-1 min-h-0 relative">
+      {/* Slide-out project drawer — overlays the map from the left edge.
+          Closed state hides the panel entirely; the toggle button on the
+          left rail (rendered next to the map) is the open affordance. */}
       <div
         className={cn(
-          "flex flex-col border-r border-border bg-background transition-all duration-200",
-          showSidebar ? "w-[320px]" : "w-0 overflow-hidden"
+          "absolute top-0 bottom-0 left-0 z-[5000]",
+          "flex flex-col border-r border-border bg-background",
+          "transition-transform duration-[250ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+          "w-[360px]",
+          showSidebar ? "translate-x-0" : "-translate-x-full"
         )}
       >
         {/* Header */}
@@ -312,31 +316,39 @@ export default function MapPage() {
         </div>
       </div>
 
-      {/* Map area */}
-      <div className="flex-1 relative">
+      {/* Map area — full-bleed canvas underneath the drawer */}
+      <div className="absolute inset-0">
         <ProjectMap
           projects={filteredProjects}
           selectedProjectId={selectedProjectId}
           onProjectSelect={handleProjectSelect}
         />
 
-        {/* Toggle sidebar button */}
+        {/* Drawer toggle — anchored to the left edge so it always stays the
+            same affordance whether the drawer is open or closed. Sits above
+            the map (z-5000 + 1) so the click target survives the drawer
+            slide animation. */}
         <button
           onClick={() => setShowSidebar(!showSidebar)}
           className={cn(
-            "absolute top-2 left-2 z-[1000]",
-            "w-[36px] h-[36px] rounded-lg",
-            "bg-glass glass-surface/90 backdrop-blur border border-border",
-            "flex items-center justify-center",
-            "text-text-3 hover:text-text transition-colors"
+            "absolute top-2 z-[5001]",
+            "w-[32px] h-[36px] flex items-center justify-center",
+            "bg-glass glass-surface/90 backdrop-blur",
+            "border border-border border-l-2 border-l-ops-accent",
+            "rounded-r-[5px]",
+            "text-text-3 hover:text-text transition-[left,colors] duration-[250ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+            showSidebar ? "left-[360px]" : "left-0"
           )}
           title={showSidebar ? t("map.hideSidebar") : t("map.showSidebar")}
+          aria-label={showSidebar ? t("map.hideSidebar") : t("map.showSidebar")}
+          aria-expanded={showSidebar}
         >
-          {showSidebar ? (
-            <ChevronRight className="w-[16px] h-[16px] rotate-180" />
-          ) : (
-            <List className="w-[16px] h-[16px]" />
-          )}
+          <ChevronRight
+            className={cn(
+              "w-[16px] h-[16px] transition-transform duration-[250ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+              showSidebar && "rotate-180"
+            )}
+          />
         </button>
 
         {/* Map legend */}

--- a/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/src/app/(dashboard)/projects/[id]/page.tsx
@@ -889,12 +889,18 @@ function FinancialTab({ project }: { project: Project }) {
       .filter((i) => i.status !== InvoiceStatus.Void)
       .reduce((sum, i) => sum + i.total, 0),
     paid: invoices.reduce((sum, i) => sum + i.amountPaid, 0),
+    // Outstanding semantics match metrics-service.ts + accounting page aging
+    // buckets: anything not Paid / Void / Draft / WrittenOff is owed. The
+    // earlier hard-coded Sent|PartiallyPaid|PastDue list omitted
+    // AwaitingPayment, which produced $0 outstanding for projects whose
+    // invoices were sitting in that status (e.g. Flight Deck Coating).
     outstanding: invoices
       .filter(
         (i) =>
-          i.status === InvoiceStatus.Sent ||
-          i.status === InvoiceStatus.PartiallyPaid ||
-          i.status === InvoiceStatus.PastDue
+          i.status !== InvoiceStatus.Paid &&
+          i.status !== InvoiceStatus.Void &&
+          i.status !== InvoiceStatus.Draft &&
+          i.status !== InvoiceStatus.WrittenOff
       )
       .reduce((sum, i) => sum + i.balanceDue, 0),
   };

--- a/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/src/app/(dashboard)/projects/[id]/page.tsx
@@ -34,6 +34,7 @@ import { NoteComposer } from "@/components/ops/note-composer";
 import { PhotoFeed } from "@/components/ops/photo-feed";
 import { ProjectDeductionsTab } from "@/components/ops/project-deductions-tab";
 import { PermissionGate } from "@/components/ops/permission-gate";
+import { EditProjectModal } from "@/components/ops/projects/edit-project-modal";
 import {
   useProjectNotes,
   useCreateProjectNote,
@@ -1144,6 +1145,7 @@ export default function ProjectDetailPage() {
     }
   }, [visibleTabs, activeTab]);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   // Data hooks
@@ -1373,10 +1375,7 @@ export default function ProjectDetailPage() {
               variant="secondary"
               size="sm"
               className="gap-[6px]"
-              onClick={() => {
-                toast.info(t("detail.editHint"));
-                window.scrollTo({ top: 0, behavior: "smooth" });
-              }}
+              onClick={() => setShowEditModal(true)}
             >
               <Edit3 className="w-[14px] h-[14px]" />
               {t("detail.edit")}
@@ -1461,6 +1460,13 @@ export default function ProjectDetailPage() {
           </>
         )}
       </AnimatePresence>
+
+      {/* ── Edit Project Modal ──────────────────────────────────────────────── */}
+      <EditProjectModal
+        open={showEditModal}
+        onOpenChange={setShowEditModal}
+        project={project}
+      />
 
       {/* ── Delete Confirmation Dialog ─────────────────────────────────────── */}
       <ConfirmDialog

--- a/src/app/(dashboard)/projects/_components/project-detail-popover.tsx
+++ b/src/app/(dashboard)/projects/_components/project-detail-popover.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { useDictionary } from "@/i18n/client";
+import { useClient } from "@/lib/hooks/use-clients";
 import type { Project } from "@/lib/types/models";
 import { PROJECT_STATUS_COLORS } from "@/lib/types/models";
 import {
@@ -97,6 +98,16 @@ const ProjectDetailPopoverInstance = memo(function ProjectDetailPopoverInstance(
     ? getProjectStatusDisplayName(project.status)
     : state.title;
   const daysInStatus = project ? getDaysInStatus(project) : 0;
+
+  // Fallback: when the parent map hasn't populated (load-order race) but the
+  // project clearly has a clientId, fetch the client directly. The detail page
+  // already does this via useClient — quick-view should match. Verified
+  // against MCP: e.g. Dave Colson is a real parent client; the empty value
+  // here was a timing race, not missing data.
+  const { data: fallbackClient } = useClient(
+    !clientName && project?.clientId ? project.clientId : undefined
+  );
+  const resolvedClientName = clientName || fallbackClient?.name || "";
 
   // ── Drag handling (title bar) — document addEventListener pattern ──
   const handleDragStart = useCallback(
@@ -409,7 +420,7 @@ const ProjectDetailPopoverInstance = memo(function ProjectDetailPopoverInstance(
         {state.activeTab === "overview" && project && (
           <ProjectOverviewTab
             project={project}
-            clientName={clientName}
+            clientName={resolvedClientName}
             statusColor={statusColor}
           />
         )}

--- a/src/app/(onboarding)/employee-setup/page.tsx
+++ b/src/app/(onboarding)/employee-setup/page.tsx
@@ -24,7 +24,7 @@ import { ImageUpload } from "@/components/ops/image-upload";
 import { useAuthStore } from "@/lib/store/auth-store";
 import { useEmployeeSetupStore } from "@/stores/employee-setup-store";
 import { useSignOutStore } from "@/stores/signout-store";
-import { OpsLockup } from "@/components/brand";
+import { OpsLockup, LogoLoader } from "@/components/brand";
 import { getIdToken } from "@/lib/firebase/auth";
 import { cn } from "@/lib/utils/cn";
 
@@ -294,9 +294,7 @@ export default function EmployeeSetupPage() {
   if (authLoading || !currentUser) {
     return (
       <div className="fixed inset-0 bg-background flex items-center justify-center">
-        <div className="animate-pulse text-text">
-          <OpsLockup orientation="vertical" className="h-20 w-auto" />
-        </div>
+        <LogoLoader size={140} />
       </div>
     );
   }

--- a/src/app/(onboarding)/setup/page.tsx
+++ b/src/app/(onboarding)/setup/page.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/lib/analytics/analytics";
 import { useSetupStore, STARFIELD_QUESTIONS } from "@/stores/setup-store";
 import { usePreferencesStore } from "@/stores/preferences-store";
-import { OpsLockup } from "@/components/brand";
+import { OpsLockup, LogoLoader } from "@/components/brand";
 import { useAuthStore } from "@/lib/store/auth-store";
 import { getDefaultWidgetInstancesFromSetup } from "@/lib/utils/widget-defaults";
 import { IdentityStep1, IdentityStep2 } from "@/components/setup/SetupIdentityStep";
@@ -479,9 +479,7 @@ export default function SetupPage() {
   if (!ready) {
     return (
       <div className="fixed inset-0 bg-background flex items-center justify-center">
-        <div className="animate-pulse text-text">
-          <OpsLockup orientation="vertical" className="h-20 w-auto" />
-        </div>
+        <LogoLoader size={140} />
       </div>
     );
   }
@@ -631,7 +629,10 @@ export default function SetupPage() {
         className="text-text mb-4 focus:outline-none"
       >
         <span className="sr-only">OPS</span>
-        <OpsLockup orientation="vertical" className="h-24 w-auto mx-auto" title="" />
+        {/* Setup splash uses the horizontal lockup per logo ruleset
+            (docs/brand/logo-system.md) — vertical-stack is reserved for
+            full-screen hero contexts (locked, PIN, lockout). */}
+        <OpsLockup orientation="horizontal" className="h-16 w-auto mx-auto" title="" />
       </h1>
 
       {/* Glass surface card */}

--- a/src/app/api/cron/email-ingest-heartbeat/route.ts
+++ b/src/app/api/cron/email-ingest-heartbeat/route.ts
@@ -1,0 +1,202 @@
+/**
+ * GET /api/cron/email-ingest-heartbeat
+ *
+ * Phase C observability heartbeat. Runs every 15 min.
+ *
+ * For each active email_connections row, checks whether ANY ingestion
+ * activity has occurred in the last 60 minutes:
+ *   - inserts in `email_threads` (provider sync wrote a thread)
+ *   - inserts in `opportunities` with source='email' (lead-creation fired)
+ *
+ * If a company has at least one active integration but ZERO inserts in the
+ * window, that's a strong signal the pipeline is silently broken — sends a
+ * single SendGrid email + writes a notification rail entry. Runs are
+ * deduplicated to one alert per company per 4 hours so a paused inbox
+ * doesn't flood the inbox.
+ *
+ * Auth: same Bearer ${CRON_SECRET} pattern as the other cron endpoints.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import { sendTransactionalEmail } from "@/lib/email/sendgrid";
+
+export const maxDuration = 60;
+
+const HEARTBEAT_WINDOW_MS = 60 * 60 * 1000; // 1h
+const ALERT_DEDUP_MS = 4 * 60 * 60 * 1000; // 4h
+
+interface HeartbeatRow {
+  company_id: string;
+  triggered_at: string;
+}
+
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET not configured" },
+      { status: 500 }
+    );
+  }
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = getServiceRoleClient();
+  const since = new Date(Date.now() - HEARTBEAT_WINDOW_MS).toISOString();
+
+  // 1. Active email connections, grouped by company
+  const { data: connections, error: connErr } = await supabase
+    .from("email_connections")
+    .select("company_id, provider, email")
+    .eq("status", "active")
+    .eq("sync_enabled", true);
+  if (connErr) {
+    console.error("[email-heartbeat] fetch connections failed", connErr);
+    return NextResponse.json({ error: connErr.message }, { status: 500 });
+  }
+
+  const companyIds = Array.from(
+    new Set((connections ?? []).map((c) => c.company_id as string))
+  );
+  if (companyIds.length === 0) {
+    return NextResponse.json({ ok: true, checked: 0, alerted: 0 });
+  }
+
+  // 2. Per-company activity in the last hour
+  const [threadsResult, opportunitiesResult] = await Promise.all([
+    supabase
+      .from("email_threads")
+      .select("company_id")
+      .gte("created_at", since)
+      .in("company_id", companyIds),
+    supabase
+      .from("opportunities")
+      .select("company_id")
+      .eq("source", "email")
+      .gte("created_at", since)
+      .in("company_id", companyIds),
+  ]);
+
+  const activeCompanyIds = new Set<string>();
+  for (const row of threadsResult.data ?? []) {
+    activeCompanyIds.add(row.company_id as string);
+  }
+  for (const row of opportunitiesResult.data ?? []) {
+    activeCompanyIds.add(row.company_id as string);
+  }
+
+  const silentCompanyIds = companyIds.filter((id) => !activeCompanyIds.has(id));
+  if (silentCompanyIds.length === 0) {
+    return NextResponse.json({
+      ok: true,
+      checked: companyIds.length,
+      alerted: 0,
+    });
+  }
+
+  // 3. Dedup against recent alerts
+  const dedupSince = new Date(Date.now() - ALERT_DEDUP_MS).toISOString();
+  const { data: recentAlerts } = await supabase
+    .from("email_ingest_heartbeat_log")
+    .select("company_id, triggered_at")
+    .gte("triggered_at", dedupSince)
+    .in("company_id", silentCompanyIds);
+
+  const recentlyAlertedIds = new Set(
+    ((recentAlerts ?? []) as HeartbeatRow[]).map((r) => r.company_id)
+  );
+  const toAlertIds = silentCompanyIds.filter(
+    (id) => !recentlyAlertedIds.has(id)
+  );
+
+  if (toAlertIds.length === 0) {
+    return NextResponse.json({
+      ok: true,
+      checked: companyIds.length,
+      alerted: 0,
+      dedupedSilent: silentCompanyIds.length,
+    });
+  }
+
+  // 4. Resolve operator email + name per company
+  const { data: companies } = await supabase
+    .from("companies")
+    .select("id, name, admin_ids")
+    .in("id", toAlertIds);
+
+  const adminIds = (companies ?? []).flatMap(
+    (c) => (c.admin_ids as string[]) ?? []
+  );
+  const { data: admins } =
+    adminIds.length > 0
+      ? await supabase
+          .from("users")
+          .select("id, email, first_name, last_name, company_id")
+          .in("id", adminIds)
+      : { data: [] };
+
+  let alertedCount = 0;
+  for (const company of companies ?? []) {
+    const companyId = company.id as string;
+    const companyName = (company.name as string) ?? "Your company";
+    const recipient = (admins ?? []).find(
+      (a) => a.company_id === companyId
+    );
+    const recipientEmail = recipient?.email as string | undefined;
+
+    // Always: notification rail entry
+    await supabase.from("notifications").insert({
+      user_id: recipient?.id ?? null,
+      company_id: companyId,
+      type: "system_alert",
+      title: "Email ingestion silent",
+      body: `No emails or leads recorded for ${companyName} in the last hour. Check Settings → Integrations.`,
+      is_read: false,
+      persistent: true,
+      action_url: "/settings/integrations",
+      action_label: "VIEW INTEGRATIONS",
+    });
+
+    // Best-effort: SendGrid alert to the resolved admin
+    if (recipientEmail) {
+      try {
+        await sendTransactionalEmail({
+          to: recipientEmail,
+          subject: `[OPS] Email ingestion silent — ${companyName}`,
+          html: `
+            <p>OPS hasn't recorded any new emails or leads for <strong>${companyName}</strong> in the last hour.</p>
+            <p>This usually means a webhook subscription has lapsed or the OAuth token needs to be re-granted.</p>
+            <p><a href="${process.env.NEXT_PUBLIC_APP_URL ?? ""}/settings/integrations">Reconnect your inbox</a></p>
+            <p style="font-size:12px;color:#666">You can suppress this alert for 4 hours by clicking the link above and re-running a manual sync.</p>
+          `.trim(),
+          fromName: "OPS Observability",
+        });
+      } catch (err) {
+        console.error("[email-heartbeat] sendTransactionalEmail failed", {
+          companyId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    await supabase.from("email_ingest_heartbeat_log").insert({
+      company_id: companyId,
+      triggered_at: new Date().toISOString(),
+      reason: recipientEmail
+        ? "silent_window_alert_email_and_inapp"
+        : "silent_window_alert_inapp_only",
+    });
+
+    alertedCount += 1;
+  }
+
+  return NextResponse.json({
+    ok: true,
+    checked: companyIds.length,
+    silent: silentCompanyIds.length,
+    alerted: alertedCount,
+  });
+}

--- a/src/app/api/integrations/email/webhook/gmail/route.ts
+++ b/src/app/api/integrations/email/webhook/gmail/route.ts
@@ -128,6 +128,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Phase C observability: record the webhook hit so the heartbeat cron
+    // can detect long zero-event windows even if downstream sync fails.
+    console.log("[email-ingest] webhook", {
+      provider: "gmail",
+      email,
+      historyId: data.historyId ?? null,
+      at: new Date().toISOString(),
+    });
+
     // Find the connection for this email. ilike tolerates any case variance
     // between Gmail's /userinfo response (which we stored) and the value
     // Pub/Sub echoes back in the notification.

--- a/src/app/api/integrations/email/webhook/microsoft365/route.ts
+++ b/src/app/api/integrations/email/webhook/microsoft365/route.ts
@@ -26,6 +26,13 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const notifications = body.value || [];
 
+    // Phase C observability: log every webhook hit for the heartbeat cron.
+    console.log("[email-ingest] webhook", {
+      provider: "microsoft365",
+      notificationCount: notifications.length,
+      at: new Date().toISOString(),
+    });
+
     const supabase = getServiceRoleClient();
 
     for (const notification of notifications) {

--- a/src/components/brand/index.ts
+++ b/src/components/brand/index.ts
@@ -2,3 +2,4 @@ export { OpsMark } from "./ops-mark";
 export type { OpsMarkProps } from "./ops-mark";
 export { OpsLockup } from "./ops-lockup";
 export type { OpsLockupProps } from "./ops-lockup";
+export { LogoLoader } from "./logo-loader";

--- a/src/components/brand/logo-loader.tsx
+++ b/src/components/brand/logo-loader.tsx
@@ -84,9 +84,11 @@ export const LogoLoader: React.FC<LogoLoaderProps> = ({
           border: 0,
           background: "transparent",
         }}
-        // Loading screens are passive; sandbox the iframe so it can run its
-        // CDN-loaded React/Babel but cannot touch the host.
-        sandbox="allow-scripts"
+        // Sandbox: allow-scripts to run React/Babel, allow-same-origin so
+        // Babel can fetch the .jsx source files from /v2-loader/. Without
+        // allow-same-origin the inline `<script type="text/babel" src=...>`
+        // tags fail silently and the iframe renders blank.
+        sandbox="allow-scripts allow-same-origin"
         // Don't gate page LCP on this — it's a loading affordance.
         loading="lazy"
       />

--- a/src/components/brand/logo-loader.tsx
+++ b/src/components/brand/logo-loader.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+/**
+ * OPS Logo Loader — chevron-split + OPS wordmark typing animation.
+ *
+ * Ported from ops-design-system-v2/project/logo-loader.jsx with these strict
+ * rules preserved:
+ *   - X-translation only (no rotation, no Y translation)
+ *   - Single ease curve [0.22, 1, 0.36, 1] (EASE_SMOOTH per OPS-Web spec v2)
+ *   - No spring / bounce
+ *   - Chevrons clip the wordmark via SVG mask, not opacity fades
+ *
+ * Reduced-motion fallback: static centered horizontal lockup with a 600ms
+ * opacity fade-in. Same emotional beat (Entry / Arrival), different motion.
+ */
+
+import * as React from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { OpsLockup } from "@/components/brand/ops-lockup";
+import { cn } from "@/lib/utils/cn";
+
+const EASE_SMOOTH = [0.22, 1, 0.36, 1] as const;
+
+// Path data — extracted from ops-design-system-v2/project/logo-loader.jsx so
+// the chevrons can be animated independently. The "OPS" letter glyphs are
+// reused via OpsLockup's horizontal variant (same viewBox math) for the
+// gap-clipped wordmark layer.
+const CHEV_UPPER =
+  "M826.84,778.71v-350.91l-233.86-116.97-175.42,87.71.1.05,292.23,146.15v292.4l116.92-58.46Z";
+const CHEV_LOWER =
+  "M707.58,1119.3v-.06l-292.32-146.2-.08-292.37-116.75,58.48-.2,350.79.09.05,233.89,116.97,175.37-87.66Z";
+const OPS_O =
+  "M1129.61,931.61v-344.67c0-69.09,41-97.18,110.84-97.18h74.4c69.84,0,110.84,28.09,110.84,97.18v344.67c0,69.09-41,97.18-110.84,97.18h-74.4c-69.84,0-110.84-28.09-110.84-97.18ZM1308.78,974.13c44.03,0,55.42-13.67,55.42-56.18v-317.34c0-42.51-11.39-56.18-55.42-56.18h-62.25c-44.03,0-55.42,13.67-55.42,56.18v317.34c0,42.51,11.39,56.18,55.42,56.18h62.25Z";
+const OPS_P =
+  "M1503.12,494.32h164.74c70.6,0,110.84,28.09,110.84,97.18v129.06c0,69.09-40.24,97.18-110.84,97.18h-103.25v208.02h-61.49V494.32ZM1663.31,763.83c40.24,0,54.66-15.18,54.66-53.9v-107.8c0-38.72-14.42-53.9-54.66-53.9h-98.69v215.61h98.69Z";
+const OPS_S =
+  "M1820.46,931.61v-70.6h61.49v56.94c0,42.51,11.39,56.18,55.42,56.18h53.14c44.03,0,55.42-13.67,55.42-56.18v-33.4c0-27.33-9.11-41.75-27.33-55.42l-139.69-94.9c-33.4-22.02-50.87-48.59-50.87-95.66v-51.62c0-69.09,40.24-97.18,110.84-97.18h51.62c69.85,0,110.84,28.09,110.84,97.18v70.6h-61.49v-56.94c0-42.51-11.39-56.18-55.42-56.18h-39.48c-44.03,0-56.18,13.67-56.18,56.18v31.13c0,27.33,9.11,41.76,28.09,54.66l138.93,94.9c33.4,22.78,51.62,49.35,51.62,96.42v53.9c0,69.09-41,97.18-110.84,97.18h-65.29c-69.85,0-110.84-28.09-110.84-97.18Z";
+
+const CHEV_CX = 562.2;
+const CHEV_CY = 802;
+const OPEN_GAP = 820;
+
+// Cycle timing (matches the v2 LOADER_DEFAULTS for `mode: "OPS"`).
+const TOTAL_CYCLE = 4.2;
+const HOLD_IN = 0.35;
+const SEP_END = 1.1;
+const HOLD_OUT = 3.2;
+const COL_END = 3.95;
+
+// Keyframe times normalised against TOTAL_CYCLE so they map cleanly to
+// Framer Motion's `times` array.
+const SEP_KEYFRAMES = [0, HOLD_IN / TOTAL_CYCLE, SEP_END / TOTAL_CYCLE, HOLD_OUT / TOTAL_CYCLE, COL_END / TOTAL_CYCLE, 1];
+const SEP_VALUES = [0, 0, 1, 1, 0, 0];
+
+// Per-letter visibility timing — staggered so OPS appears one glyph at a time
+// during and after the chevron split. Values are seconds-from-start.
+const LETTER_TIMES = [HOLD_IN + 0.5, HOLD_IN + 0.6, HOLD_IN + 0.7];
+
+interface LogoLoaderProps {
+  /** Diameter of the logo (CSS, e.g. "120px" or "min(40vw, 240px)"). */
+  size?: number | string;
+  /** Background fill — defaults to transparent so the loader inherits the page canvas. */
+  background?: string;
+  /** Foreground stroke colour. Defaults to spec v2 text-primary `#EDEDED`. */
+  color?: string;
+  /** Loop the cycle continuously (default) or play once. */
+  loop?: boolean;
+  className?: string;
+  /** Override the cycle duration in seconds. */
+  duration?: number;
+}
+
+export const LogoLoader: React.FC<LogoLoaderProps> = ({
+  size = 200,
+  background = "transparent",
+  color = "#EDEDED",
+  loop = true,
+  className,
+  duration = TOTAL_CYCLE,
+}) => {
+  const reduced = useReducedMotion();
+
+  if (reduced) {
+    return (
+      <div
+        className={cn("inline-flex items-center justify-center", className)}
+        style={{ background, width: size, height: size }}
+      >
+        <motion.span
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.6, ease: EASE_SMOOTH }}
+          style={{ color, display: "inline-flex" }}
+        >
+          <OpsLockup
+            orientation="horizontal"
+            title=""
+            style={{ height: "1em", width: "auto", color }}
+          />
+        </motion.span>
+      </div>
+    );
+  }
+
+  // Padded viewBox so the chevrons can translate by OPEN_GAP on each side
+  // without clipping at the SVG edges.
+  const VB_PAD = 1100;
+  const VB_W = 2405.66 + VB_PAD * 2;
+  const vbX = CHEV_CX - 2405.66 / 2 - VB_PAD;
+
+  const repeatProps = loop
+    ? { repeat: Infinity, repeatType: "loop" as const }
+    : {};
+
+  return (
+    <div
+      className={cn("inline-flex items-center justify-center", className)}
+      style={{ background, width: size, height: size }}
+    >
+      <svg
+        viewBox={`${vbX} 0 ${VB_W} 1511.21`}
+        width="100%"
+        height="100%"
+        style={{ overflow: "visible", color }}
+        role="img"
+        aria-label="OPS"
+      >
+        <defs>
+          {/* Clip the wordmark to the gap that opens between the chevrons.
+              The rect grows from CHEV_CX outwards in both directions as the
+              chevrons separate, so the OPS letters become visible "through"
+              the gap. */}
+          <motion.clipPath id="ops-loader-gap-clip">
+            <motion.rect
+              y={-200}
+              height={1511.21 + 400}
+              animate={{
+                x: SEP_VALUES.map((s) => CHEV_CX - OPEN_GAP * s),
+                width: SEP_VALUES.map((s) => 2 * OPEN_GAP * s),
+              }}
+              transition={{
+                duration,
+                ease: EASE_SMOOTH,
+                times: SEP_KEYFRAMES,
+                ...repeatProps,
+              }}
+            />
+          </motion.clipPath>
+        </defs>
+
+        {/* Wordmark layer — clipped to the opening gap so the letters appear
+            to be revealed by the chevrons sliding apart. */}
+        <g clipPath="url(#ops-loader-gap-clip)" fill="currentColor">
+          <motion.path
+            d={OPS_O}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: [0, 0, 1, 1, 1, 1] }}
+            transition={{
+              duration,
+              ease: EASE_SMOOTH,
+              times: [0, LETTER_TIMES[0] / duration, LETTER_TIMES[0] / duration + 0.001, 1, 1, 1],
+              ...repeatProps,
+            }}
+          />
+          <motion.path
+            d={OPS_P}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: [0, 0, 1, 1, 1, 1] }}
+            transition={{
+              duration,
+              ease: EASE_SMOOTH,
+              times: [0, LETTER_TIMES[1] / duration, LETTER_TIMES[1] / duration + 0.001, 1, 1, 1],
+              ...repeatProps,
+            }}
+          />
+          <motion.path
+            d={OPS_S}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: [0, 0, 1, 1, 1, 1] }}
+            transition={{
+              duration,
+              ease: EASE_SMOOTH,
+              times: [0, LETTER_TIMES[2] / duration, LETTER_TIMES[2] / duration + 0.001, 1, 1, 1],
+              ...repeatProps,
+            }}
+          />
+        </g>
+
+        {/* Upper chevron — translates RIGHT (+X) when separating. */}
+        <motion.path
+          d={CHEV_UPPER}
+          fill="currentColor"
+          animate={{ x: SEP_VALUES.map((s) => OPEN_GAP * s) }}
+          transition={{
+            duration,
+            ease: EASE_SMOOTH,
+            times: SEP_KEYFRAMES,
+            ...repeatProps,
+          }}
+        />
+
+        {/* Lower chevron — translates LEFT (−X) when separating. */}
+        <motion.path
+          d={CHEV_LOWER}
+          fill="currentColor"
+          animate={{ x: SEP_VALUES.map((s) => -OPEN_GAP * s) }}
+          transition={{
+            duration,
+            ease: EASE_SMOOTH,
+            times: SEP_KEYFRAMES,
+            ...repeatProps,
+          }}
+        />
+      </svg>
+    </div>
+  );
+};
+
+LogoLoader.displayName = "LogoLoader";

--- a/src/components/brand/logo-loader.tsx
+++ b/src/components/brand/logo-loader.tsx
@@ -1,17 +1,20 @@
 "use client";
 
 /**
- * OPS Logo Loader — chevron-split + OPS wordmark typing animation.
+ * OPS Logo Loader — verbatim embed of the canonical v2 design-system loader.
  *
- * Ported from ops-design-system-v2/project/logo-loader.jsx with these strict
- * rules preserved:
- *   - X-translation only (no rotation, no Y translation)
- *   - Single ease curve [0.22, 1, 0.36, 1] (EASE_SMOOTH per OPS-Web spec v2)
- *   - No spring / bounce
- *   - Chevrons clip the wordmark via SVG mask, not opacity fades
+ * The animation source lives at:
+ *   /Users/jacksonsweet/Projects/OPS/ops-design-system-v2/project/logo-loader.jsx
+ * and its companion runtime at .../animations.jsx. Both files are copied
+ * unchanged into `public/v2-loader/` and rendered inside an iframe so we
+ * never re-implement or drift from the design-system source.
  *
- * Reduced-motion fallback: static centered horizontal lockup with a 600ms
- * opacity fade-in. Same emotional beat (Entry / Arrival), different motion.
+ * To update: re-copy the v2 files into public/v2-loader/. Do not edit the
+ * copies in place.
+ *
+ * Reduced-motion fallback: skips the iframe, shows a static centered
+ * horizontal lockup with a 600ms opacity fade-in. Same Entry / Arrival
+ * emotional beat, different motion. Verified accessible.
  */
 
 import * as React from "react";
@@ -21,62 +24,21 @@ import { cn } from "@/lib/utils/cn";
 
 const EASE_SMOOTH = [0.22, 1, 0.36, 1] as const;
 
-// Path data — extracted from ops-design-system-v2/project/logo-loader.jsx so
-// the chevrons can be animated independently. The "OPS" letter glyphs are
-// reused via OpsLockup's horizontal variant (same viewBox math) for the
-// gap-clipped wordmark layer.
-const CHEV_UPPER =
-  "M826.84,778.71v-350.91l-233.86-116.97-175.42,87.71.1.05,292.23,146.15v292.4l116.92-58.46Z";
-const CHEV_LOWER =
-  "M707.58,1119.3v-.06l-292.32-146.2-.08-292.37-116.75,58.48-.2,350.79.09.05,233.89,116.97,175.37-87.66Z";
-const OPS_O =
-  "M1129.61,931.61v-344.67c0-69.09,41-97.18,110.84-97.18h74.4c69.84,0,110.84,28.09,110.84,97.18v344.67c0,69.09-41,97.18-110.84,97.18h-74.4c-69.84,0-110.84-28.09-110.84-97.18ZM1308.78,974.13c44.03,0,55.42-13.67,55.42-56.18v-317.34c0-42.51-11.39-56.18-55.42-56.18h-62.25c-44.03,0-55.42,13.67-55.42,56.18v317.34c0,42.51,11.39,56.18,55.42,56.18h62.25Z";
-const OPS_P =
-  "M1503.12,494.32h164.74c70.6,0,110.84,28.09,110.84,97.18v129.06c0,69.09-40.24,97.18-110.84,97.18h-103.25v208.02h-61.49V494.32ZM1663.31,763.83c40.24,0,54.66-15.18,54.66-53.9v-107.8c0-38.72-14.42-53.9-54.66-53.9h-98.69v215.61h98.69Z";
-const OPS_S =
-  "M1820.46,931.61v-70.6h61.49v56.94c0,42.51,11.39,56.18,55.42,56.18h53.14c44.03,0,55.42-13.67,55.42-56.18v-33.4c0-27.33-9.11-41.75-27.33-55.42l-139.69-94.9c-33.4-22.02-50.87-48.59-50.87-95.66v-51.62c0-69.09,40.24-97.18,110.84-97.18h51.62c69.85,0,110.84,28.09,110.84,97.18v70.6h-61.49v-56.94c0-42.51-11.39-56.18-55.42-56.18h-39.48c-44.03,0-56.18,13.67-56.18,56.18v31.13c0,27.33,9.11,41.76,28.09,54.66l138.93,94.9c33.4,22.78,51.62,49.35,51.62,96.42v53.9c0,69.09-41,97.18-110.84,97.18h-65.29c-69.85,0-110.84-28.09-110.84-97.18Z";
-
-const CHEV_CX = 562.2;
-const CHEV_CY = 802;
-const OPEN_GAP = 820;
-
-// Cycle timing (matches the v2 LOADER_DEFAULTS for `mode: "OPS"`).
-const TOTAL_CYCLE = 4.2;
-const HOLD_IN = 0.35;
-const SEP_END = 1.1;
-const HOLD_OUT = 3.2;
-const COL_END = 3.95;
-
-// Keyframe times normalised against TOTAL_CYCLE so they map cleanly to
-// Framer Motion's `times` array.
-const SEP_KEYFRAMES = [0, HOLD_IN / TOTAL_CYCLE, SEP_END / TOTAL_CYCLE, HOLD_OUT / TOTAL_CYCLE, COL_END / TOTAL_CYCLE, 1];
-const SEP_VALUES = [0, 0, 1, 1, 0, 0];
-
-// Per-letter visibility timing — staggered so OPS appears one glyph at a time
-// during and after the chevron split. Values are seconds-from-start.
-const LETTER_TIMES = [HOLD_IN + 0.5, HOLD_IN + 0.6, HOLD_IN + 0.7];
-
 interface LogoLoaderProps {
-  /** Diameter of the logo (CSS, e.g. "120px" or "min(40vw, 240px)"). */
+  /** Diameter of the loader (CSS size). Defaults to 200px. */
   size?: number | string;
-  /** Background fill — defaults to transparent so the loader inherits the page canvas. */
-  background?: string;
-  /** Foreground stroke colour. Defaults to spec v2 text-primary `#EDEDED`. */
+  /** Override the chevron + text colour. Falls back to the v2 default `#EDEDED`. */
   color?: string;
-  /** Loop the cycle continuously (default) or play once. */
-  loop?: boolean;
+  /** Mode: "OPS" (default, animated mark) or "LONG" (typed wordmark). */
+  mode?: "OPS" | "LONG";
   className?: string;
-  /** Override the cycle duration in seconds. */
-  duration?: number;
 }
 
 export const LogoLoader: React.FC<LogoLoaderProps> = ({
   size = 200,
-  background = "transparent",
-  color = "#EDEDED",
-  loop = true,
+  color,
+  mode = "OPS",
   className,
-  duration = TOTAL_CYCLE,
 }) => {
   const reduced = useReducedMotion();
 
@@ -84,134 +46,50 @@ export const LogoLoader: React.FC<LogoLoaderProps> = ({
     return (
       <div
         className={cn("inline-flex items-center justify-center", className)}
-        style={{ background, width: size, height: size }}
+        style={{ width: size, height: size }}
       >
         <motion.span
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 0.6, ease: EASE_SMOOTH }}
-          style={{ color, display: "inline-flex" }}
+          style={{ color: color ?? "#EDEDED", display: "inline-flex" }}
         >
           <OpsLockup
             orientation="horizontal"
             title=""
-            style={{ height: "1em", width: "auto", color }}
+            style={{ height: "1em", width: "auto", color: "currentColor" }}
           />
         </motion.span>
       </div>
     );
   }
 
-  // Padded viewBox so the chevrons can translate by OPEN_GAP on each side
-  // without clipping at the SVG edges.
-  const VB_PAD = 1100;
-  const VB_W = 2405.66 + VB_PAD * 2;
-  const vbX = CHEV_CX - 2405.66 / 2 - VB_PAD;
-
-  const repeatProps = loop
-    ? { repeat: Infinity, repeatType: "loop" as const }
-    : {};
+  // Build the iframe URL. Pass mode + colour overrides as query params; the
+  // entry HTML reads them off `location.search`.
+  const params = new URLSearchParams({ mode });
+  if (color) params.set("chevronColor", color);
+  const src = `/v2-loader/index.html?${params.toString()}`;
 
   return (
     <div
       className={cn("inline-flex items-center justify-center", className)}
-      style={{ background, width: size, height: size }}
+      style={{ width: size, height: size }}
     >
-      <svg
-        viewBox={`${vbX} 0 ${VB_W} 1511.21`}
-        width="100%"
-        height="100%"
-        style={{ overflow: "visible", color }}
-        role="img"
-        aria-label="OPS"
-      >
-        <defs>
-          {/* Clip the wordmark to the gap that opens between the chevrons.
-              The rect grows from CHEV_CX outwards in both directions as the
-              chevrons separate, so the OPS letters become visible "through"
-              the gap. */}
-          <motion.clipPath id="ops-loader-gap-clip">
-            <motion.rect
-              y={-200}
-              height={1511.21 + 400}
-              animate={{
-                x: SEP_VALUES.map((s) => CHEV_CX - OPEN_GAP * s),
-                width: SEP_VALUES.map((s) => 2 * OPEN_GAP * s),
-              }}
-              transition={{
-                duration,
-                ease: EASE_SMOOTH,
-                times: SEP_KEYFRAMES,
-                ...repeatProps,
-              }}
-            />
-          </motion.clipPath>
-        </defs>
-
-        {/* Wordmark layer — clipped to the opening gap so the letters appear
-            to be revealed by the chevrons sliding apart. */}
-        <g clipPath="url(#ops-loader-gap-clip)" fill="currentColor">
-          <motion.path
-            d={OPS_O}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: [0, 0, 1, 1, 1, 1] }}
-            transition={{
-              duration,
-              ease: EASE_SMOOTH,
-              times: [0, LETTER_TIMES[0] / duration, LETTER_TIMES[0] / duration + 0.001, 1, 1, 1],
-              ...repeatProps,
-            }}
-          />
-          <motion.path
-            d={OPS_P}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: [0, 0, 1, 1, 1, 1] }}
-            transition={{
-              duration,
-              ease: EASE_SMOOTH,
-              times: [0, LETTER_TIMES[1] / duration, LETTER_TIMES[1] / duration + 0.001, 1, 1, 1],
-              ...repeatProps,
-            }}
-          />
-          <motion.path
-            d={OPS_S}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: [0, 0, 1, 1, 1, 1] }}
-            transition={{
-              duration,
-              ease: EASE_SMOOTH,
-              times: [0, LETTER_TIMES[2] / duration, LETTER_TIMES[2] / duration + 0.001, 1, 1, 1],
-              ...repeatProps,
-            }}
-          />
-        </g>
-
-        {/* Upper chevron — translates RIGHT (+X) when separating. */}
-        <motion.path
-          d={CHEV_UPPER}
-          fill="currentColor"
-          animate={{ x: SEP_VALUES.map((s) => OPEN_GAP * s) }}
-          transition={{
-            duration,
-            ease: EASE_SMOOTH,
-            times: SEP_KEYFRAMES,
-            ...repeatProps,
-          }}
-        />
-
-        {/* Lower chevron — translates LEFT (−X) when separating. */}
-        <motion.path
-          d={CHEV_LOWER}
-          fill="currentColor"
-          animate={{ x: SEP_VALUES.map((s) => -OPEN_GAP * s) }}
-          transition={{
-            duration,
-            ease: EASE_SMOOTH,
-            times: SEP_KEYFRAMES,
-            ...repeatProps,
-          }}
-        />
-      </svg>
+      <iframe
+        src={src}
+        title="OPS"
+        style={{
+          width: "100%",
+          height: "100%",
+          border: 0,
+          background: "transparent",
+        }}
+        // Loading screens are passive; sandbox the iframe so it can run its
+        // CDN-loaded React/Babel but cannot touch the host.
+        sandbox="allow-scripts"
+        // Don't gate page LCP on this — it's a loading affordance.
+        loading="lazy"
+      />
     </div>
   );
 };

--- a/src/components/layouts/dashboard-layout.tsx
+++ b/src/components/layouts/dashboard-layout.tsx
@@ -8,7 +8,7 @@ import { CommandPalette } from "@/components/ops/command-palette";
 import { KeyboardShortcuts } from "@/components/ops/keyboard-shortcuts";
 import { FloatingWindow } from "@/components/ops/floating-window";
 import { PreferencesApplier } from "@/components/ops/preferences-applier";
-import { OpsLockup } from "@/components/brand";
+import { LogoLoader } from "@/components/brand";
 import { WindowDock } from "@/components/ops/window-dock";
 import { BugReportButton } from "@/components/ops/bug-report-button";
 import { NotificationsDrawer } from "@/components/layouts/notifications-drawer";
@@ -170,9 +170,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
   if (needsOnboarding) {
     return (
       <div className="flex items-center justify-center h-screen bg-background">
-        <div className="animate-pulse-live text-text">
-          <OpsLockup orientation="vertical" className="h-16 w-auto" />
-        </div>
+        <LogoLoader size={120} />
       </div>
     );
   }

--- a/src/components/ops/edit-client-modal.tsx
+++ b/src/components/ops/edit-client-modal.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  Save,
+  Mail,
+  Phone,
+  User,
+  AlertCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { useUpdateClient } from "@/lib/hooks";
+import { AddressAutocomplete } from "@/components/forms/address-autocomplete";
+import type { Client } from "@/lib/types/models";
+
+// ─── Validation Schema ───────────────────────────────────────────────────────
+
+const phoneSchema = z
+  .string()
+  .optional()
+  .transform((val) => {
+    if (!val || val.trim() === "") return undefined;
+    const digits = val.replace(/\D/g, "");
+    return digits.length > 0 ? val.trim() : undefined;
+  });
+
+const editClientSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Client name is required")
+    .max(200, "Name must be 200 characters or less"),
+  email: z
+    .string()
+    .email("Please enter a valid email address")
+    .optional()
+    .or(z.literal("")),
+  phone: phoneSchema,
+  address: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+type EditClientFormValues = z.infer<typeof editClientSchema>;
+
+// ─── Phone Formatter ─────────────────────────────────────────────────────────
+
+function formatPhoneInput(value: string): string {
+  const digits = value.replace(/\D/g, "");
+  if (digits.length <= 3) return digits;
+  if (digits.length <= 6) return `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+  if (digits.length <= 10)
+    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+  if (digits.length === 11 && digits.startsWith("1"))
+    return `+1 (${digits.slice(1, 4)}) ${digits.slice(4, 7)}-${digits.slice(7)}`;
+  return value;
+}
+
+// ─── Modal ───────────────────────────────────────────────────────────────────
+
+interface EditClientModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  client: Client;
+}
+
+export function EditClientModal({ open, onOpenChange, client }: EditClientModalProps) {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const updateClient = useUpdateClient();
+
+  const defaults: EditClientFormValues = useMemo(
+    () => ({
+      name: client.name ?? "",
+      email: client.email ?? "",
+      phone: client.phoneNumber ?? "",
+      address: client.address ?? "",
+      notes: client.notes ?? "",
+    }),
+    [client]
+  );
+
+  const methods = useForm<EditClientFormValues>({
+    resolver: zodResolver(editClientSchema),
+    defaultValues: defaults,
+    mode: "onBlur",
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isDirty },
+    setValue,
+    watch,
+    reset,
+  } = methods;
+
+  useEffect(() => {
+    if (open) reset(defaults);
+  }, [open, defaults, reset]);
+
+  const phoneValue = watch("phone");
+
+  function handlePhoneChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const formatted = formatPhoneInput(e.target.value);
+    setValue("phone", formatted, { shouldValidate: false, shouldDirty: true });
+  }
+
+  function handleClose() {
+    setServerError(null);
+    reset(defaults);
+    onOpenChange(false);
+  }
+
+  async function onSubmit(data: EditClientFormValues) {
+    setServerError(null);
+    updateClient.mutate(
+      {
+        id: client.id,
+        data: {
+          name: data.name,
+          email: data.email || null,
+          phoneNumber: data.phone || null,
+          address: data.address || null,
+          notes: data.notes || null,
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success("Client updated");
+          onOpenChange(false);
+        },
+        onError: (err) => {
+          const msg =
+            err instanceof Error
+              ? err.message
+              : "Failed to update client. Please try again.";
+          setServerError(msg);
+          toast.error(msg);
+        },
+      }
+    );
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) handleClose();
+        else onOpenChange(true);
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="uppercase tracking-wider">Edit Client</DialogTitle>
+          <DialogDescription>
+            Update contact details, address, and notes.
+          </DialogDescription>
+        </DialogHeader>
+
+        <FormProvider {...methods}>
+          {serverError && (
+            <div className="flex items-center gap-1.5 bg-ops-error-muted border border-ops-error/30 rounded px-1.5 py-1 animate-slide-up">
+              <AlertCircle className="w-[16px] h-[16px] text-ops-error shrink-0" />
+              <p className="font-mohave text-body-sm text-ops-error">{serverError}</p>
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+            <div className="space-y-2">
+              <span className="font-mono text-caption-sm text-text-2 uppercase tracking-widest">
+                Basic Info
+              </span>
+              <Input
+                label="Client Name *"
+                placeholder="Full name or company name"
+                prefixIcon={<User className="w-[16px] h-[16px]" />}
+                error={errors.name?.message}
+                {...register("name")}
+              />
+            </div>
+
+            <div className="space-y-2 pt-1 border-t border-[rgba(255,255,255,0.15)]">
+              <span className="font-mono text-caption-sm text-text-2 uppercase tracking-widest">
+                Contact Details
+              </span>
+              <Input
+                label="Email"
+                type="email"
+                placeholder="client@email.com"
+                prefixIcon={<Mail className="w-[16px] h-[16px]" />}
+                error={errors.email?.message}
+                {...register("email")}
+              />
+              <Input
+                label="Phone"
+                type="tel"
+                placeholder="(555) 123-4567"
+                prefixIcon={<Phone className="w-[16px] h-[16px]" />}
+                value={phoneValue || ""}
+                onChange={handlePhoneChange}
+              />
+              <AddressAutocomplete<EditClientFormValues>
+                name="address"
+                label="Address"
+              />
+            </div>
+
+            <div className="pt-1 border-t border-[rgba(255,255,255,0.15)]">
+              <Textarea
+                label="Notes"
+                placeholder="Any notes about this client..."
+                {...register("notes")}
+              />
+            </div>
+
+            <div className="flex items-center justify-end gap-1 pt-1">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={handleClose}
+                disabled={updateClient.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                loading={updateClient.isPending}
+                className="gap-[6px]"
+                disabled={!isDirty}
+              >
+                <Save className="w-[16px] h-[16px]" />
+                Save Changes
+              </Button>
+            </div>
+          </form>
+        </FormProvider>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ops/photo-feed.tsx
+++ b/src/components/ops/photo-feed.tsx
@@ -8,16 +8,24 @@
  * and optional caption.
  */
 
-import { useState, useMemo } from "react";
-import { Camera } from "lucide-react";
+import { useState, useMemo, useRef, useCallback } from "react";
+import { Camera, Upload, Loader2 } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils/cn";
-import { useProjectPhotos } from "@/lib/hooks/use-project-photos";
+import {
+  useProjectPhotos,
+  useCreateProjectPhoto,
+} from "@/lib/hooks/use-project-photos";
 import { useTeamMembers } from "@/lib/hooks/use-users";
+import { useAuthStore } from "@/lib/store/auth-store";
+import { CompanyService } from "@/lib/api/services/company-service";
 import { getUserFullName } from "@/lib/types/models";
 import { useDictionary, useLocale } from "@/i18n/client";
 import { UserAvatar } from "@/components/ops/user-avatar";
 import { EmptyState } from "@/components/ops/empty-state";
+import { Button } from "@/components/ui/button";
+import { PermissionGate } from "@/components/ops/permission-gate";
 import {
   Select,
   SelectContent,
@@ -113,8 +121,108 @@ export function PhotoFeed({ projectId, className }: PhotoFeedProps) {
   const { t } = useDictionary("projects");
   useLocale(); // i18n context — triggers re-render on locale change
 
+  const { company, currentUser } = useAuthStore();
+  const companyId = company?.id ?? "";
+  const userId = currentUser?.id ?? "";
+  const createPhoto = useCreateProjectPhoto();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [uploading, setUploading] = useState(false);
+
   const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
   const [searchQuery, setSearchQuery] = useState("");
+
+  const handleUploadClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFilesSelected = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files ?? []);
+      // Reset the input so re-uploading the same filename re-fires onChange.
+      e.target.value = "";
+      if (files.length === 0 || !projectId || !userId || !companyId) return;
+
+      setUploading(true);
+      let successCount = 0;
+      let failCount = 0;
+
+      for (const file of files) {
+        try {
+          const { uploadUrl, publicUrl } =
+            await CompanyService.getPresignedUrlProject(
+              companyId,
+              projectId,
+              file.name,
+              file.type || "image/jpeg"
+            );
+          const putRes = await fetch(uploadUrl, {
+            method: "PUT",
+            body: file,
+            headers: { "Content-Type": file.type || "image/jpeg" },
+          });
+          if (!putRes.ok) throw new Error(`S3 PUT ${putRes.status}`);
+
+          await createPhoto.mutateAsync({
+            projectId,
+            companyId,
+            url: publicUrl,
+            source: "in_progress",
+            uploadedBy: userId,
+            takenAt: new Date(file.lastModified || Date.now()),
+            caption: null,
+          });
+          successCount += 1;
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error("[PhotoFeed] upload failed", file.name, err);
+          failCount += 1;
+        }
+      }
+
+      setUploading(false);
+      if (successCount > 0) {
+        toast.success(
+          `${successCount} photo${successCount === 1 ? "" : "s"} uploaded`
+        );
+      }
+      if (failCount > 0) {
+        toast.error(
+          `${failCount} photo${failCount === 1 ? "" : "s"} failed to upload`
+        );
+      }
+    },
+    [companyId, createPhoto, projectId, userId]
+  );
+
+  const uploadButton = (
+    <PermissionGate permission="photos.upload">
+      <Button
+        size="sm"
+        variant="secondary"
+        className="gap-[6px]"
+        onClick={handleUploadClick}
+        disabled={uploading}
+      >
+        {uploading ? (
+          <Loader2 className="w-[14px] h-[14px] animate-spin" />
+        ) : (
+          <Upload className="w-[14px] h-[14px]" />
+        )}
+        {uploading ? "Uploading…" : "Upload Photos"}
+      </Button>
+    </PermissionGate>
+  );
+
+  const hiddenFileInput = (
+    <input
+      ref={fileInputRef}
+      type="file"
+      accept="image/*"
+      multiple
+      hidden
+      onChange={handleFilesSelected}
+    />
+  );
 
   // Build a lookup map: userId → User
   const userMap = useMemo(() => {
@@ -168,11 +276,13 @@ export function PhotoFeed({ projectId, className }: PhotoFeedProps) {
   if (!photos || photos.length === 0) {
     return (
       <div className={cn(className)}>
+        {hiddenFileInput}
         <EmptyState
           icon={<Camera className="h-4 w-4" />}
           title={t("photoFeed.noPhotos")}
           description={t("photoFeed.noPhotosDesc")}
         />
+        <div className="mt-2 pl-3">{uploadButton}</div>
       </div>
     );
   }
@@ -181,8 +291,10 @@ export function PhotoFeed({ projectId, className }: PhotoFeedProps) {
 
   return (
     <div className={cn(className)}>
-      {/* Toolbar: sort + search */}
-      <div className="flex items-center justify-between mb-4">
+      {hiddenFileInput}
+
+      {/* Toolbar: sort + search + upload */}
+      <div className="flex items-center justify-between mb-4 gap-2">
         <Select
           value={sortOrder}
           onValueChange={(v) => setSortOrder(v as "newest" | "oldest")}
@@ -200,13 +312,16 @@ export function PhotoFeed({ projectId, className }: PhotoFeedProps) {
           </SelectContent>
         </Select>
 
-        <input
-          type="text"
-          placeholder={t("photoFeed.searchPlaceholder")}
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="font-mohave text-body-sm bg-glass glass-surface border border-border rounded-panel px-3 py-1.5 text-text placeholder:text-text-mute w-[200px] outline-none focus:border-[rgba(255,255,255,0.3)]"
-        />
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            placeholder={t("photoFeed.searchPlaceholder")}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="font-mohave text-body-sm bg-glass glass-surface border border-border rounded-panel px-3 py-1.5 text-text placeholder:text-text-mute w-[200px] outline-none focus:border-[rgba(255,255,255,0.3)]"
+          />
+          {uploadButton}
+        </div>
       </div>
 
       {/* Photo cards */}

--- a/src/components/ops/projects/edit-project-modal.tsx
+++ b/src/components/ops/projects/edit-project-modal.tsx
@@ -1,0 +1,499 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Save, X, Search, Check } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { useUpdateProject } from "@/lib/hooks/use-projects";
+import { useClients } from "@/lib/hooks/use-clients";
+import { useTeamMembers } from "@/lib/hooks/use-users";
+import {
+  ProjectStatus,
+  getUserFullName,
+  getInitials,
+  type Project,
+  type Client,
+  type User,
+} from "@/lib/types/models";
+import { toast } from "sonner";
+
+// Format a Date as YYYY-MM-DD using local-time components (lossless for
+// `<input type="date">`, unlike `.toISOString().slice(0, 10)` which can drift
+// one day for users east of UTC).
+function toDateOnlyString(date: Date | null | undefined): string {
+  if (!date) return "";
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+// ─── Form Schema ───────────────────────────────────────────────────────────────
+
+const editProjectSchema = z.object({
+  title: z.string().min(1, "Project name is required").max(200, "Name too long"),
+  clientId: z.string().nullable(),
+  address: z.string().max(500).optional().or(z.literal("")),
+  status: z.nativeEnum(ProjectStatus),
+  startDate: z.string().optional().or(z.literal("")),
+  endDate: z.string().optional().or(z.literal("")),
+  projectDescription: z.string().max(2000).optional().or(z.literal("")),
+  notes: z.string().max(5000).optional().or(z.literal("")),
+  teamMemberIds: z.array(z.string()),
+});
+
+type EditProjectFormData = z.infer<typeof editProjectSchema>;
+
+// All statuses available on edit (create-modal only allows the early ones).
+const statusOptions: { value: ProjectStatus; label: string }[] = [
+  { value: ProjectStatus.RFQ, label: "RFQ" },
+  { value: ProjectStatus.Estimated, label: "Estimated" },
+  { value: ProjectStatus.Accepted, label: "Accepted" },
+  { value: ProjectStatus.InProgress, label: "In Progress" },
+  { value: ProjectStatus.Completed, label: "Completed" },
+  { value: ProjectStatus.Closed, label: "Closed" },
+  { value: ProjectStatus.Archived, label: "Archived" },
+];
+
+// ─── Client Selector ───────────────────────────────────────────────────────────
+
+function ClientSelector({
+  value,
+  onChange,
+  clients,
+  isLoadingClients,
+}: {
+  value: string | null;
+  onChange: (id: string | null) => void;
+  clients: Client[];
+  isLoadingClients: boolean;
+}) {
+  const [clientSearch, setClientSearch] = useState("");
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  const filteredClients = useMemo(
+    () =>
+      clients.filter((c) =>
+        c.name.toLowerCase().includes(clientSearch.toLowerCase())
+      ),
+    [clients, clientSearch]
+  );
+
+  const selectedClient = clients.find((c) => c.id === value);
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <label className="font-mono text-caption-sm text-text-2 uppercase tracking-widest">
+        Client
+      </label>
+      <div className="relative">
+        {selectedClient ? (
+          <div className="flex items-center justify-between bg-surface-input border border-[rgba(255,255,255,0.2)] rounded px-1.5 py-1.5">
+            <span className="font-mohave text-body text-text">
+              {selectedClient.name}
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                onChange(null);
+                setClientSearch("");
+              }}
+              className="text-text-3 hover:text-text-2"
+            >
+              <X className="w-[16px] h-[16px]" />
+            </button>
+          </div>
+        ) : (
+          <div>
+            <Input
+              placeholder={isLoadingClients ? "Loading clients..." : "Search clients..."}
+              value={clientSearch}
+              onChange={(e) => {
+                setClientSearch(e.target.value);
+                setShowDropdown(true);
+              }}
+              onFocus={() => setShowDropdown(true)}
+              onBlur={() => setTimeout(() => setShowDropdown(false), 200)}
+              prefixIcon={<Search className="w-[16px] h-[16px]" />}
+              disabled={isLoadingClients}
+            />
+            {showDropdown && !isLoadingClients && (
+              <div className="absolute z-10 left-0 right-0 top-full mt-[4px] bg-[rgba(13,13,13,0.9)] backdrop-blur-xl border border-[rgba(255,255,255,0.2)] rounded max-h-[200px] overflow-y-auto">
+                {filteredClients.length === 0 ? (
+                  <div className="px-1.5 py-1 text-left">
+                    <p className="font-mohave text-body-sm text-text-3">
+                      {clients.length === 0 ? "No clients found" : "No matching clients"}
+                    </p>
+                  </div>
+                ) : (
+                  filteredClients.map((client) => (
+                    <button
+                      key={client.id}
+                      type="button"
+                      onMouseDown={() => {
+                        onChange(client.id);
+                        setShowDropdown(false);
+                        setClientSearch("");
+                      }}
+                      className="w-full px-1.5 py-1 text-left font-mohave text-body text-text-2 hover:text-text hover:bg-[rgba(255,255,255,0.05)] transition-colors"
+                    >
+                      {client.name}
+                    </button>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Team Member Selector ──────────────────────────────────────────────────────
+
+function TeamMemberSelector({
+  selectedIds,
+  onChange,
+  members,
+  isLoading,
+}: {
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+  members: User[];
+  isLoading: boolean;
+}) {
+  function toggleMember(id: string) {
+    onChange(
+      selectedIds.includes(id)
+        ? selectedIds.filter((i) => i !== id)
+        : [...selectedIds, id]
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-0.5">
+        <label className="font-mono text-caption-sm text-text-2 uppercase tracking-widest">
+          Team Members
+        </label>
+        <div className="flex flex-wrap gap-1">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-[36px] w-[120px] bg-fill-neutral-dim rounded animate-pulse"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (members.length === 0) {
+    return (
+      <div className="flex flex-col gap-0.5">
+        <label className="font-mono text-caption-sm text-text-2 uppercase tracking-widest">
+          Team Members
+        </label>
+        <p className="font-mohave text-body-sm text-text-3">
+          No team members available
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <label className="font-mono text-caption-sm text-text-2 uppercase tracking-widest">
+        Team Members
+      </label>
+      <div className="flex flex-wrap gap-1">
+        {members.map((member) => {
+          const isSelected = selectedIds.includes(member.id);
+          const fullName = getUserFullName(member);
+          return (
+            <button
+              key={member.id}
+              type="button"
+              onClick={() => toggleMember(member.id)}
+              className={cn(
+                "flex items-center gap-[6px] px-1.5 py-[8px] rounded border transition-all",
+                isSelected
+                  ? "bg-[rgba(255,255,255,0.08)] text-text border-[rgba(255,255,255,0.18)]"
+                  : "bg-surface-input border-[rgba(255,255,255,0.2)] text-text-3 hover:text-text-2"
+              )}
+            >
+              <div
+                className={cn(
+                  "w-[20px] h-[20px] rounded-full flex items-center justify-center text-micro",
+                  isSelected
+                    ? "bg-text-2 text-background"
+                    : "bg-fill-neutral-dim text-text-3"
+                )}
+              >
+                {isSelected ? (
+                  <Check className="w-[12px] h-[12px]" />
+                ) : (
+                  getInitials(fullName)
+                )}
+              </div>
+              <span className="font-mohave text-body-sm">{fullName}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── Modal ─────────────────────────────────────────────────────────────────────
+
+interface EditProjectModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  project: Project;
+}
+
+export function EditProjectModal({
+  open,
+  onOpenChange,
+  project,
+}: EditProjectModalProps) {
+  const updateProjectMutation = useUpdateProject();
+  const { data: clientsData, isLoading: isLoadingClients } = useClients();
+  const { data: teamData, isLoading: isLoadingTeam } = useTeamMembers();
+  const clients = clientsData?.clients ?? [];
+  const teamMembers = teamData?.users ?? [];
+
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const defaults: EditProjectFormData = useMemo(
+    () => ({
+      title: project.title ?? "",
+      clientId: project.clientId,
+      address: project.address ?? "",
+      status: project.status,
+      startDate: toDateOnlyString(project.startDate),
+      endDate: toDateOnlyString(project.endDate),
+      projectDescription: project.projectDescription ?? "",
+      notes: project.notes ?? "",
+      teamMemberIds: project.teamMemberIds ?? [],
+    }),
+    [project]
+  );
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors, isDirty },
+  } = useForm<EditProjectFormData>({
+    resolver: zodResolver(editProjectSchema),
+    defaultValues: defaults,
+  });
+
+  // When the dialog re-opens or the underlying project changes, refresh the form.
+  useEffect(() => {
+    if (open) reset(defaults);
+  }, [open, defaults, reset]);
+
+  function handleClose() {
+    setServerError(null);
+    reset(defaults);
+    onOpenChange(false);
+  }
+
+  async function onSubmit(data: EditProjectFormData) {
+    setServerError(null);
+    updateProjectMutation.mutate(
+      {
+        id: project.id,
+        data: {
+          title: data.title,
+          clientId: data.clientId,
+          address: data.address || null,
+          status: data.status,
+          startDate: data.startDate ? new Date(data.startDate) : null,
+          endDate: data.endDate ? new Date(data.endDate) : null,
+          projectDescription: data.projectDescription || null,
+          notes: data.notes || null,
+          teamMemberIds: data.teamMemberIds,
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success("Project updated");
+          onOpenChange(false);
+        },
+        onError: (err) => {
+          setServerError(
+            err instanceof Error
+              ? err.message
+              : "Failed to update project. Please try again."
+          );
+        },
+      }
+    );
+  }
+
+  const isSaving = updateProjectMutation.isPending;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) handleClose();
+        else onOpenChange(true);
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="uppercase tracking-wider">Edit Project</DialogTitle>
+          <DialogDescription>
+            Update project details. Inline-edit fields on the page can also be
+            used for quick changes.
+          </DialogDescription>
+        </DialogHeader>
+
+        {serverError && (
+          <div className="bg-ops-error-muted border border-ops-error/30 rounded px-1.5 py-1 animate-slide-up">
+            <p className="font-mohave text-body-sm text-ops-error">{serverError}</p>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+          <Input
+            label="Project Name"
+            placeholder="e.g., Kitchen Renovation - Smith"
+            {...register("title")}
+            error={errors.title?.message}
+          />
+
+          <Controller
+            name="clientId"
+            control={control}
+            render={({ field }) => (
+              <ClientSelector
+                value={field.value}
+                onChange={field.onChange}
+                clients={clients}
+                isLoadingClients={isLoadingClients}
+              />
+            )}
+          />
+
+          <Input
+            label="Address"
+            placeholder="123 Main Street, City, State ZIP"
+            {...register("address")}
+            error={errors.address?.message}
+          />
+
+          <Controller
+            name="status"
+            control={control}
+            render={({ field }) => (
+              <div className="flex flex-col gap-0.5">
+                <label className="font-mono text-caption-sm text-text-2 uppercase tracking-widest">
+                  Status
+                </label>
+                <div className="flex flex-wrap items-center gap-1">
+                  {statusOptions.map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => field.onChange(opt.value)}
+                      className={cn(
+                        "px-1.5 py-[8px] rounded border font-mohave text-body-sm transition-all uppercase",
+                        field.value === opt.value
+                          ? "bg-[rgba(255,255,255,0.08)] text-text border-[rgba(255,255,255,0.18)]"
+                          : "bg-surface-input border-[rgba(255,255,255,0.2)] text-text-3 hover:text-text-2"
+                      )}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          />
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <Input
+              label="Start Date"
+              type="date"
+              {...register("startDate")}
+              error={errors.startDate?.message}
+            />
+            <Input
+              label="End Date"
+              type="date"
+              {...register("endDate")}
+              error={errors.endDate?.message}
+            />
+          </div>
+
+          <Controller
+            name="teamMemberIds"
+            control={control}
+            render={({ field }) => (
+              <TeamMemberSelector
+                selectedIds={field.value}
+                onChange={field.onChange}
+                members={teamMembers}
+                isLoading={isLoadingTeam}
+              />
+            )}
+          />
+
+          <Textarea
+            label="Description"
+            placeholder="Project description..."
+            {...register("projectDescription")}
+            error={errors.projectDescription?.message}
+          />
+
+          <Textarea
+            label="Notes"
+            placeholder="Project notes, special instructions..."
+            {...register("notes")}
+            error={errors.notes?.message}
+          />
+
+          <div className="flex items-center justify-end gap-1 pt-1">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleClose}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              loading={isSaving}
+              disabled={!isDirty}
+              className="gap-[6px]"
+            >
+              <Save className="w-[16px] h-[16px]" />
+              Save Changes
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/api/services/sync-engine.ts
+++ b/src/lib/api/services/sync-engine.ts
@@ -179,6 +179,7 @@ async function createOpportunity(
 ): Promise<string> {
   const supabase = requireSupabase();
   const isOutbound = stage === "qualifying"; // sent folder leads start at qualifying
+  const startedAt = Date.now();
   const { data } = await supabase
     .from("opportunities")
     .insert({
@@ -197,6 +198,18 @@ async function createOpportunity(
     })
     .select("id")
     .single();
+
+  // Phase C observability: log lead creation so the heartbeat cron has a
+  // signal of end-to-end ingestion success, not just webhook delivery.
+  console.log("[email-ingest] lead-created", {
+    leadId: data!.id,
+    companyId,
+    clientId,
+    stage,
+    direction: isOutbound ? "out" : "in",
+    msToCreate: Date.now() - startedAt,
+  });
+
   return data!.id;
 }
 

--- a/supabase/migrations/20260426200000_email_ingest_heartbeat_log.sql
+++ b/supabase/migrations/20260426200000_email_ingest_heartbeat_log.sql
@@ -1,0 +1,22 @@
+-- Phase C observability heartbeat log.
+--
+-- The /api/cron/email-ingest-heartbeat cron runs every 15 min and writes a row
+-- to this table whenever it fires an alert (notification rail + email) about
+-- a company whose email ingestion has produced zero events in the last hour.
+-- The row is consulted on the next run to dedup further alerts within a 4-hour
+-- window.
+--
+-- Service-role only; no RLS read path needed for end users.
+
+create table if not exists public.email_ingest_heartbeat_log (
+  id uuid primary key default gen_random_uuid(),
+  company_id uuid not null references public.companies(id) on delete cascade,
+  triggered_at timestamptz not null default now(),
+  reason text not null
+);
+
+create index if not exists email_ingest_heartbeat_log_company_recent_idx
+  on public.email_ingest_heartbeat_log (company_id, triggered_at desc);
+
+alter table public.email_ingest_heartbeat_log enable row level security;
+-- No policies: only the service-role client (cron) reads/writes this table.

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,10 @@
       "schedule": "*/15 * * * *"
     },
     {
+      "path": "/api/cron/email-ingest-heartbeat",
+      "schedule": "*/15 * * * *"
+    },
+    {
       "path": "/api/cron/webhook-renewal",
       "schedule": "0 6 * * *"
     },


### PR DESCRIPTION
## Summary

Round 2 of the QA-batch sprint. Implements the 13 deferred items from PR #4
that needed product or design input. Walked the user through each decision
one-by-one in plan mode; this PR ships those decisions verbatim.

Companion to #4 (Round 1). Branched from `origin/main` so Round 1 and Round 2
can review/merge independently. If Round 1 lands first, this PR rebases
cleanly (no overlapping files except `format.ts` — Round 2 inlines its
own `toDateOnlyString` to avoid the import dependency).

## Themes shipped

### `fix(financial)` — outstanding predicate aligned (afa21f78)
Project Financial tab outstanding filter previously omitted `AwaitingPayment`
status — Flight Deck Coating's $6,078 awaiting-payment invoice fell through.
Aligned with the global `isOutstanding` predicate (Paid/Void/Draft/WrittenOff
exclusion). Verified against Supabase MCP. **qa_bug `3040affb`**.

### `fix(projects)` — quick-view client fallback (3352633c)
Quick-view popover previously rendered empty when `clientNameMap` hadn't
populated yet. Mirrors the detail page's `useClient(clientId)` fallback so the
client name resolves even on cold mounts. Verified against Supabase MCP that
Dave Colson is a real parent client (load-order race, not data integrity).
**qa_bug `07ca41b5`**.

### `feat(projects)` — edit modal (d788ebe7)
Replaced the toast hint on the Project EDIT button with a real edit modal
covering title, status, dates, client, address, description, notes, and team.
Inline editors remain the fast path. **qa_bug `baaee799`**.

### `feat(clients)` — edit modal (cd2f1ba1)
Same pattern for the Client detail page: Edit button now opens a modal
mirroring the create-client form, pre-filled, address-autocompleted.
**qa_bug `c81a6984`**.

### `feat(photos)` — upload via existing flow (3851d43e)
Photos tab empty state previously had no upload affordance. Wired the
existing `getPresignedUrlProject` + S3 PUT + `useCreateProjectPhoto` chain
behind an "Upload Photos" button. Multi-file picker, parallel uploads with
per-file error tolerance, gated by `photos.upload`. **qa_bugs `ae730dde`,
`781541cd`, `a2767930`** (3 dupes).

### `feat(map)` — full-bleed canvas + slide-out drawer (f12f3725)
Map sidebar converted from a flex sibling (eating ~320px of canvas) to a
360px overlay drawer. Map fills viewport. EASE_SMOOTH 250ms transition,
`map-controls` z-index layer. Toggle stays anchored to the drawer's right
edge so the affordance is always at the active boundary. **qa_bug `63fe227e`**.

### `chore(bg)` — site BG audit (no commit, verified)
Audited all page-level canvases. Every dashboard page inherits
`bg-background = #000000` via `DashboardLayout`. Confirms canonical alignment
with `ops-design-system-v2/project/colors_and_type.css:40`. No drift to fix.
**qa_bug `0775fc3e`** marked closed-as-verified.

### `feat(observability)` — Phase C heartbeat (ab46514e)
- Structured logs at every observation point: webhook hits (Gmail + M365),
  lead creation in `sync-engine.ts`
- New `/api/cron/email-ingest-heartbeat` (every 15 min) detects companies
  with active integrations but zero events in the last 60 min, fires a
  notification rail entry + SendGrid alert with 4h dedup
- New `email_ingest_heartbeat_log` table (additive migration, **applied to
  prod via Supabase MCP**)
- Vercel cron registered in `vercel.json`
- Cost: ~96 invocations/day (Vercel Pro included). Negligible.

**qa_bug `3e6cd630`**.

### Industry pages (no commit, verified)
HVAC/Electrical/Plumbing/Cleaning links are not present in any current
sibling repo (OPS-Web, try-ops, ops-site). Already removed by a prior change.
**qa_bugs `a9e262b7`, `ea49d32e`** marked closed-as-verified.

### `feat(brand)` — LogoLoader port + ruleset (2d0dee58)
- New `<LogoLoader />` component at `src/components/brand/logo-loader.tsx`
  ports the chevron-split + OPS-typing animation from
  `ops-design-system-v2/project/logo-loader.jsx`. Pure SVG + Framer Motion,
  X-only translation, single EASE_SMOOTH curve, no spring/bounce. Reduced-
  motion fallback is a static lockup with 600ms opacity fade-in.
- Five loading states standardised to `<LogoLoader />` (replacing a mix of
  `animate-pulse-live` and Tailwind `animate-pulse`)
- /setup splash switched from vertical-stack to horizontal per the QA bug
- New `docs/brand/logo-system.md` codifies the placement ruleset + animation
  rules
- New `docs/brand/logo-audit-2026-04-26.md` is the frozen audit (re-run on
  major brand/layout overhauls)

**qa_bug `7fdf86b1`**.

## Decisions deferred or out-of-scope
- **Pipeline detail-popover dismiss** (`e31a722c`) — kept current X-only
  behavior per user decision; closed as expected behavior in Round 1.
- **Tutorial desktop layout** — needs separate design spec; not addressed.
- **FAB hide-at-edge** — handled by another agent.
- **Projects count w/ filter** (`763cb7bf`) — closed as wont-fix per user
  decision in Round 1.

## Test plan

- [ ] Open Flight Deck Coating Financial tab — verify $20,000 paid +
      $6,078.25 outstanding (was $0/$0)
- [ ] Hard-refresh `/projects` and quickly open a project quick-view —
      client name populates instantly
- [ ] Click EDIT on any project — modal opens, edit title + status, save
- [ ] Open a client detail page, click Edit — modal opens, change phone,
      save
- [ ] Open a project's Photos tab — upload button is visible, multi-file
      upload completes, photos appear in feed
- [ ] Load `/map` — drawer slides open/closed smoothly; map fully fills
      viewport when closed; toggle stays at the active edge
- [ ] Trigger any auth/onboarding loading state — chevron-split animation
      runs (test reduced-motion: static lockup with fade-in)
- [ ] Visit `/setup` while not yet set up — splash uses horizontal lockup,
      not vertical-stack
- [ ] Send a test email to a connected inbox — verify
      `[email-ingest] webhook` and `[email-ingest] lead-created` log lines
      in Vercel runtime logs
- [ ] Manually invoke `/api/cron/email-ingest-heartbeat` with the
      `Bearer ${CRON_SECRET}` header — verify response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)