### PR TITLE
fix(lint): rename pmf-bridge useNew to shouldUseNewTemplate

### DIFF
--- a/src/lib/email/pmf-bridge.tsx
+++ b/src/lib/email/pmf-bridge.tsx
@@ -25,7 +25,7 @@ import { PmfThresholdAlert } from "./react/templates/PmfThresholdAlert";
 import { PmfDailyDigest } from "./react/templates/PmfDailyDigest";
 import { PmfWeeklyDigest } from "./react/templates/PmfWeeklyDigest";
 
-function useNew(): boolean {
+function shouldUseNewTemplate(): boolean {
   return process.env.EMAIL_PMF_NEW_TEMPLATES === "true";
 }
 
@@ -35,15 +35,19 @@ function useNew(): boolean {
 // that mock the legacy template module to capture props at construction time.
 
 export function thresholdAlertEmail(props: ThresholdAlertProps) {
-  return useNew()
+  return shouldUseNewTemplate()
     ? PmfThresholdAlert(props)
     : LegacyThresholdAlertEmail(props);
 }
 
 export function dailyDigestEmail(props: DailyDigestProps) {
-  return useNew() ? PmfDailyDigest(props) : LegacyDailyDigestEmail(props);
+  return shouldUseNewTemplate()
+    ? PmfDailyDigest(props)
+    : LegacyDailyDigestEmail(props);
 }
 
 export function weeklyDigestEmail(props: WeeklyDigestProps) {
-  return useNew() ? PmfWeeklyDigest(props) : LegacyWeeklyDigestEmail(props);
+  return shouldUseNewTemplate()
+    ? PmfWeeklyDigest(props)
+    : LegacyWeeklyDigestEmail(props);
 }


### PR DESCRIPTION
## Summary

Hotfix to unblock CI. ESLint's `react-hooks/rules-of-hooks` incorrectly classifies `useNew()` as a React Hook because of the `use*` prefix, but it is a feature-flag check function (no hooks rules apply). Renaming the function clears 3 CI errors that have been blocking green builds.

## Changes

- Rename private function `useNew` to `shouldUseNewTemplate` in `src/lib/email/pmf-bridge.tsx`
- Update 3 internal call sites (`thresholdAlertEmail`, `dailyDigestEmail`, `weeklyDigestEmail`)
- The function is not exported, so no external call sites required updating

## Lint impact

Before: 5 `react-hooks/rules-of-hooks` errors (3 in pmf-bridge + 2 pre-existing in `estimates-overview-widget.tsx` / `unscheduled-tasks-widget.tsx`)

After: 2 `react-hooks/rules-of-hooks` errors (only the pre-existing widget ones remain — separate issue, not in scope here)

## Test plan

- [x] `npm run lint` — pmf-bridge errors gone, only pre-existing widget errors remain
- [x] `npm run type-check` — matches baseline (only pre-existing zxcvbn module errors)
- [x] `npx vitest run` — 636 tests pass, 4 file-level failures match baseline exactly (no new failures)
- [x] No behavioral change — pure rename