### PR TITLE
fix(routes): Next.js 15 dynamic route signature for suppressions/[email]

### DIFF
--- a/src/app/api/admin/email/suppressions/[email]/route.ts
+++ b/src/app/api/admin/email/suppressions/[email]/route.ts
@@ -11,11 +11,12 @@ import { requireAdmin, withAdmin } from "@/lib/admin/api-auth";
 import { getAdminSupabase } from "@/lib/supabase/admin-client";
 import { removeSuppression } from "@/lib/email/suppressions";
 
-type RouteContext = { params: { email: string } };
+type RouteContext = { params: Promise<{ email: string }> };
 
 export const GET = withAdmin(async (req: NextRequest, ctx: RouteContext) => {
   await requireAdmin(req);
-  const email = decodeURIComponent(ctx.params.email).toLowerCase().trim();
+  const { email: rawEmail } = await ctx.params;
+  const email = decodeURIComponent(rawEmail).toLowerCase().trim();
   if (!email) return NextResponse.json({ error: "email required" }, { status: 400 });
 
   const list = new URL(req.url).searchParams.get("list") ?? "global";
@@ -35,7 +36,8 @@ export const GET = withAdmin(async (req: NextRequest, ctx: RouteContext) => {
 
 export const DELETE = withAdmin(async (req: NextRequest, ctx: RouteContext) => {
   const adminUser = await requireAdmin(req);
-  const email = decodeURIComponent(ctx.params.email).toLowerCase().trim();
+  const { email: rawEmail } = await ctx.params;
+  const email = decodeURIComponent(rawEmail).toLowerCase().trim();
   if (!email) return NextResponse.json({ error: "email required" }, { status: 400 });
 
   const list = new URL(req.url).searchParams.get("list") ?? "global";


### PR DESCRIPTION
URGENT — production deploys broken since PR 1 merged. Type "RouteContext" wasn't matching Next.js 15's expected handler signature where params is now Promise.

## Fix
- `type RouteContext = { params: { email: string } }` → `Promise<{ email: string }>`
- Add `await ctx.params` destructure in GET + DELETE handlers
- Pure type-shape fix, no behavior change

## Test plan
- [x] type-check clean
- [ ] Vercel preview build succeeds (this is the real test — local build env has node_modules corruption from earlier disk pressure)
- [ ] Production deploy goes green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)