### PR TITLE
PR 3: Email Campaigns + Jobs Pipeline

### DIFF
--- a/src/app/admin/email/_components/campaign-create-modal.tsx
+++ b/src/app/admin/email/_components/campaign-create-modal.tsx
@@ -1,0 +1,314 @@
+"use client";
+import * as React from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { EASE_SMOOTH } from "@/lib/utils/motion";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreated?: (id: string) => void;
+}
+
+interface TemplateOption {
+  id: string;
+  label: string;
+  description: string;
+}
+
+const TEMPLATES: TemplateOption[] = [
+  {
+    id: "product_update",
+    label: "Product update",
+    description: "Periodic product news to active subscribers and trials.",
+  },
+  {
+    id: "trial_expiry_campaign",
+    label: "Trial expiry warning",
+    description: "Trial expiry urgency campaign — points users at billing.",
+  },
+  {
+    id: "feature_announcement",
+    label: "Feature announcement",
+    description: "Major feature ship announcement.",
+  },
+  {
+    id: "reengagement",
+    label: "Reengagement",
+    description: "Win-back for dormant users (not trial-specific).",
+  },
+];
+
+interface SegmentOption {
+  id: string;
+  label: string;
+  description: string;
+}
+
+const SEGMENTS: SegmentOption[] = [
+  { id: "all_users", label: "All opted-in users", description: "Everyone is_active and not opted out." },
+  { id: "trial_users", label: "Trial users", description: "Companies whose subscription_status is trial." },
+  { id: "active_subscribers", label: "Active subscribers", description: "active or grace subscriptions." },
+];
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80);
+}
+
+interface CreateResponse {
+  campaign: { id: string };
+}
+
+export function CampaignCreateModal({ open, onClose, onCreated }: Props) {
+  const reduce = useReducedMotion();
+  const qc = useQueryClient();
+
+  const [name, setName] = React.useState("");
+  const [templateId, setTemplateId] = React.useState(TEMPLATES[0].id);
+  const [segment, setSegment] = React.useState(SEGMENTS[0].id);
+  const [scheduleAt, setScheduleAt] = React.useState("");
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Reset form when the modal closes — next open starts clean.
+  React.useEffect(() => {
+    if (!open) {
+      setName("");
+      setTemplateId(TEMPLATES[0].id);
+      setSegment(SEGMENTS[0].id);
+      setScheduleAt("");
+      setError(null);
+    }
+  }, [open]);
+
+  const slug = React.useMemo(() => slugify(name), [name]);
+
+  const audienceQuery = useQuery({
+    queryKey: ["audienceEstimate", segment],
+    queryFn: async () => {
+      const res = await fetch(
+        "/api/admin/email/campaigns/audience-estimate",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ filter: { segment } }),
+        }
+      );
+      if (!res.ok) throw new Error("estimate_failed");
+      return (await res.json()) as { count: number };
+    },
+    enabled: open,
+    staleTime: 30_000,
+  });
+
+  const createMutation = useMutation<CreateResponse, Error>({
+    mutationFn: async () => {
+      setError(null);
+      const trimmed = name.trim();
+      if (!trimmed) throw new Error("Name is required.");
+      if (!slug) throw new Error("Name must contain at least one letter or digit.");
+
+      const createRes = await fetch("/api/admin/email/campaigns", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: trimmed,
+          slug,
+          templateId,
+          audienceFilter: { segment },
+        }),
+      });
+      if (!createRes.ok) {
+        const errBody = await createRes.json().catch(() => null);
+        throw new Error(errBody?.error ?? "create_failed");
+      }
+      const body = (await createRes.json()) as CreateResponse;
+
+      if (scheduleAt) {
+        const when = new Date(scheduleAt);
+        const schedRes = await fetch(
+          `/api/admin/email/campaigns/${body.campaign.id}/schedule`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ scheduledFor: when.toISOString() }),
+          }
+        );
+        if (!schedRes.ok) {
+          const errBody = await schedRes.json().catch(() => null);
+          throw new Error(errBody?.error ?? "schedule_failed");
+        }
+      }
+
+      return body;
+    },
+    onSuccess: (body) => {
+      qc.invalidateQueries({ queryKey: ["campaigns"] });
+      onCreated?.(body.campaign.id);
+      onClose();
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  const audienceText = audienceQuery.isLoading
+    ? "counting…"
+    : audienceQuery.isError
+    ? "[count unavailable]"
+    : `${audienceQuery.data?.count ?? 0} recipients`;
+
+  const t = reduce
+    ? { duration: 0.15 }
+    : { duration: 0.32, ease: EASE_SMOOTH };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 flex items-center justify-center px-4"
+          style={{ background: "rgba(0,0,0,0.65)", zIndex: 3000 }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={t}
+          onClick={onClose}
+        >
+          <motion.div
+            onClick={(e) => e.stopPropagation()}
+            initial={{ y: 16, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: 16, opacity: 0 }}
+            transition={t}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="campaign-create-title"
+            className="w-full max-w-[480px] p-6 rounded-[12px]"
+            style={{
+              background: "rgba(18,18,20,0.78)",
+              backdropFilter: "blur(28px) saturate(1.3)",
+              WebkitBackdropFilter: "blur(28px) saturate(1.3)",
+              border: "1px solid rgba(255,255,255,0.09)",
+            }}
+          >
+            <h2
+              id="campaign-create-title"
+              className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED] mb-1"
+            >
+              // NEW CAMPAIGN
+            </h2>
+            <p className="font-mono text-[11px] text-[#8A8A8A] mb-5">
+              [save as draft now, schedule once you&apos;re ready]
+            </p>
+
+            <label className="block mb-4">
+              <span className="font-cakemono font-light text-[11px] tracking-[0.06em] text-[#B5B5B5] block mb-1">
+                NAME
+              </span>
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="w-full font-mohave text-[14px] bg-transparent border border-white/10 rounded-[5px] px-3 py-2 text-[#EDEDED] focus:outline-none focus:border-[#6F94B0]"
+                placeholder="Q2 product update"
+                autoFocus
+              />
+              {slug ? (
+                <span className="font-mono text-[10px] text-[#6A6A6A] mt-1 block">
+                  [slug = {slug}]
+                </span>
+              ) : null}
+            </label>
+
+            <label className="block mb-4">
+              <span className="font-cakemono font-light text-[11px] tracking-[0.06em] text-[#B5B5B5] block mb-1">
+                TEMPLATE
+              </span>
+              <select
+                value={templateId}
+                onChange={(e) => setTemplateId(e.target.value)}
+                className="w-full font-mohave text-[14px] bg-transparent border border-white/10 rounded-[5px] px-3 py-2 text-[#EDEDED]"
+              >
+                {TEMPLATES.map((t) => (
+                  <option key={t.id} value={t.id} className="bg-black">
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+              <span className="font-mono text-[10px] text-[#6A6A6A] mt-1 block">
+                [{TEMPLATES.find((t) => t.id === templateId)?.description}]
+              </span>
+            </label>
+
+            <label className="block mb-4">
+              <span className="font-cakemono font-light text-[11px] tracking-[0.06em] text-[#B5B5B5] block mb-1">
+                AUDIENCE
+              </span>
+              <select
+                value={segment}
+                onChange={(e) => setSegment(e.target.value)}
+                className="w-full font-mohave text-[14px] bg-transparent border border-white/10 rounded-[5px] px-3 py-2 text-[#EDEDED]"
+              >
+                {SEGMENTS.map((s) => (
+                  <option key={s.id} value={s.id} className="bg-black">
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+              <span
+                className="font-mono text-[11px] text-[#9DB582] mt-1 block"
+                style={{ fontFeatureSettings: '"tnum" 1' }}
+              >
+                [{audienceText}]
+              </span>
+            </label>
+
+            <label className="block mb-6">
+              <span className="font-cakemono font-light text-[11px] tracking-[0.06em] text-[#B5B5B5] block mb-1">
+                SCHEDULE FOR
+              </span>
+              <input
+                type="datetime-local"
+                value={scheduleAt}
+                onChange={(e) => setScheduleAt(e.target.value)}
+                className="w-full font-mono text-[13px] bg-transparent border border-white/10 rounded-[5px] px-3 py-2 text-[#EDEDED] focus:outline-none focus:border-[#6F94B0]"
+              />
+              <span className="font-mono text-[10px] text-[#6A6A6A] mt-1 block">
+                [leave blank to save as draft]
+              </span>
+            </label>
+
+            {error ? (
+              <p
+                className="font-mono text-[11px] text-[#B58289] mb-4"
+                role="alert"
+              >
+                [error] {error}
+              </p>
+            ) : null}
+
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={onClose}
+                className="font-cakemono font-light text-[12px] tracking-[0.06em] text-[#8A8A8A] hover:text-[#EDEDED] px-3 py-2 transition-colors"
+              >
+                CANCEL
+              </button>
+              <button
+                onClick={() => createMutation.mutate()}
+                disabled={!name.trim() || createMutation.isPending}
+                className="font-cakemono font-light text-[12px] tracking-[0.06em] text-[#6F94B0] border border-[#6F94B0] hover:bg-[#6F94B0] hover:text-black disabled:opacity-40 disabled:cursor-not-allowed px-4 py-2 rounded-[5px] transition-colors"
+              >
+                {createMutation.isPending
+                  ? "SAVING…"
+                  : scheduleAt
+                  ? "SCHEDULE SEND"
+                  : "SAVE DRAFT"}
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/app/admin/email/_components/campaign-detail-modal.tsx
+++ b/src/app/admin/email/_components/campaign-detail-modal.tsx
@@ -1,0 +1,302 @@
+"use client";
+import * as React from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { CampaignStatusPill } from "./campaign-status-pill";
+import { CampaignProgressBar } from "./campaign-progress-bar";
+import type { Campaign, CampaignStatus } from "@/lib/email/campaigns";
+import { EASE_SMOOTH } from "@/lib/utils/motion";
+
+interface JobRow {
+  id: string;
+  recipient_email: string;
+  status: string;
+  sent_at: string | null;
+  last_error: string | null;
+  retry_count: number;
+  sg_message_id: string | null;
+}
+
+interface DetailResponse {
+  campaign: Campaign;
+  jobs: JobRow[];
+  jobsTotal: number;
+}
+
+interface Props {
+  campaignId: string | null;
+  onClose: () => void;
+}
+
+const POLL_STATUSES: CampaignStatus[] = ["scheduled", "in_flight"];
+
+export function CampaignDetailModal({ campaignId, onClose }: Props) {
+  const reduce = useReducedMotion();
+  const qc = useQueryClient();
+
+  const detail = useQuery({
+    queryKey: ["campaign", campaignId],
+    queryFn: async () => {
+      const r = await fetch(
+        `/api/admin/email/campaigns/${campaignId}?jobLimit=50`
+      );
+      if (!r.ok) throw new Error("detail_failed");
+      return (await r.json()) as DetailResponse;
+    },
+    enabled: !!campaignId,
+    refetchInterval: (q) => {
+      const status = q.state.data?.campaign.sendStatus;
+      return status && POLL_STATUSES.includes(status) ? 5000 : false;
+    },
+  });
+
+  const pause = useMutation({
+    mutationFn: async () => {
+      const r = await fetch(`/api/admin/email/campaigns/${campaignId}/pause`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ reason: "manual operator pause" }),
+      });
+      if (!r.ok) throw new Error("pause_failed");
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["campaign", campaignId] });
+      qc.invalidateQueries({ queryKey: ["campaigns"] });
+    },
+  });
+
+  const resume = useMutation({
+    mutationFn: async () => {
+      const r = await fetch(
+        `/api/admin/email/campaigns/${campaignId}/resume`,
+        { method: "POST" }
+      );
+      if (!r.ok) throw new Error("resume_failed");
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["campaign", campaignId] });
+      qc.invalidateQueries({ queryKey: ["campaigns"] });
+    },
+  });
+
+  const cancel = useMutation({
+    mutationFn: async () => {
+      const r = await fetch(
+        `/api/admin/email/campaigns/${campaignId}/cancel`,
+        { method: "POST" }
+      );
+      if (!r.ok) throw new Error("cancel_failed");
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["campaign", campaignId] });
+      qc.invalidateQueries({ queryKey: ["campaigns"] });
+      onClose();
+    },
+  });
+
+  const t = reduce
+    ? { duration: 0.15 }
+    : { duration: 0.32, ease: EASE_SMOOTH };
+
+  const c = detail.data?.campaign;
+  const showPause = c?.sendStatus === "in_flight";
+  const showResume = c?.sendStatus === "paused";
+  const showCancel =
+    c?.sendStatus === "scheduled" ||
+    c?.sendStatus === "in_flight" ||
+    c?.sendStatus === "paused";
+
+  return (
+    <AnimatePresence>
+      {campaignId && c ? (
+        <motion.div
+          className="fixed inset-0 flex items-center justify-center px-4"
+          style={{ background: "rgba(0,0,0,0.65)", zIndex: 3000 }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={t}
+          onClick={onClose}
+        >
+          <motion.div
+            onClick={(e) => e.stopPropagation()}
+            initial={{ y: 16, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: 16, opacity: 0 }}
+            transition={t}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="campaign-detail-title"
+            className="w-full max-w-[720px] max-h-[80vh] overflow-y-auto p-6 rounded-[12px]"
+            style={{
+              background: "rgba(18,18,20,0.78)",
+              backdropFilter: "blur(28px) saturate(1.3)",
+              WebkitBackdropFilter: "blur(28px) saturate(1.3)",
+              border: "1px solid rgba(255,255,255,0.09)",
+            }}
+          >
+            <div className="flex items-start justify-between mb-4 gap-3">
+              <div className="min-w-0">
+                <h2
+                  id="campaign-detail-title"
+                  className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED] mb-1 truncate"
+                >
+                  // {c.name.toUpperCase()}
+                </h2>
+                <span className="font-mono text-[11px] text-[#8A8A8A]">
+                  [{c.slug}] [template = {c.templateId}]
+                </span>
+              </div>
+              <CampaignStatusPill status={c.sendStatus} />
+            </div>
+
+            <div
+              className="grid grid-cols-3 gap-4 mb-5"
+              style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+            >
+              <Counter label="DELIVERED" value={c.deliveredCount} />
+              <Counter label="OPENED" value={c.openedCount} />
+              <Counter label="CLICKED" value={c.clickedCount} />
+              <Counter label="BOUNCED" value={c.bouncedCount} accent="brick" />
+              <Counter label="FAILED" value={c.failedCount} accent="brick" />
+              <Counter
+                label="SUPPRESSED"
+                value={c.suppressedSkippedCount}
+                accent="mute"
+              />
+            </div>
+
+            <CampaignProgressBar
+              sent={c.sentCount}
+              bounced={c.bouncedCount}
+              failed={c.failedCount}
+              total={c.recipientCountActual ?? c.recipientCountEstimate}
+            />
+
+            <div className="mt-6 mb-2 flex items-center justify-between">
+              <span className="font-cakemono font-light text-[11px] tracking-[0.06em] text-[#B5B5B5]">
+                JOBS [{detail.data?.jobsTotal ?? 0}]
+              </span>
+              <div className="flex gap-2">
+                {showPause ? (
+                  <button
+                    onClick={() => pause.mutate()}
+                    disabled={pause.isPending}
+                    className="font-cakemono font-light text-[11px] tracking-[0.06em] text-[#C4A868] border border-[#C4A868]/40 px-2 py-1 rounded-[4px] hover:bg-[#C4A868]/10 disabled:opacity-40 transition-colors"
+                  >
+                    {pause.isPending ? "PAUSING…" : "PAUSE"}
+                  </button>
+                ) : null}
+                {showResume ? (
+                  <button
+                    onClick={() => resume.mutate()}
+                    disabled={resume.isPending}
+                    className="font-cakemono font-light text-[11px] tracking-[0.06em] text-[#9DB582] border border-[#9DB582]/40 px-2 py-1 rounded-[4px] hover:bg-[#9DB582]/10 disabled:opacity-40 transition-colors"
+                  >
+                    {resume.isPending ? "RESUMING…" : "RESUME"}
+                  </button>
+                ) : null}
+                {showCancel ? (
+                  <button
+                    onClick={() => cancel.mutate()}
+                    disabled={cancel.isPending}
+                    className="font-cakemono font-light text-[11px] tracking-[0.06em] text-[#B58289] border border-[#93321A]/50 px-2 py-1 rounded-[4px] hover:bg-[#93321A]/10 disabled:opacity-40 transition-colors"
+                  >
+                    {cancel.isPending ? "CANCELLING…" : "CANCEL"}
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="border-t border-white/[0.06]">
+              {detail.data?.jobs.map((j) => (
+                <div
+                  key={j.id}
+                  className="flex items-center justify-between gap-3 py-2 border-b border-white/[0.04]"
+                >
+                  <span className="font-mono text-[12px] text-[#EDEDED] truncate">
+                    {j.recipient_email}
+                  </span>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {j.last_error ? (
+                      <span
+                        className="font-mono text-[10px] text-[#B58289] max-w-[240px] truncate"
+                        title={j.last_error}
+                      >
+                        [{j.last_error}]
+                      </span>
+                    ) : null}
+                    <span
+                      className="font-cakemono font-light text-[10px] tracking-[0.06em]"
+                      style={{ color: jobStatusColor(j.status) }}
+                    >
+                      {j.status.toUpperCase().replace("_", " ")}
+                    </span>
+                  </div>
+                </div>
+              ))}
+              {(detail.data?.jobs.length ?? 0) === 0 ? (
+                <p className="font-mono text-[11px] text-[#6A6A6A] py-4">
+                  [no jobs yet — dispatcher will enqueue when scheduled time arrives]
+                </p>
+              ) : null}
+            </div>
+          </motion.div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}
+
+function Counter({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent?: "brick" | "mute";
+}) {
+  const reduce = useReducedMotion();
+  const color =
+    accent === "brick" ? "#B58289" : accent === "mute" ? "#6A6A6A" : "#EDEDED";
+  const t = reduce
+    ? { duration: 0.15 }
+    : { duration: 0.3, ease: EASE_SMOOTH };
+  return (
+    <div>
+      <span className="font-cakemono font-light text-[10px] tracking-[0.06em] text-[#8A8A8A] block">
+        {label}
+      </span>
+      <motion.span
+        key={value}
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={t}
+        className="font-mono text-[20px]"
+        style={{ color, fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+      >
+        {value}
+      </motion.span>
+    </div>
+  );
+}
+
+function jobStatusColor(s: string): string {
+  switch (s) {
+    case "sent":
+      return "#9DB582";
+    case "bounced":
+      return "#B58289";
+    case "failed":
+      return "#93321A";
+    case "skipped_suppressed":
+      return "#6A6A6A";
+    case "dispatching":
+      return "#C4A868";
+    case "cancelled":
+      return "#6A6A6A";
+    default:
+      return "#8A8A8A";
+  }
+}

--- a/src/app/admin/email/_components/campaign-progress-bar.tsx
+++ b/src/app/admin/email/_components/campaign-progress-bar.tsx
@@ -1,0 +1,76 @@
+"use client";
+import * as React from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { EASE_SMOOTH } from "@/lib/utils/motion";
+
+interface Props {
+  sent: number;
+  total: number;
+  bounced: number;
+  failed: number;
+}
+
+/**
+ * Segmented progress bar — olive (sent), rose (bounced), brick (failed)
+ * stacked on a 2px rail. Shows the campaign's actual delivery shape, not
+ * just a generic percentage.
+ */
+export function CampaignProgressBar({ sent, total, bounced, failed }: Props) {
+  const reduce = useReducedMotion();
+  const safeTotal = Math.max(total, 1);
+  const sentPct = Math.min(sent / safeTotal, 1);
+  const bouncedPct = Math.min(bounced / safeTotal, 1);
+  const failedPct = Math.min(failed / safeTotal, 1);
+
+  const t = reduce
+    ? { duration: 0.15 }
+    : { duration: 0.6, ease: EASE_SMOOTH };
+
+  return (
+    <div className="space-y-1">
+      <div
+        className="h-[2px] rounded-[2px] relative overflow-hidden"
+        style={{ background: "rgba(255,255,255,0.06)" }}
+        aria-label={`${sent} of ${total} sent`}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-valuenow={sent}
+      >
+        <motion.div
+          className="absolute inset-y-0 left-0"
+          style={{ background: "#9DB582" }}
+          initial={{ width: 0 }}
+          animate={{ width: `${sentPct * 100}%` }}
+          transition={t}
+        />
+        <motion.div
+          className="absolute inset-y-0"
+          style={{ background: "#B58289", left: `${sentPct * 100}%` }}
+          initial={{ width: 0 }}
+          animate={{ width: `${bouncedPct * 100}%` }}
+          transition={t}
+        />
+        <motion.div
+          className="absolute inset-y-0"
+          style={{
+            background: "#93321A",
+            left: `${(sentPct + bouncedPct) * 100}%`,
+          }}
+          initial={{ width: 0 }}
+          animate={{ width: `${failedPct * 100}%` }}
+          transition={t}
+        />
+      </div>
+      <div
+        className="flex gap-3 font-mono text-[10px] text-[#8A8A8A]"
+        style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+      >
+        <span>SENT {sent}</span>
+        <span>BOUNCED {bounced}</span>
+        <span>FAILED {failed}</span>
+        <span className="ml-auto">/ {total}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/email/_components/campaign-status-pill.tsx
+++ b/src/app/admin/email/_components/campaign-status-pill.tsx
@@ -1,0 +1,49 @@
+"use client";
+import * as React from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import type { CampaignStatus } from "@/lib/email/campaigns";
+import {
+  statusPillVariants,
+  statusPillVariantsReduced,
+} from "@/lib/utils/motion";
+
+interface PillStyle {
+  fg: string;
+  bg: string;
+  bd: string;
+  label: string;
+}
+
+const STYLES: Record<CampaignStatus, PillStyle> = {
+  draft:     { fg: "#8A8A8A", bg: "rgba(138,138,138,0.08)", bd: "rgba(138,138,138,0.30)", label: "DRAFT" },
+  scheduled: { fg: "#B5B5B5", bg: "rgba(181,181,181,0.08)", bd: "rgba(181,181,181,0.30)", label: "SCHEDULED" },
+  in_flight: { fg: "#C4A868", bg: "rgba(196,168,104,0.08)", bd: "rgba(196,168,104,0.40)", label: "SENDING" },
+  completed: { fg: "#9DB582", bg: "rgba(157,181,130,0.08)", bd: "rgba(157,181,130,0.40)", label: "SENT" },
+  failed:    { fg: "#B58289", bg: "rgba(181,130,137,0.08)", bd: "rgba(147,50,26,0.50)",   label: "FAILED" },
+  cancelled: { fg: "#6A6A6A", bg: "rgba(106,106,106,0.06)", bd: "rgba(106,106,106,0.25)", label: "CANCELLED" },
+  paused:    { fg: "#C4A868", bg: "transparent",            bd: "rgba(196,168,104,0.55)", label: "PAUSED" },
+};
+
+interface Props {
+  status: CampaignStatus;
+}
+
+export function CampaignStatusPill({ status }: Props) {
+  const reduce = useReducedMotion();
+  const s = STYLES[status];
+  return (
+    <motion.span
+      variants={reduce ? statusPillVariantsReduced : statusPillVariants}
+      initial="hidden"
+      animate="visible"
+      className="inline-flex items-center font-cakemono font-light text-[11px] tracking-[0.06em] px-2 py-[3px] rounded-[4px]"
+      style={{
+        color: s.fg,
+        background: s.bg,
+        border: `1px solid ${s.bd}`,
+      }}
+    >
+      {s.label}
+    </motion.span>
+  );
+}

--- a/src/app/admin/email/_components/email-content.tsx
+++ b/src/app/admin/email/_components/email-content.tsx
@@ -7,6 +7,7 @@ import { EmailLogTab } from "./email-log-tab";
 import { NewsletterTab } from "./newsletter-tab";
 import { TriggersTab } from "./triggers-tab";
 import { ScheduleTab } from "./schedule-tab";
+import { ScheduledSendsTab } from "./scheduled-sends-tab";
 import type {
   EmailOverviewStats,
   EmailEngagementStats,
@@ -25,13 +26,14 @@ interface EmailContentProps {
 
 export function EmailContent({ overview, engagement, funnels, emailLog, newsletters }: EmailContentProps) {
   return (
-    <SubTabs tabs={["Overview", "Funnels", "Email Log", "Newsletter", "Schedule", "Triggers"]}>
+    <SubTabs tabs={["Overview", "Scheduled Sends", "Funnels", "Email Log", "Newsletter", "Lifecycle", "Triggers"]}>
       {(tab) => {
         if (tab === "Overview") return <OverviewTab stats={overview} engagement={engagement} />;
+        if (tab === "Scheduled Sends") return <ScheduledSendsTab />;
         if (tab === "Funnels") return <FunnelsTab data={funnels} />;
         if (tab === "Email Log") return <EmailLogTab entries={emailLog} />;
         if (tab === "Newsletter") return <NewsletterTab newsletters={newsletters} />;
-        if (tab === "Schedule") return <ScheduleTab />;
+        if (tab === "Lifecycle") return <ScheduleTab />;
         if (tab === "Triggers") return <TriggersTab />;
         return null;
       }}

--- a/src/app/admin/email/_components/scheduled-sends-tab.tsx
+++ b/src/app/admin/email/_components/scheduled-sends-tab.tsx
@@ -1,0 +1,145 @@
+"use client";
+import * as React from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { useQuery } from "@tanstack/react-query";
+import { CampaignStatusPill } from "./campaign-status-pill";
+import { CampaignProgressBar } from "./campaign-progress-bar";
+import { CampaignCreateModal } from "./campaign-create-modal";
+import { CampaignDetailModal } from "./campaign-detail-modal";
+import {
+  campaignRowVariants,
+  campaignRowVariantsReduced,
+} from "@/lib/utils/motion";
+import type { Campaign } from "@/lib/email/campaigns";
+
+interface ListResponse {
+  rows: Campaign[];
+  total: number;
+}
+
+function formatScheduled(campaign: Campaign): string {
+  if (campaign.sendStatus === "draft") return "Draft, not scheduled.";
+  if (!campaign.scheduledFor) return "—";
+  const when = new Date(campaign.scheduledFor);
+  return when.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function ScheduledSendsTab() {
+  const reduce = useReducedMotion();
+  const [createOpen, setCreateOpen] = React.useState(false);
+  const [detailId, setDetailId] = React.useState<string | null>(null);
+
+  const list = useQuery({
+    queryKey: ["campaigns"],
+    queryFn: async () => {
+      const r = await fetch("/api/admin/email/campaigns?limit=50");
+      if (!r.ok) throw new Error("list_failed");
+      return (await r.json()) as ListResponse;
+    },
+    refetchInterval: 8000,
+  });
+
+  return (
+    <section className="space-y-4">
+      <header className="flex items-center justify-between">
+        <div>
+          <h3 className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED]">
+            // SCHEDULED SENDS
+          </h3>
+          <p
+            className="font-mono text-[11px] text-[#8A8A8A]"
+            style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+          >
+            [{list.data?.total ?? 0} campaigns]
+          </p>
+        </div>
+        <button
+          onClick={() => setCreateOpen(true)}
+          className="font-cakemono font-light text-[12px] tracking-[0.06em] text-[#6F94B0] border border-[#6F94B0] hover:bg-[#6F94B0] hover:text-black px-3 py-1.5 rounded-[5px] transition-colors"
+        >
+          NEW CAMPAIGN
+        </button>
+      </header>
+
+      <div className="space-y-1.5">
+        {(list.data?.rows ?? []).map((c, i) => (
+          <motion.button
+            key={c.id}
+            type="button"
+            onClick={() => setDetailId(c.id)}
+            custom={i}
+            variants={
+              reduce ? campaignRowVariantsReduced : campaignRowVariants
+            }
+            initial="hidden"
+            animate="visible"
+            className="block w-full text-left p-3 rounded-[10px] hover:bg-white/[0.03] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#6F94B0] transition-colors"
+            style={{ border: "1px solid rgba(255,255,255,0.06)" }}
+          >
+            <div className="flex items-start justify-between gap-3 mb-2">
+              <div className="min-w-0">
+                <div className="flex items-baseline gap-2 flex-wrap">
+                  <span className="font-mohave text-[14px] text-[#EDEDED] truncate">
+                    {c.name}
+                  </span>
+                  <span className="font-mono text-[10px] text-[#6A6A6A]">
+                    [{c.slug}]
+                  </span>
+                </div>
+                <span
+                  className="font-mono text-[10px] text-[#8A8A8A] block mt-0.5"
+                  style={{ fontFeatureSettings: '"tnum" 1' }}
+                >
+                  {formatScheduled(c)} · template:{c.templateId}
+                </span>
+              </div>
+              <CampaignStatusPill status={c.sendStatus} />
+            </div>
+            <CampaignProgressBar
+              sent={c.sentCount}
+              bounced={c.bouncedCount}
+              failed={c.failedCount}
+              total={c.recipientCountActual ?? c.recipientCountEstimate}
+            />
+          </motion.button>
+        ))}
+
+        {list.isLoading ? (
+          <p className="font-mono text-[12px] text-[#8A8A8A] py-8">
+            [loading campaigns…]
+          </p>
+        ) : null}
+
+        {!list.isLoading && (list.data?.rows.length ?? 0) === 0 ? (
+          <p className="font-mono text-[12px] text-[#8A8A8A] py-8">
+            [no campaigns yet — start with NEW CAMPAIGN]
+          </p>
+        ) : null}
+
+        {list.isError ? (
+          <p
+            className="font-mono text-[12px] text-[#B58289] py-2"
+            role="alert"
+          >
+            [error] failed to load campaigns
+          </p>
+        ) : null}
+      </div>
+
+      <CampaignCreateModal
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={(id) => setDetailId(id)}
+      />
+      <CampaignDetailModal
+        campaignId={detailId}
+        onClose={() => setDetailId(null)}
+      />
+    </section>
+  );
+}

--- a/src/app/api/admin/email/campaigns/[id]/cancel/route.ts
+++ b/src/app/api/admin/email/campaigns/[id]/cancel/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { cancelCampaign } from "@/lib/email/campaigns";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export const POST = withAdmin(async (req: NextRequest, ctx: RouteContext) => {
+  await requireAdmin(req);
+  const { id } = await ctx.params;
+  const c = await cancelCampaign(id);
+  return NextResponse.json({ campaign: c });
+});

--- a/src/app/api/admin/email/campaigns/[id]/pause/route.ts
+++ b/src/app/api/admin/email/campaigns/[id]/pause/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { pauseCampaign } from "@/lib/email/campaigns";
+import { z } from "zod";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const Body = z.object({ reason: z.string().min(1).max(200) });
+
+export const POST = withAdmin(async (req: NextRequest, ctx: RouteContext) => {
+  const user = await requireAdmin(req);
+  const { id } = await ctx.params;
+  const parsed = Body.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "validation_failed", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+  const tag = user.email ? ` [by ${user.email}]` : "";
+  const c = await pauseCampaign(id, `${parsed.data.reason}${tag}`);
+  return NextResponse.json({ campaign: c });
+});

--- a/src/app/api/admin/email/campaigns/[id]/resume/route.ts
+++ b/src/app/api/admin/email/campaigns/[id]/resume/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { resumeCampaign } from "@/lib/email/campaigns";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export const POST = withAdmin(async (req: NextRequest, ctx: RouteContext) => {
+  await requireAdmin(req);
+  const { id } = await ctx.params;
+  const c = await resumeCampaign(id);
+  return NextResponse.json({ campaign: c });
+});

--- a/src/app/api/admin/email/campaigns/[id]/route.ts
+++ b/src/app/api/admin/email/campaigns/[id]/route.ts
@@ -1,0 +1,45 @@
+/**
+ * GET /api/admin/email/campaigns/[id]
+ *
+ * Returns a campaign + paginated slice of its email_jobs.
+ * Used by the campaign detail modal at 5s polling cadence while
+ * the campaign is in_flight or scheduled.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { getCampaignStats } from "@/lib/email/campaigns";
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export const GET = withAdmin(async (req: NextRequest, ctx: RouteContext) => {
+  await requireAdmin(req);
+  const { id } = await ctx.params;
+
+  const c = await getCampaignStats(id);
+  if (!c) return NextResponse.json({ error: "not_found" }, { status: 404 });
+
+  const sp = req.nextUrl.searchParams;
+  const jobLimit = Math.min(
+    Math.max(Number(sp.get("jobLimit") ?? 50), 1),
+    200
+  );
+  const jobOffset = Math.max(Number(sp.get("jobOffset") ?? 0), 0);
+
+  const db = getServiceRoleClient();
+  const { data: jobs, count } = await db
+    .from("email_jobs")
+    .select(
+      "id, recipient_email, status, sent_at, last_error, retry_count, sg_message_id",
+      { count: "exact" }
+    )
+    .eq("campaign_id", id)
+    .order("created_at", { ascending: false })
+    .range(jobOffset, jobOffset + jobLimit - 1);
+
+  return NextResponse.json({
+    campaign: c,
+    jobs: jobs ?? [],
+    jobsTotal: count ?? 0,
+  });
+});

--- a/src/app/api/admin/email/campaigns/[id]/schedule/route.ts
+++ b/src/app/api/admin/email/campaigns/[id]/schedule/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { scheduleCampaign } from "@/lib/email/campaigns";
+import { z } from "zod";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const Body = z.object({ scheduledFor: z.string().datetime() });
+
+export const POST = withAdmin(async (req: NextRequest, ctx: RouteContext) => {
+  await requireAdmin(req);
+  const { id } = await ctx.params;
+  const parsed = Body.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "validation_failed", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+  const when = new Date(parsed.data.scheduledFor);
+  // Allow up to 60s clock skew so an admin scheduling for "now" doesn't get
+  // rejected by a stale browser clock.
+  if (when.getTime() < Date.now() - 60_000) {
+    return NextResponse.json(
+      { error: "scheduled_for must be in the future" },
+      { status: 400 }
+    );
+  }
+  const c = await scheduleCampaign(id, when);
+  return NextResponse.json({ campaign: c });
+});

--- a/src/app/api/admin/email/campaigns/audience-estimate/route.ts
+++ b/src/app/api/admin/email/campaigns/audience-estimate/route.ts
@@ -1,0 +1,27 @@
+/**
+ * POST /api/admin/email/campaigns/audience-estimate
+ *
+ * Returns the recipient count for a given audience filter — drives the
+ * live count under the Audience selector in the campaign create modal.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { estimateAudience } from "@/lib/email/audiences";
+import { z } from "zod";
+
+const Body = z.object({
+  filter: z.record(z.string(), z.unknown()).default({}),
+});
+
+export const POST = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+  const parsed = Body.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "validation_failed", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+  const count = await estimateAudience(parsed.data.filter);
+  return NextResponse.json({ count });
+});

--- a/src/app/api/admin/email/campaigns/route.ts
+++ b/src/app/api/admin/email/campaigns/route.ts
@@ -1,0 +1,71 @@
+/**
+ * GET  /api/admin/email/campaigns           — list campaigns
+ * POST /api/admin/email/campaigns           — create a draft campaign
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import {
+  listCampaigns,
+  createCampaign,
+  type CampaignStatus,
+} from "@/lib/email/campaigns";
+import { estimateAudience } from "@/lib/email/audiences";
+import { z } from "zod";
+
+const ALL_STATUSES: CampaignStatus[] = [
+  "draft",
+  "scheduled",
+  "in_flight",
+  "completed",
+  "failed",
+  "cancelled",
+  "paused",
+];
+
+function parseStatus(raw: string | null): CampaignStatus | undefined {
+  if (!raw) return undefined;
+  return (ALL_STATUSES as string[]).includes(raw)
+    ? (raw as CampaignStatus)
+    : undefined;
+}
+
+const CreateSchema = z.object({
+  name: z.string().min(1).max(120),
+  slug: z
+    .string()
+    .regex(/^[a-z0-9-]+$/, "slug must be lowercase letters, digits, and dashes")
+    .min(1)
+    .max(80),
+  templateId: z.string().min(1),
+  audienceFilter: z.record(z.string(), z.unknown()).default({}),
+  audienceTemplateId: z.string().uuid().nullable().optional(),
+});
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+  const sp = req.nextUrl.searchParams;
+  const status = parseStatus(sp.get("status"));
+  const limit = Math.min(Math.max(Number(sp.get("limit") ?? 50), 1), 200);
+  const offset = Math.max(Number(sp.get("offset") ?? 0), 0);
+  const result = await listCampaigns({ status, limit, offset });
+  return NextResponse.json(result);
+});
+
+export const POST = withAdmin(async (req: NextRequest) => {
+  const user = await requireAdmin(req);
+  const body = await req.json().catch(() => null);
+  const parsed = CreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "validation_failed", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+  const recipientCountEstimate = await estimateAudience(parsed.data.audienceFilter);
+  const campaign = await createCampaign({
+    ...parsed.data,
+    createdByUserId: user.uid,
+    recipientCountEstimate,
+  });
+  return NextResponse.json({ campaign }, { status: 201 });
+});

--- a/src/app/api/cron/email/dispatcher/route.ts
+++ b/src/app/api/cron/email/dispatcher/route.ts
@@ -1,0 +1,116 @@
+/**
+ * /api/cron/email/dispatcher
+ *
+ * Runs every minute. Picks up to N campaigns whose scheduled_for has
+ * passed, resolves the audience, enqueues one email_jobs row per opted-in
+ * recipient, and transitions the campaign to in_flight (or completed when
+ * the audience is empty after suppression).
+ *
+ * Auth: Bearer ${CRON_SECRET}.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import { resolveAudience } from "@/lib/email/audiences";
+import { enqueueCampaignJobs } from "@/lib/email/campaigns";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const READY_BATCH = 5;
+
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET not configured" },
+      { status: 500 }
+    );
+  }
+  const auth = request.headers.get("authorization");
+  if (auth !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const db = getServiceRoleClient();
+  const nowIso = new Date().toISOString();
+
+  const { data: ready, error } = await db
+    .from("email_campaigns")
+    .select("id, name, audience_filter, audience_template_id")
+    .eq("send_status", "scheduled")
+    .lte("scheduled_for", nowIso)
+    .order("scheduled_for", { ascending: true })
+    .limit(READY_BATCH);
+
+  if (error) {
+    console.error("[email-dispatcher] read failed:", error);
+    return NextResponse.json({ error: "read_failed" }, { status: 500 });
+  }
+
+  const results: Array<{
+    id: string;
+    enqueued: number;
+    suppressedSkipped: number;
+    error?: string;
+  }> = [];
+
+  for (const c of ready ?? []) {
+    try {
+      // PR 5 introduces email_audience_templates; PR 3 falls back to the
+      // inline audience_filter when the template table doesn't exist.
+      let filter = (c.audience_filter ?? {}) as Record<string, unknown>;
+      if (c.audience_template_id) {
+        const { data: tpl } = await db
+          .from("email_audience_templates")
+          .select("filter")
+          .eq("id", c.audience_template_id)
+          .maybeSingle();
+        if (tpl) {
+          filter = (tpl.filter ?? {}) as Record<string, unknown>;
+          await db
+            .rpc("increment_audience_template_usage" as never, {
+              p_template_id: c.audience_template_id,
+            } as never)
+            .then((res) => {
+              if (res.error) {
+                // PR 5 RPC absent in PR 3 — swallow silently.
+              }
+            })
+            .then(() => undefined, () => undefined);
+        }
+      }
+
+      const { recipients } = await resolveAudience(filter, db);
+      const recipientList = recipients.map((r) => ({
+        email: r.email,
+        userId: r.userId,
+        payload: { recipient_user_id: r.userId },
+      }));
+
+      const result = await enqueueCampaignJobs({
+        campaignId: c.id,
+        recipients: recipientList,
+        client: db,
+      });
+
+      results.push({ id: c.id, ...result });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[email-dispatcher] campaign ${c.id} failed:`, message);
+      // Mark campaign failed so it doesn't keep retrying every minute.
+      await db
+        .from("email_campaigns")
+        .update({ send_status: "failed" })
+        .eq("id", c.id);
+      results.push({
+        id: c.id,
+        enqueued: 0,
+        suppressedSkipped: 0,
+        error: message,
+      });
+    }
+  }
+
+  return NextResponse.json({ ok: true, processed: results.length, results });
+}

--- a/src/app/api/cron/email/worker/route.ts
+++ b/src/app/api/cron/email/worker/route.ts
@@ -97,7 +97,10 @@ export async function GET(request: NextRequest) {
   };
 
   let totalSent = 0;
-  let totalBounced = 0;
+  // Bounces arrive via the SendGrid webhook (PR 6), not in the worker
+  // dispatch path — the counter is reported here for API stability and
+  // populated upstream by the webhook handler.
+  const totalBounced = 0;
   let totalFailed = 0;
   let totalSkipped = 0;
 

--- a/src/app/api/cron/email/worker/route.ts
+++ b/src/app/api/cron/email/worker/route.ts
@@ -1,0 +1,258 @@
+/**
+ * /api/cron/email/worker
+ *
+ * Runs every minute. Atomically claims up to BATCH_LIMIT pending jobs
+ * (FOR UPDATE SKIP LOCKED via the `claim_email_jobs` RPC), invokes the
+ * registered campaign template's gatedSend wrapper for each, and updates
+ * email_jobs + email_campaigns counters. When all jobs for a campaign are
+ * terminal, transitions the campaign to `completed` and inserts a
+ * notification onto the rail for the operator who scheduled it.
+ *
+ * Auth: Bearer ${CRON_SECRET}. Service-role DB only.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import { completeCampaignIfDone } from "@/lib/email/campaigns";
+import { bootstrapCampaignTemplates } from "@/lib/email/campaign-templates-bootstrap";
+import { getCampaignTemplate } from "@/lib/email/campaign-templates";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const BATCH_LIMIT = 200;
+const INTER_SEND_DELAY_MS = 10;
+const MAX_RETRIES = 3;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface ClaimedJob {
+  id: string;
+  campaign_id: string;
+  recipient_email: string;
+  recipient_user_id: string | null;
+  template_payload: Record<string, unknown>;
+  retry_count: number;
+}
+
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET not configured" },
+      { status: 500 }
+    );
+  }
+  if (request.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  bootstrapCampaignTemplates();
+  const db = getServiceRoleClient();
+
+  const { data: claimed, error: claimErr } = await db.rpc("claim_email_jobs", {
+    p_limit: BATCH_LIMIT,
+  });
+  if (claimErr) {
+    console.error("[email-worker] claim failed:", claimErr);
+    return NextResponse.json({ error: "claim_failed" }, { status: 500 });
+  }
+
+  const jobs = (claimed ?? []) as ClaimedJob[];
+
+  // Look up the template + status for each campaign once per batch.
+  const campaignIds = Array.from(new Set(jobs.map((j) => j.campaign_id)));
+  const campaignMap = new Map<
+    string,
+    { template_id: string; send_status: string; name: string; created_by_user_id: string | null }
+  >();
+
+  if (campaignIds.length > 0) {
+    const { data: campaigns } = await db
+      .from("email_campaigns")
+      .select("id, template_id, send_status, name, created_by_user_id")
+      .in("id", campaignIds);
+    for (const c of campaigns ?? []) {
+      campaignMap.set(c.id, {
+        template_id: c.template_id,
+        send_status: c.send_status,
+        name: c.name,
+        created_by_user_id: c.created_by_user_id,
+      });
+    }
+  }
+
+  // Per-campaign tallies for notification body.
+  const tallies = new Map<
+    string,
+    { sent: number; bounced: number; failed: number; skipped: number }
+  >();
+  const tally = (cid: string) => {
+    let t = tallies.get(cid);
+    if (!t) {
+      t = { sent: 0, bounced: 0, failed: 0, skipped: 0 };
+      tallies.set(cid, t);
+    }
+    return t;
+  };
+
+  let totalSent = 0;
+  let totalBounced = 0;
+  let totalFailed = 0;
+  let totalSkipped = 0;
+
+  for (const job of jobs) {
+    const campaign = campaignMap.get(job.campaign_id);
+
+    // Campaign was paused or cancelled while this batch was claimed —
+    // re-pend (paused) or finalise as cancelled (cancelled). Pause logic
+    // hardens in PR 4 with the killswitch state machine.
+    if (
+      !campaign ||
+      campaign.send_status === "paused" ||
+      campaign.send_status === "cancelled"
+    ) {
+      await db
+        .from("email_jobs")
+        .update({
+          status: campaign?.send_status === "cancelled" ? "cancelled" : "pending",
+        })
+        .eq("id", job.id);
+      continue;
+    }
+
+    const tpl = getCampaignTemplate(campaign.template_id);
+    if (!tpl) {
+      await db
+        .from("email_jobs")
+        .update({
+          status: "failed",
+          last_error: `unknown template_id ${campaign.template_id}`,
+        })
+        .eq("id", job.id);
+      await db.rpc("increment_campaign_counter", {
+        p_campaign_id: job.campaign_id,
+        p_field: "failed_count",
+        p_delta: 1,
+      });
+      tally(job.campaign_id).failed++;
+      totalFailed++;
+      continue;
+    }
+
+    try {
+      const result = await tpl.sender({
+        recipientEmail: job.recipient_email,
+        recipientUserId: job.recipient_user_id,
+        payload: job.template_payload,
+        campaignId: job.campaign_id,
+      });
+
+      if (result.status === "suppression_skipped") {
+        await db
+          .from("email_jobs")
+          .update({ status: "skipped_suppressed" })
+          .eq("id", job.id);
+        await db.rpc("increment_campaign_counter", {
+          p_campaign_id: job.campaign_id,
+          p_field: "suppressed_skipped_count",
+          p_delta: 1,
+        });
+        tally(job.campaign_id).skipped++;
+        totalSkipped++;
+      } else {
+        await db
+          .from("email_jobs")
+          .update({
+            status: "sent",
+            sent_at: new Date().toISOString(),
+            sg_message_id: result.messageId,
+          })
+          .eq("id", job.id);
+        await db.rpc("increment_campaign_counter", {
+          p_campaign_id: job.campaign_id,
+          p_field: "sent_count",
+          p_delta: 1,
+        });
+        tally(job.campaign_id).sent++;
+        totalSent++;
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const newRetry = job.retry_count + 1;
+      const finalFail = newRetry >= MAX_RETRIES;
+      await db
+        .from("email_jobs")
+        .update({
+          status: finalFail ? "failed" : "pending",
+          retry_count: newRetry,
+          last_error: message.slice(0, 1000),
+        })
+        .eq("id", job.id);
+      if (finalFail) {
+        await db.rpc("increment_campaign_counter", {
+          p_campaign_id: job.campaign_id,
+          p_field: "failed_count",
+          p_delta: 1,
+        });
+        tally(job.campaign_id).failed++;
+        totalFailed++;
+      }
+    }
+
+    // Pace ourselves so a 200-job batch doesn't smash the SendGrid API.
+    await sleep(INTER_SEND_DELAY_MS);
+  }
+
+  // After processing, complete any campaigns with no remaining work and
+  // post a notification rail entry for the originating operator.
+  for (const cid of campaignIds) {
+    const completed = await completeCampaignIfDone(cid, db);
+    if (!completed) continue;
+
+    const meta = campaignMap.get(cid);
+    if (!meta?.created_by_user_id) continue;
+
+    const { data: u } = await db
+      .from("users")
+      .select("company_id")
+      .eq("id", meta.created_by_user_id)
+      .maybeSingle();
+
+    const t = tally(cid);
+    const summaryBits: string[] = [];
+    if (t.sent > 0) summaryBits.push(`${t.sent} delivered`);
+    if (t.bounced > 0) summaryBits.push(`${t.bounced} bounced`);
+    if (t.failed > 0) summaryBits.push(`${t.failed} failed`);
+    if (t.skipped > 0) summaryBits.push(`${t.skipped} suppressed`);
+    const body =
+      summaryBits.length > 0
+        ? `${summaryBits.join(", ")}. Open the campaign to see numbers.`
+        : "Campaign finished. Open it to review the run.";
+
+    await db
+      .from("notifications")
+      .insert({
+        user_id: meta.created_by_user_id,
+        company_id: u?.company_id ?? null,
+        type: "campaign_done",
+        title: `Campaign sent: ${meta.name}`,
+        body,
+        is_read: false,
+        persistent: false,
+        action_url: `/admin/email?campaign=${cid}`,
+        action_label: "VIEW CAMPAIGN",
+      })
+      .select()
+      .maybeSingle();
+  }
+
+  return NextResponse.json({
+    ok: true,
+    claimed: jobs.length,
+    sent: totalSent,
+    bounced: totalBounced,
+    failed: totalFailed,
+    skipped: totalSkipped,
+  });
+}

--- a/src/lib/email/audiences.ts
+++ b/src/lib/email/audiences.ts
@@ -1,0 +1,89 @@
+/**
+ * OPS Email — Starter audience resolver.
+ * PR 5 will replace this module with a full predicate engine + saved
+ * audience templates. PR 3 ships three hardcoded segments to validate the
+ * dispatcher → worker pipeline end-to-end.
+ *
+ * Subscription status values are verified against production schema:
+ *   active | cancelled | expired | trial
+ * (NOT 'trialing' — common Stripe convention but OPS persists 'trial').
+ */
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type StarterSegment = "all_users" | "trial_users" | "active_subscribers";
+
+export interface AudienceResult {
+  recipients: Array<{ email: string; userId: string }>;
+}
+
+export async function resolveAudience(
+  filter: Record<string, unknown>,
+  client?: SupabaseClient
+): Promise<AudienceResult> {
+  const db = client ?? getServiceRoleClient();
+  const segment = (filter?.segment as StarterSegment | undefined) ?? "all_users";
+
+  switch (segment) {
+    case "all_users":
+      return resolveAllUsers(db);
+    case "trial_users":
+      return resolveTrialUsers(db);
+    case "active_subscribers":
+      return resolveActiveSubscribers(db);
+    default:
+      throw new Error(`resolveAudience: unknown segment "${segment}"`);
+  }
+}
+
+async function resolveAllUsers(db: SupabaseClient): Promise<AudienceResult> {
+  const { data, error } = await db.from("users")
+    .select("id, email")
+    .eq("is_active", true)
+    .or("removed_from_email_list.is.null,removed_from_email_list.eq.false")
+    .not("email", "is", null);
+  if (error) throw new Error(`resolveAllUsers: ${error.message}`);
+  return {
+    recipients: (data ?? [])
+      .filter((u) => !!u.email)
+      .map((u) => ({ email: u.email as string, userId: u.id as string })),
+  };
+}
+
+async function resolveTrialUsers(db: SupabaseClient): Promise<AudienceResult> {
+  const { data, error } = await db.from("users")
+    .select("id, email, companies!inner(subscription_status, trial_end_date)")
+    .eq("is_active", true)
+    .or("removed_from_email_list.is.null,removed_from_email_list.eq.false")
+    .eq("companies.subscription_status", "trial")
+    .not("email", "is", null);
+  if (error) throw new Error(`resolveTrialUsers: ${error.message}`);
+  return {
+    recipients: (data ?? [])
+      .filter((u) => !!u.email)
+      .map((u) => ({ email: u.email as string, userId: u.id as string })),
+  };
+}
+
+async function resolveActiveSubscribers(db: SupabaseClient): Promise<AudienceResult> {
+  const { data, error } = await db.from("users")
+    .select("id, email, companies!inner(subscription_status)")
+    .eq("is_active", true)
+    .or("removed_from_email_list.is.null,removed_from_email_list.eq.false")
+    .in("companies.subscription_status", ["active", "grace"])
+    .not("email", "is", null);
+  if (error) throw new Error(`resolveActiveSubscribers: ${error.message}`);
+  return {
+    recipients: (data ?? [])
+      .filter((u) => !!u.email)
+      .map((u) => ({ email: u.email as string, userId: u.id as string })),
+  };
+}
+
+export async function estimateAudience(
+  filter: Record<string, unknown>,
+  client?: SupabaseClient
+): Promise<number> {
+  const result = await resolveAudience(filter, client);
+  return result.recipients.length;
+}

--- a/src/lib/email/campaign-templates-bootstrap.ts
+++ b/src/lib/email/campaign-templates-bootstrap.ts
@@ -1,0 +1,145 @@
+/**
+ * Wires the four PR β / PR 3 marketing senders into the campaign template
+ * registry. Bootstrap is idempotent — safe to call from every cron tick
+ * since worker entry points run cold.
+ *
+ * NOTE: senders live in `./sendgrid` (the .tsx chokepoint), not `./senders`
+ * — `./senders.ts` only exposes the four sender-identity buckets (DISPATCH,
+ * GATE, FIELD_NOTES, portalSender).
+ */
+import { registerCampaignTemplate } from "./campaign-templates";
+import {
+  sendProductUpdate,
+  sendTrialExpiryWarning,
+  sendFeatureAnnouncement,
+  sendReengagement,
+} from "./sendgrid";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.opsapp.co";
+
+let booted = false;
+export function bootstrapCampaignTemplates(): void {
+  if (booted) return;
+
+  registerCampaignTemplate({
+    id: "product_update",
+    label: "Product update",
+    description: "Periodic product news to active subscribers and trials.",
+    sender: async (ctx) => {
+      const p = ctx.payload as Record<string, unknown>;
+      const items = Array.isArray(p.items)
+        ? (p.items as Array<{ title: string; body: string }>)
+        : [];
+      return sendProductUpdate({
+        email: ctx.recipientEmail,
+        userId: ctx.recipientUserId,
+        campaignId: ctx.campaignId,
+        firstName: typeof p.firstName === "string" ? p.firstName : null,
+        headline: typeof p.headline === "string" ? p.headline : undefined,
+        eyebrow: typeof p.eyebrow === "string" ? p.eyebrow : undefined,
+        intro:
+          typeof p.intro === "string"
+            ? p.intro
+            : "A few small changes shipped this week.",
+        items: items.length > 0 ? items : [
+          {
+            title: "OPS just got faster",
+            body: "Faster project lookup, faster pipeline triage, faster crew dispatch.",
+          },
+        ],
+        closing: typeof p.closing === "string" ? p.closing : undefined,
+        ctaLabel: typeof p.ctaLabel === "string" ? p.ctaLabel : undefined,
+        ctaUrl: typeof p.ctaUrl === "string" ? p.ctaUrl : APP_URL,
+        subject: typeof p.subject === "string" ? p.subject : undefined,
+      });
+    },
+  });
+
+  registerCampaignTemplate({
+    id: "trial_expiry_campaign",
+    label: "Trial expiry warning",
+    description: "Trial expiry urgency campaign — points users at billing.",
+    sender: async (ctx) => {
+      const p = ctx.payload as Record<string, unknown>;
+      return sendTrialExpiryWarning({
+        email: ctx.recipientEmail,
+        userId: ctx.recipientUserId,
+        campaignId: ctx.campaignId,
+        companyName: typeof p.companyName === "string" ? p.companyName : "your team",
+        daysRemaining: typeof p.daysRemaining === "number" ? p.daysRemaining : 3,
+        trialEndDisplay: typeof p.trialEndDisplay === "string" ? p.trialEndDisplay : "soon",
+        subscribeUrl:
+          typeof p.subscribeUrl === "string"
+            ? p.subscribeUrl
+            : `${APP_URL}/settings/billing`,
+      });
+    },
+  });
+
+  registerCampaignTemplate({
+    id: "feature_announcement",
+    label: "Feature announcement",
+    description: "Major feature ship announcement.",
+    sender: async (ctx) => {
+      const p = ctx.payload as Record<string, unknown>;
+      const featureName =
+        typeof p.featureName === "string" ? p.featureName : "A new feature";
+      return sendFeatureAnnouncement({
+        email: ctx.recipientEmail,
+        userId: ctx.recipientUserId,
+        campaignId: ctx.campaignId,
+        firstName: typeof p.firstName === "string" ? p.firstName : null,
+        featureName,
+        headline:
+          typeof p.headline === "string"
+            ? p.headline
+            : `${featureName} just shipped.`,
+        whatItDoes:
+          typeof p.whatItDoes === "string"
+            ? p.whatItDoes
+            : `${featureName} is live in OPS today.`,
+        whyItMatters:
+          typeof p.whyItMatters === "string"
+            ? p.whyItMatters
+            : "Built to take one more piece of busywork off your plate.",
+        howToFindIt:
+          typeof p.howToFindIt === "string" ? p.howToFindIt : undefined,
+        ctaUrl: typeof p.ctaUrl === "string" ? p.ctaUrl : APP_URL,
+        ctaLabel: typeof p.ctaLabel === "string" ? p.ctaLabel : undefined,
+        subject: typeof p.subject === "string" ? p.subject : undefined,
+      });
+    },
+  });
+
+  registerCampaignTemplate({
+    id: "reengagement",
+    label: "Reengagement",
+    description: "Win-back for dormant users (not trial-specific).",
+    sender: async (ctx) => {
+      const p = ctx.payload as Record<string, unknown>;
+      return sendReengagement({
+        email: ctx.recipientEmail,
+        userId: ctx.recipientUserId,
+        campaignId: ctx.campaignId,
+        firstName: typeof p.firstName === "string" ? p.firstName : null,
+        headline: typeof p.headline === "string" ? p.headline : undefined,
+        eyebrow: typeof p.eyebrow === "string" ? p.eyebrow : undefined,
+        daysSinceActive:
+          typeof p.daysSinceActive === "number" ? p.daysSinceActive : undefined,
+        opener: typeof p.opener === "string" ? p.opener : undefined,
+        body: typeof p.body === "string" ? p.body : undefined,
+        closing: typeof p.closing === "string" ? p.closing : undefined,
+        ctaLabel: typeof p.ctaLabel === "string" ? p.ctaLabel : undefined,
+        ctaUrl: typeof p.ctaUrl === "string" ? p.ctaUrl : APP_URL,
+        subject: typeof p.subject === "string" ? p.subject : undefined,
+      });
+    },
+  });
+
+  booted = true;
+}
+
+/** Test helper. Resets the booted flag so reset+rebootstrap works. */
+export function __resetCampaignTemplatesBootstrap(): void {
+  booted = false;
+}

--- a/src/lib/email/campaign-templates.ts
+++ b/src/lib/email/campaign-templates.ts
@@ -1,0 +1,43 @@
+/**
+ * Campaign template registry. Each entry maps a campaign template_id
+ * to a sender function from the PR β template suite. PR 7 replaces
+ * with a versioned registry pulled from the email_template_versions table.
+ */
+import type { GatedSendResult } from "@/lib/email/sendgrid";
+
+export interface CampaignTemplateContext {
+  recipientEmail: string;
+  recipientUserId: string | null;
+  payload: Record<string, unknown>;
+  campaignId: string;
+}
+
+export type CampaignTemplateSender = (
+  ctx: CampaignTemplateContext
+) => Promise<GatedSendResult>;
+
+export interface CampaignTemplateMeta {
+  id: string;
+  label: string;
+  description: string;
+  sender: CampaignTemplateSender;
+}
+
+const REGISTRY: Record<string, CampaignTemplateMeta> = {};
+
+export function registerCampaignTemplate(meta: CampaignTemplateMeta): void {
+  REGISTRY[meta.id] = meta;
+}
+
+export function getCampaignTemplate(id: string): CampaignTemplateMeta | null {
+  return REGISTRY[id] ?? null;
+}
+
+export function listCampaignTemplates(): CampaignTemplateMeta[] {
+  return Object.values(REGISTRY);
+}
+
+/** Test helper. Resets the registry so tests don't leak state. */
+export function __resetCampaignTemplatesForTests(): void {
+  for (const k of Object.keys(REGISTRY)) delete REGISTRY[k];
+}

--- a/src/lib/email/campaigns.ts
+++ b/src/lib/email/campaigns.ts
@@ -1,0 +1,252 @@
+/**
+ * OPS Email — Campaign service.
+ * Service-role only. Never import from client components.
+ */
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import { filterSuppressed } from "@/lib/email/suppressions";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type CampaignStatus =
+  | "draft" | "scheduled" | "in_flight"
+  | "completed" | "failed" | "cancelled" | "paused";
+
+export interface Campaign {
+  id: string;
+  name: string;
+  slug: string;
+  templateId: string;
+  audienceFilter: Record<string, unknown>;
+  audienceTemplateId: string | null;
+  scheduledFor: string | null;
+  sendStatus: CampaignStatus;
+  recipientCountEstimate: number;
+  recipientCountActual: number | null;
+  sentCount: number;
+  deliveredCount: number;
+  bouncedCount: number;
+  openedCount: number;
+  clickedCount: number;
+  suppressedSkippedCount: number;
+  failedCount: number;
+  pausedAt: string | null;
+  pauseReason: string | null;
+  createdByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+interface Row {
+  id: string; name: string; slug: string; template_id: string;
+  audience_filter: Record<string, unknown> | null;
+  audience_template_id: string | null;
+  scheduled_for: string | null;
+  send_status: CampaignStatus;
+  recipient_count_estimate: number;
+  recipient_count_actual: number | null;
+  sent_count: number; delivered_count: number; bounced_count: number;
+  opened_count: number; clicked_count: number;
+  suppressed_skipped_count: number; failed_count: number;
+  paused_at: string | null; pause_reason: string | null;
+  created_by_user_id: string | null;
+  created_at: string; updated_at: string; completed_at: string | null;
+}
+
+function rowToCampaign(r: Row): Campaign {
+  return {
+    id: r.id, name: r.name, slug: r.slug, templateId: r.template_id,
+    audienceFilter: r.audience_filter ?? {},
+    audienceTemplateId: r.audience_template_id,
+    scheduledFor: r.scheduled_for, sendStatus: r.send_status,
+    recipientCountEstimate: r.recipient_count_estimate,
+    recipientCountActual: r.recipient_count_actual,
+    sentCount: r.sent_count, deliveredCount: r.delivered_count,
+    bouncedCount: r.bounced_count, openedCount: r.opened_count,
+    clickedCount: r.clicked_count,
+    suppressedSkippedCount: r.suppressed_skipped_count,
+    failedCount: r.failed_count, pausedAt: r.paused_at,
+    pauseReason: r.pause_reason, createdByUserId: r.created_by_user_id,
+    createdAt: r.created_at, updatedAt: r.updated_at, completedAt: r.completed_at,
+  };
+}
+
+export async function createCampaign(input: {
+  name: string; slug: string; templateId: string;
+  audienceFilter?: Record<string, unknown>;
+  audienceTemplateId?: string | null;
+  createdByUserId?: string | null;
+  recipientCountEstimate?: number;
+  client?: SupabaseClient;
+}): Promise<Campaign> {
+  const db = input.client ?? getServiceRoleClient();
+  const { data, error } = await db
+    .from("email_campaigns")
+    .insert({
+      name: input.name, slug: input.slug, template_id: input.templateId,
+      audience_filter: input.audienceFilter ?? {},
+      audience_template_id: input.audienceTemplateId ?? null,
+      created_by_user_id: input.createdByUserId ?? null,
+      recipient_count_estimate: input.recipientCountEstimate ?? 0,
+      send_status: "draft",
+    })
+    .select("*").single();
+  if (error) throw new Error(`createCampaign: ${error.message}`);
+  return rowToCampaign(data as Row);
+}
+
+export async function scheduleCampaign(
+  campaignId: string, scheduledFor: Date, client?: SupabaseClient
+): Promise<Campaign> {
+  const db = client ?? getServiceRoleClient();
+  const { data, error } = await db
+    .from("email_campaigns")
+    .update({ scheduled_for: scheduledFor.toISOString(), send_status: "scheduled" })
+    .eq("id", campaignId).select("*").single();
+  if (error) throw new Error(`scheduleCampaign: ${error.message}`);
+  return rowToCampaign(data as Row);
+}
+
+export async function cancelCampaign(
+  campaignId: string, client?: SupabaseClient
+): Promise<Campaign> {
+  const db = client ?? getServiceRoleClient();
+  const { data, error } = await db
+    .from("email_campaigns")
+    .update({ send_status: "cancelled" })
+    .in("send_status", ["draft","scheduled","in_flight","paused"])
+    .eq("id", campaignId).select("*").single();
+  if (error) throw new Error(`cancelCampaign: ${error.message}`);
+  await db.from("email_jobs").update({ status: "cancelled" })
+    .eq("campaign_id", campaignId).eq("status", "pending");
+  return rowToCampaign(data as Row);
+}
+
+export async function pauseCampaign(
+  campaignId: string, reason: string, client?: SupabaseClient
+): Promise<Campaign> {
+  const db = client ?? getServiceRoleClient();
+  const { data, error } = await db
+    .from("email_campaigns")
+    .update({
+      send_status: "paused",
+      paused_at: new Date().toISOString(),
+      pause_reason: reason,
+    })
+    .eq("id", campaignId).eq("send_status", "in_flight")
+    .select("*").single();
+  if (error) throw new Error(`pauseCampaign: ${error.message}`);
+  return rowToCampaign(data as Row);
+}
+
+export async function resumeCampaign(
+  campaignId: string, client?: SupabaseClient
+): Promise<Campaign> {
+  const db = client ?? getServiceRoleClient();
+  const { data, error } = await db
+    .from("email_campaigns")
+    .update({ send_status: "in_flight", paused_at: null, pause_reason: null })
+    .eq("id", campaignId).eq("send_status", "paused")
+    .select("*").single();
+  if (error) throw new Error(`resumeCampaign: ${error.message}`);
+  return rowToCampaign(data as Row);
+}
+
+export async function enqueueCampaignJobs(input: {
+  campaignId: string;
+  recipients: Array<{ email: string; userId?: string | null; payload?: Record<string, unknown> }>;
+  client?: SupabaseClient;
+}): Promise<{ enqueued: number; suppressedSkipped: number }> {
+  const db = input.client ?? getServiceRoleClient();
+  const emails = input.recipients.map((r) => r.email.toLowerCase());
+  const suppressedSet = await filterSuppressed(emails, "global", db);
+
+  const rows = input.recipients
+    .filter((r) => !suppressedSet.has(r.email.toLowerCase()))
+    .map((r) => ({
+      campaign_id: input.campaignId,
+      recipient_email: r.email.toLowerCase(),
+      recipient_user_id: r.userId ?? null,
+      template_payload: r.payload ?? {},
+      status: "pending" as const,
+    }));
+
+  const skippedCount = input.recipients.length - rows.length;
+
+  if (rows.length > 0) {
+    const { error } = await db.from("email_jobs").upsert(rows, {
+      onConflict: "campaign_id,recipient_email",
+      ignoreDuplicates: true,
+    });
+    if (error) throw new Error(`enqueueCampaignJobs: ${error.message}`);
+  }
+
+  // If audience yielded zero rows, jump straight to completed so the
+  // campaign doesn't sit indefinitely in in_flight waiting for jobs that
+  // never get enqueued.
+  if (rows.length === 0) {
+    await db.from("email_campaigns").update({
+      recipient_count_actual: 0,
+      suppressed_skipped_count: skippedCount,
+      send_status: "completed",
+      completed_at: new Date().toISOString(),
+    }).eq("id", input.campaignId);
+  } else {
+    await db.from("email_campaigns").update({
+      recipient_count_actual: rows.length,
+      suppressed_skipped_count: skippedCount,
+      send_status: "in_flight",
+    }).eq("id", input.campaignId);
+  }
+
+  return { enqueued: rows.length, suppressedSkipped: skippedCount };
+}
+
+export async function completeCampaignIfDone(
+  campaignId: string, client?: SupabaseClient
+): Promise<boolean> {
+  const db = client ?? getServiceRoleClient();
+  const { count: pendingCount, error: cErr } = await db
+    .from("email_jobs")
+    .select("id", { count: "exact", head: true })
+    .eq("campaign_id", campaignId)
+    .in("status", ["pending","dispatching"]);
+  if (cErr) throw new Error(`completeCampaignIfDone: ${cErr.message}`);
+  if ((pendingCount ?? 0) > 0) return false;
+
+  const { data: c } = await db.from("email_campaigns")
+    .select("send_status").eq("id", campaignId).single();
+  if (c?.send_status === "completed" || c?.send_status === "cancelled") return false;
+
+  const { error: uErr } = await db.from("email_campaigns")
+    .update({ send_status: "completed", completed_at: new Date().toISOString() })
+    .eq("id", campaignId);
+  if (uErr) throw new Error(`completeCampaignIfDone update: ${uErr.message}`);
+  return true;
+}
+
+export async function getCampaignStats(
+  campaignId: string, client?: SupabaseClient
+): Promise<Campaign | null> {
+  const db = client ?? getServiceRoleClient();
+  const { data, error } = await db.from("email_campaigns")
+    .select("*").eq("id", campaignId).maybeSingle();
+  if (error) throw new Error(`getCampaignStats: ${error.message}`);
+  return data ? rowToCampaign(data as Row) : null;
+}
+
+export async function listCampaigns(input: {
+  status?: CampaignStatus | CampaignStatus[];
+  limit?: number; offset?: number;
+  client?: SupabaseClient;
+} = {}): Promise<{ rows: Campaign[]; total: number }> {
+  const db = input.client ?? getServiceRoleClient();
+  let q = db.from("email_campaigns").select("*", { count: "exact" })
+    .order("created_at", { ascending: false })
+    .range(input.offset ?? 0, (input.offset ?? 0) + (input.limit ?? 50) - 1);
+  if (input.status) {
+    q = Array.isArray(input.status) ? q.in("send_status", input.status) : q.eq("send_status", input.status);
+  }
+  const { data, count, error } = await q;
+  if (error) throw new Error(`listCampaigns: ${error.message}`);
+  return { rows: (data ?? []).map((r) => rowToCampaign(r as Row)), total: count ?? 0 };
+}

--- a/src/lib/email/constants.ts
+++ b/src/lib/email/constants.ts
@@ -20,6 +20,7 @@ export const LIST_DISPLAY_NAMES: Record<string, string> = {
   global: "OPS account notifications",
   field_notes: "Field Notes (newsletter)",
   product_updates: "OPS product updates",
+  reengagement: "OPS reengagement campaigns",
   blog: "OPS blog",
   beta: "OPS beta program",
 };
@@ -49,6 +50,9 @@ export const KIND_TO_LIST: Record<string, string> = {
   portal_questions_reminder: "global",
   blog_newsletter: "blog",
   field_notes_newsletter: "field_notes",
+  product_update: "product_updates",
+  feature_announcement: "product_updates",
+  reengagement: "reengagement",
   pmf_threshold_alert: "global",
   pmf_daily_digest: "global",
   pmf_weekly_digest: "global",

--- a/src/lib/email/pmf-bridge.tsx
+++ b/src/lib/email/pmf-bridge.tsx
@@ -25,7 +25,7 @@ import { PmfThresholdAlert } from "./react/templates/PmfThresholdAlert";
 import { PmfDailyDigest } from "./react/templates/PmfDailyDigest";
 import { PmfWeeklyDigest } from "./react/templates/PmfWeeklyDigest";
 
-function useNew(): boolean {
+function shouldUseNewTemplate(): boolean {
   return process.env.EMAIL_PMF_NEW_TEMPLATES === "true";
 }
 
@@ -35,15 +35,19 @@ function useNew(): boolean {
 // that mock the legacy template module to capture props at construction time.
 
 export function thresholdAlertEmail(props: ThresholdAlertProps) {
-  return useNew()
+  return shouldUseNewTemplate()
     ? PmfThresholdAlert(props)
     : LegacyThresholdAlertEmail(props);
 }
 
 export function dailyDigestEmail(props: DailyDigestProps) {
-  return useNew() ? PmfDailyDigest(props) : LegacyDailyDigestEmail(props);
+  return shouldUseNewTemplate()
+    ? PmfDailyDigest(props)
+    : LegacyDailyDigestEmail(props);
 }
 
 export function weeklyDigestEmail(props: WeeklyDigestProps) {
-  return useNew() ? PmfWeeklyDigest(props) : LegacyWeeklyDigestEmail(props);
+  return shouldUseNewTemplate()
+    ? PmfWeeklyDigest(props)
+    : LegacyWeeklyDigestEmail(props);
 }

--- a/src/lib/email/react/templates/FeatureAnnouncement.tsx
+++ b/src/lib/email/react/templates/FeatureAnnouncement.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import { OpsEmailLayout } from "../layouts/OpsEmailLayout";
+import { Headline, Paragraph, Button, Spacer, Divider } from "../primitives";
+import { DISPATCH } from "../../senders";
+
+interface FeatureAnnouncementProps {
+  /** First name or "Operator" fallback. */
+  firstName?: string | null;
+  /** Short, punchy feature name. Renders inside the eyebrow + opening line. */
+  featureName: string;
+  /** Headline. Tactical, declarative — "We just shipped X." style. */
+  headline: string;
+  /** Lead paragraph: what it does. */
+  whatItDoes: string;
+  /** Body paragraph: why it matters / which problem it kills. */
+  whyItMatters: string;
+  /** Optional how-to-find-it micro paragraph. */
+  howToFindIt?: string;
+  /** Primary CTA — usually links straight into the feature in-app. */
+  ctaUrl: string;
+  ctaLabel?: string;
+  unsubscribeUrl: string;
+  list?: string;
+}
+
+export function FeatureAnnouncement({
+  firstName,
+  featureName,
+  headline,
+  whatItDoes,
+  whyItMatters,
+  howToFindIt,
+  ctaUrl,
+  ctaLabel,
+  unsubscribeUrl,
+  list,
+}: FeatureAnnouncementProps) {
+  const greeting = firstName ? `${firstName},` : "Operator,";
+  return (
+    <OpsEmailLayout
+      preview={`${featureName} just shipped.`}
+      eyebrow={`Feature ship — ${featureName}`}
+      senderAddress={DISPATCH.email}
+      unsubscribeUrl={unsubscribeUrl}
+      list={list ?? "product_updates"}
+    >
+      <Headline>{headline}</Headline>
+      <Paragraph>{greeting}</Paragraph>
+      <Paragraph>{whatItDoes}</Paragraph>
+      <Paragraph>{whyItMatters}</Paragraph>
+      {howToFindIt ? (
+        <>
+          <Spacer size="sm" />
+          <Paragraph>
+            <strong>Where to find it.</strong> {howToFindIt}
+          </Paragraph>
+        </>
+      ) : null}
+      <Spacer size="md" />
+      <Button href={ctaUrl}>{ctaLabel ?? `Try ${featureName}`} &rarr;</Button>
+      <Spacer size="lg" />
+      <Divider spacing="sm" />
+      <Paragraph small>
+        &mdash; Jack
+        <br />
+        Founder, OPS
+      </Paragraph>
+    </OpsEmailLayout>
+  );
+}
+
+FeatureAnnouncement.PreviewProps = {
+  firstName: "Mike",
+  featureName: "Inbox calibration",
+  headline: "Inbox calibration just shipped.",
+  whatItDoes:
+    "Inbox now learns which threads matter to you and which don't. Lead, customer, supplier, noise — every email gets a tag in under a second.",
+  whyItMatters:
+    "Before this, leads slipped past you when you were on the wall. Now the inbox sorts itself while you're working, and the leads land in the pipeline without you lifting a finger.",
+  howToFindIt:
+    "Open the inbox tab. The triage panel appears the first time you scroll an unsorted thread.",
+  ctaUrl: "https://app.opsapp.co/inbox",
+  ctaLabel: "Open the inbox",
+  unsubscribeUrl: "https://app.opsapp.co/unsubscribe?list=product_updates",
+} satisfies FeatureAnnouncementProps;
+
+export default FeatureAnnouncement;

--- a/src/lib/email/react/templates/ProductUpdate.tsx
+++ b/src/lib/email/react/templates/ProductUpdate.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import { OpsEmailLayout } from "../layouts/OpsEmailLayout";
+import { Headline, Paragraph, Button, Spacer, Divider } from "../primitives";
+import { DISPATCH } from "../../senders";
+
+interface ProductUpdateItem {
+  title: string;
+  body: string;
+}
+
+interface ProductUpdateProps {
+  /** First name or "Operator" fallback. Used in the opener. */
+  firstName?: string | null;
+  /** Headline copy. Defaults to "What shipped this week." */
+  headline?: string;
+  /** Eyebrow above the headline. */
+  eyebrow?: string;
+  /** Sentence that introduces the list. */
+  intro: string;
+  /** Up to ~5 short items. The list is rendered as a tactical bullet block. */
+  items: ProductUpdateItem[];
+  /** Optional closing paragraph rendered before the CTA. */
+  closing?: string;
+  /** CTA button label. Defaults to "Open OPS". */
+  ctaLabel?: string;
+  /** CTA destination — usually an in-app page that highlights the change. */
+  ctaUrl: string;
+  unsubscribeUrl: string;
+  list?: string;
+}
+
+export function ProductUpdate({
+  firstName,
+  headline,
+  eyebrow,
+  intro,
+  items,
+  closing,
+  ctaLabel,
+  ctaUrl,
+  unsubscribeUrl,
+  list,
+}: ProductUpdateProps) {
+  const greeting = firstName ? `${firstName},` : "Operator,";
+  return (
+    <OpsEmailLayout
+      preview={headline ?? "What shipped this week."}
+      eyebrow={eyebrow ?? "Product update"}
+      senderAddress={DISPATCH.email}
+      unsubscribeUrl={unsubscribeUrl}
+      list={list ?? "product_updates"}
+    >
+      <Headline>{headline ?? "What shipped this week."}</Headline>
+      <Paragraph>{greeting}</Paragraph>
+      <Paragraph>{intro}</Paragraph>
+      <Spacer size="sm" />
+      {items.map((item, idx) => (
+        <Paragraph key={idx}>
+          <strong>{item.title}.</strong> {item.body}
+        </Paragraph>
+      ))}
+      {closing ? (
+        <>
+          <Spacer size="sm" />
+          <Paragraph>{closing}</Paragraph>
+        </>
+      ) : null}
+      <Spacer size="md" />
+      <Button href={ctaUrl}>{ctaLabel ?? "Open OPS"} &rarr;</Button>
+      <Spacer size="lg" />
+      <Divider spacing="sm" />
+      <Paragraph small>
+        &mdash; Jack
+        <br />
+        Founder, OPS
+      </Paragraph>
+    </OpsEmailLayout>
+  );
+}
+
+ProductUpdate.PreviewProps = {
+  firstName: "Mike",
+  headline: "What shipped this week.",
+  eyebrow: "Product update",
+  intro:
+    "Quick rundown of the changes that landed this week — every one came out of a job-site moment.",
+  items: [
+    {
+      title: "Faster project search",
+      body: "Open the project picker, start typing — results show up in two keystrokes flat.",
+    },
+    {
+      title: "Sharper push notifications",
+      body: "Crew-level pushes now route by trade so the framers don't get pinged for plumbing.",
+    },
+    {
+      title: "Inbox calibration",
+      body: "Rebuilt the inbox triage flow so leads stop slipping past your screen.",
+    },
+  ],
+  closing:
+    "If something's broken or missing, hit reply. Every email lands in my inbox.",
+  ctaLabel: "See it in OPS",
+  ctaUrl: "https://app.opsapp.co",
+  unsubscribeUrl: "https://app.opsapp.co/unsubscribe?list=product_updates",
+} satisfies ProductUpdateProps;
+
+export default ProductUpdate;

--- a/src/lib/email/react/templates/Reengagement.tsx
+++ b/src/lib/email/react/templates/Reengagement.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import { OpsEmailLayout } from "../layouts/OpsEmailLayout";
+import { Headline, Paragraph, Button, Spacer, Divider } from "../primitives";
+import { DISPATCH } from "../../senders";
+
+interface ReengagementProps {
+  /** First name or "Operator" fallback. */
+  firstName?: string | null;
+  /** Headline copy. Defaults to "Still running things from texts and Post-its?". */
+  headline?: string;
+  /** Eyebrow. Defaults to "Come back". */
+  eyebrow?: string;
+  /** Days since last active — used to pick a tone. Optional. */
+  daysSinceActive?: number;
+  /** Lead paragraph (the "I noticed" sentence). */
+  opener?: string;
+  /** Body — the why-we-built-it paragraph. */
+  body?: string;
+  /** Closing — the come-back-it's-still-here line. */
+  closing?: string;
+  /** Primary CTA. Defaults to "Pick up where you left off". */
+  ctaLabel?: string;
+  /** CTA URL — usually the dashboard. */
+  ctaUrl: string;
+  unsubscribeUrl: string;
+  list?: string;
+}
+
+export function Reengagement({
+  firstName,
+  headline,
+  eyebrow,
+  daysSinceActive,
+  opener,
+  body,
+  closing,
+  ctaLabel,
+  ctaUrl,
+  unsubscribeUrl,
+  list,
+}: ReengagementProps) {
+  const greeting = firstName ? `${firstName},` : "Operator,";
+
+  const defaultOpener = daysSinceActive
+    ? `Noticed it's been ${daysSinceActive} days since you last opened OPS. No problem. The app, your data, your crews — all still sitting there.`
+    : "Noticed you haven't opened OPS in a while. No problem. The app, your data, your crews — all still sitting there.";
+
+  const defaultBody =
+    "I built OPS because every other app on the market was built by people who never swung a hammer. If something pulled you off the platform — bad timing, a crew that pushed back, a job that ate your week — that tracks. Running a trades business means the thing on fire today is the only thing that matters.";
+
+  const defaultClosing =
+    "If you've got a minute, log back in. The dashboard remembers what you were doing.";
+
+  return (
+    <OpsEmailLayout
+      preview={headline ?? "Still running things from texts and Post-its?"}
+      eyebrow={eyebrow ?? "Come back"}
+      senderAddress={DISPATCH.email}
+      unsubscribeUrl={unsubscribeUrl}
+      list={list ?? "reengagement"}
+    >
+      <Headline>{headline ?? "Still running things from texts and Post-its?"}</Headline>
+      <Paragraph>{greeting}</Paragraph>
+      <Paragraph>{opener ?? defaultOpener}</Paragraph>
+      <Paragraph>{body ?? defaultBody}</Paragraph>
+      <Paragraph>{closing ?? defaultClosing}</Paragraph>
+      <Spacer size="md" />
+      <Button href={ctaUrl}>{ctaLabel ?? "Pick up where you left off"} &rarr;</Button>
+      <Spacer size="lg" />
+      <Divider spacing="sm" />
+      <Paragraph small>
+        &mdash; Jack
+        <br />
+        Founder, OPS
+      </Paragraph>
+    </OpsEmailLayout>
+  );
+}
+
+Reengagement.PreviewProps = {
+  firstName: "Mike",
+  daysSinceActive: 21,
+  ctaUrl: "https://app.opsapp.co",
+  unsubscribeUrl: "https://app.opsapp.co/unsubscribe?list=reengagement",
+} satisfies ReengagementProps;
+
+export default Reengagement;

--- a/src/lib/email/sendgrid.tsx
+++ b/src/lib/email/sendgrid.tsx
@@ -33,6 +33,9 @@ import { BetaAccessDecision } from "./react/templates/BetaAccessDecision";
 import { TrialExpiryWarning } from "./react/templates/TrialExpiryWarning";
 import { TrialExpiryDiscount } from "./react/templates/TrialExpiryDiscount";
 import { TrialExpiryReengagement } from "./react/templates/TrialExpiryReengagement";
+import { ProductUpdate } from "./react/templates/ProductUpdate";
+import { FeatureAnnouncement } from "./react/templates/FeatureAnnouncement";
+import { Reengagement } from "./react/templates/Reengagement";
 import { AdsBriefing } from "./react/templates/AdsBriefing";
 import { BlogNewsletter } from "./react/templates/BlogNewsletter";
 import {
@@ -92,6 +95,15 @@ function buildComplianceHeaders(opts: { email: string; kind: string }): {
 }
 
 /**
+ * Outcome of a `gatedSend` call. Exposed so the campaign worker can branch
+ * on suppression vs. delivery and can persist the SendGrid `messageId` for
+ * webhook attribution.
+ */
+export type GatedSendResult =
+  | { status: "sent"; messageId: string | null }
+  | { status: "suppression_skipped"; reason: "suppressed" };
+
+/**
  * Single-recipient send chokepoint. Every typed sendXxx function below
  * routes through this. Performs the suppression check, dispatches via
  * SendGrid (with compliance headers injected), and writes to email_log.
@@ -116,7 +128,14 @@ async function gatedSend(params: {
   headers?: Record<string, string>;
   userId?: string;
   metadata?: Record<string, unknown>;
-}): Promise<{ status: "sent" | "suppression_skipped"; reason?: string }> {
+  /**
+   * Campaign UUID, when this send is part of a marketing/lifecycle campaign.
+   * Stored on `email_log.campaign_id` and forwarded to SendGrid as a
+   * `customArgs.campaign_id` so inbound webhooks (PR 6) can attribute
+   * opens / clicks / bounces back to the originating campaign.
+   */
+  campaignId?: string | null;
+}): Promise<GatedSendResult> {
   ensureInitialized();
   const lower = params.to.trim().toLowerCase();
   if (!lower) throw new Error("gatedSend: empty `to` address");
@@ -132,6 +151,7 @@ async function gatedSend(params: {
       status: "suppression_skipped",
       metadata: { ...(params.metadata ?? {}), list },
       userId: params.userId,
+      campaignId: params.campaignId ?? null,
     });
     return { status: "suppression_skipped", reason: "suppressed" };
   }
@@ -139,7 +159,12 @@ async function gatedSend(params: {
   const headers =
     params.headers ?? buildComplianceHeaders({ email: lower, kind: params.emailType }).headers;
 
-  await sgMail.send({
+  const customArgs: Record<string, string> = {};
+  if (params.campaignId) customArgs.campaign_id = params.campaignId;
+  if (params.userId) customArgs.user_id = params.userId;
+  customArgs.email_type = params.emailType;
+
+  const [response] = await sgMail.send({
     to: params.to,
     from: params.from,
     replyTo: params.replyTo,
@@ -147,7 +172,17 @@ async function gatedSend(params: {
     html: params.html,
     text: params.text,
     headers,
+    customArgs: Object.keys(customArgs).length > 0 ? customArgs : undefined,
   });
+
+  // SendGrid returns the message id in the `x-message-id` response header.
+  // Capture it so the campaign worker can write it onto email_jobs.sg_message_id.
+  const responseHeaders = (response as { headers?: Record<string, string> })
+    .headers;
+  const messageId =
+    typeof responseHeaders?.["x-message-id"] === "string"
+      ? responseHeaders["x-message-id"]
+      : null;
 
   await logEmail({
     emailType: params.emailType,
@@ -156,9 +191,11 @@ async function gatedSend(params: {
     status: "sent",
     metadata: { ...(params.metadata ?? {}), list, from: params.from.email },
     userId: params.userId,
+    campaignId: params.campaignId ?? null,
+    sgMessageId: messageId,
   });
 
-  return { status: "sent" };
+  return { status: "sent", messageId };
 }
 
 /**
@@ -173,17 +210,22 @@ async function logEmail(params: {
   metadata?: Record<string, unknown>;
   userId?: string;
   errorMessage?: string;
+  campaignId?: string | null;
+  sgMessageId?: string | null;
 }): Promise<void> {
   try {
     const db = getServiceRoleClient();
+    const metadata: Record<string, unknown> = { ...(params.metadata ?? {}) };
+    if (params.sgMessageId) metadata.sg_message_id = params.sgMessageId;
     const { error } = await db.from("email_log").insert({
       email_type: params.emailType,
       recipient_email: params.recipient,
       subject: params.subject,
       status: params.status,
       error_message: params.errorMessage ?? null,
-      metadata: params.metadata ?? {},
+      metadata,
       user_id: params.userId ?? null,
+      campaign_id: params.campaignId ?? null,
     });
     if (error) console.error("[email_log] insert failed:", error.message);
   } catch (e) {
@@ -851,11 +893,13 @@ export async function sendTrialExpiryWarning(params: {
   daysRemaining: number;
   trialEndDisplay: string;
   subscribeUrl: string;
+  campaignId?: string | null;
+  userId?: string | null;
   /** @deprecated retained for backward compat; no longer used */
   accentColor?: string;
   /** @deprecated retained for backward compat; no longer used */
   logoUrl?: string | null;
-}): Promise<void> {
+}): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
     kind: "trial_expiry_warning",
@@ -876,7 +920,7 @@ export async function sendTrialExpiryWarning(params: {
       ? "Tomorrow — your OPS trial ends"
       : `${params.daysRemaining} days left on your OPS trial`;
 
-  await gatedSend({
+  return gatedSend({
     to: params.email,
     from: DISPATCH,
     replyTo: DISPATCH.email,
@@ -886,6 +930,8 @@ export async function sendTrialExpiryWarning(params: {
     list: compliance.list,
     headers: compliance.headers,
     metadata: { companyName: params.companyName, daysRemaining: params.daysRemaining },
+    campaignId: params.campaignId ?? null,
+    userId: params.userId ?? undefined,
   });
 }
 
@@ -975,6 +1021,160 @@ export async function sendTrialExpiryReengagement(params: {
     list: compliance.list,
     headers: compliance.headers,
     metadata: { companyName: params.companyName, daysSinceExpiry: params.daysSinceExpiry },
+  });
+}
+
+// ─── Campaign senders (PR 3 — Marketing/lifecycle, OPS Dispatch) ──────────
+//
+// These four senders feed the campaign-template registry. Each accepts an
+// optional `campaignId` so the dispatcher/worker can attribute opens,
+// clicks, bounces back to the originating campaign via SendGrid customArgs
+// and email_log.campaign_id.
+
+export async function sendProductUpdate(params: {
+  email: string;
+  firstName?: string | null;
+  headline?: string;
+  eyebrow?: string;
+  intro: string;
+  items: Array<{ title: string; body: string }>;
+  closing?: string;
+  ctaLabel?: string;
+  ctaUrl: string;
+  campaignId?: string | null;
+  userId?: string | null;
+  subject?: string;
+}): Promise<GatedSendResult> {
+  const compliance = buildComplianceHeaders({
+    email: params.email,
+    kind: "product_update",
+  });
+  const html = await render(
+    <ProductUpdate
+      firstName={params.firstName ?? null}
+      headline={params.headline}
+      eyebrow={params.eyebrow}
+      intro={params.intro}
+      items={params.items}
+      closing={params.closing}
+      ctaLabel={params.ctaLabel}
+      ctaUrl={params.ctaUrl}
+      unsubscribeUrl={compliance.unsubscribeUrl}
+      list={compliance.list}
+    />,
+  );
+
+  return gatedSend({
+    to: params.email,
+    from: DISPATCH,
+    replyTo: DISPATCH.email,
+    subject: params.subject ?? params.headline ?? "What shipped this week.",
+    html,
+    emailType: "product_update",
+    list: compliance.list,
+    headers: compliance.headers,
+    metadata: { itemCount: params.items.length },
+    campaignId: params.campaignId ?? null,
+    userId: params.userId ?? undefined,
+  });
+}
+
+export async function sendFeatureAnnouncement(params: {
+  email: string;
+  firstName?: string | null;
+  featureName: string;
+  headline: string;
+  whatItDoes: string;
+  whyItMatters: string;
+  howToFindIt?: string;
+  ctaUrl: string;
+  ctaLabel?: string;
+  campaignId?: string | null;
+  userId?: string | null;
+  subject?: string;
+}): Promise<GatedSendResult> {
+  const compliance = buildComplianceHeaders({
+    email: params.email,
+    kind: "feature_announcement",
+  });
+  const html = await render(
+    <FeatureAnnouncement
+      firstName={params.firstName ?? null}
+      featureName={params.featureName}
+      headline={params.headline}
+      whatItDoes={params.whatItDoes}
+      whyItMatters={params.whyItMatters}
+      howToFindIt={params.howToFindIt}
+      ctaUrl={params.ctaUrl}
+      ctaLabel={params.ctaLabel}
+      unsubscribeUrl={compliance.unsubscribeUrl}
+      list={compliance.list}
+    />,
+  );
+
+  return gatedSend({
+    to: params.email,
+    from: DISPATCH,
+    replyTo: DISPATCH.email,
+    subject: params.subject ?? params.headline,
+    html,
+    emailType: "feature_announcement",
+    list: compliance.list,
+    headers: compliance.headers,
+    metadata: { featureName: params.featureName },
+    campaignId: params.campaignId ?? null,
+    userId: params.userId ?? undefined,
+  });
+}
+
+export async function sendReengagement(params: {
+  email: string;
+  firstName?: string | null;
+  headline?: string;
+  eyebrow?: string;
+  daysSinceActive?: number;
+  opener?: string;
+  body?: string;
+  closing?: string;
+  ctaLabel?: string;
+  ctaUrl: string;
+  campaignId?: string | null;
+  userId?: string | null;
+  subject?: string;
+}): Promise<GatedSendResult> {
+  const compliance = buildComplianceHeaders({
+    email: params.email,
+    kind: "reengagement",
+  });
+  const html = await render(
+    <Reengagement
+      firstName={params.firstName ?? null}
+      headline={params.headline}
+      eyebrow={params.eyebrow}
+      daysSinceActive={params.daysSinceActive}
+      opener={params.opener}
+      body={params.body}
+      closing={params.closing}
+      ctaLabel={params.ctaLabel}
+      ctaUrl={params.ctaUrl}
+      unsubscribeUrl={compliance.unsubscribeUrl}
+      list={compliance.list}
+    />,
+  );
+
+  return gatedSend({
+    to: params.email,
+    from: DISPATCH,
+    replyTo: DISPATCH.email,
+    subject:
+      params.subject ?? params.headline ?? "Still running things from texts and Post-its?",
+    html,
+    emailType: "reengagement",
+    list: compliance.list,
+    headers: compliance.headers,
+    metadata: { daysSinceActive: params.daysSinceActive ?? null },
+    campaignId: params.campaignId ?? null,
+    userId: params.userId ?? undefined,
   });
 }
 

--- a/src/lib/utils/motion.ts
+++ b/src/lib/utils/motion.ts
@@ -442,3 +442,66 @@ export const quickActionsRowVariantsReduced: Variants = {
     transition: { delay: i * 0.015, duration: 0.15 },
   }),
 };
+
+// ── Email Campaigns admin (PR 3 — 2026-04-27) ──
+
+/** Campaign list row stagger — 60ms cascade, 320ms duration */
+export const campaignRowVariants: Variants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: { delay: i * 0.06, duration: 0.32, ease: EASE_SMOOTH },
+  }),
+  exit: { opacity: 0, y: -6, transition: { duration: 0.2, ease: EASE_SMOOTH } },
+};
+
+export const campaignRowVariantsReduced: Variants = {
+  hidden: { opacity: 0 },
+  visible: (i: number) => ({
+    opacity: 1,
+    transition: { delay: i * 0.02, duration: 0.15 },
+  }),
+  exit: { opacity: 0, transition: { duration: 0.1 } },
+};
+
+/** Status pill scale-in on mount or status flip */
+export const statusPillVariants: Variants = {
+  hidden: { opacity: 0, scale: 0.9 },
+  visible: { opacity: 1, scale: 1, transition: { duration: 0.25, ease: EASE_SMOOTH } },
+};
+
+export const statusPillVariantsReduced: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.15 } },
+};
+
+/**
+ * Campaign progress bar segment fill. Consumers pass `progress` (0-1) via
+ * the `custom` prop and animate `width` directly — pathLength was the
+ * original spec but progress bars on `<motion.div>` use width % so a 2px
+ * tall rule still feels material.
+ */
+export const progressBarVariants: Variants = {
+  hidden: { width: 0 },
+  visible: (progress: number) => ({
+    width: `${Math.max(0, Math.min(progress, 1)) * 100}%`,
+    transition: { duration: 0.6, ease: EASE_SMOOTH },
+  }),
+};
+
+export const progressBarVariantsReduced: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.15 } },
+};
+
+/** Counter cell entrance — small lift on every value change so the eye trusts the number */
+export const counterVariants: Variants = {
+  hidden: { opacity: 0, y: 4 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.3, ease: EASE_SMOOTH } },
+};
+
+export const counterVariantsReduced: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.15 } },
+};

--- a/supabase/migrations/086_email_campaigns.sql
+++ b/supabase/migrations/086_email_campaigns.sql
@@ -1,0 +1,56 @@
+-- 086_email_campaigns.sql
+-- Marketing and lifecycle email campaigns. One row per send (or scheduled send).
+
+DO $$ BEGIN
+  CREATE TYPE email_campaign_status AS ENUM (
+    'draft', 'scheduled', 'in_flight',
+    'completed', 'failed', 'cancelled', 'paused'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS public.email_campaigns (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  slug text NOT NULL UNIQUE,
+  template_id text NOT NULL,
+  audience_filter jsonb NOT NULL DEFAULT '{}'::jsonb,
+  audience_template_id uuid NULL,  -- FK added by PR 5 once email_audience_templates exists
+  scheduled_for timestamptz NULL,
+  send_status email_campaign_status NOT NULL DEFAULT 'draft',
+  recipient_count_estimate int NOT NULL DEFAULT 0,
+  recipient_count_actual int NULL,
+  sent_count int NOT NULL DEFAULT 0,
+  delivered_count int NOT NULL DEFAULT 0,
+  bounced_count int NOT NULL DEFAULT 0,
+  opened_count int NOT NULL DEFAULT 0,
+  clicked_count int NOT NULL DEFAULT 0,
+  suppressed_skipped_count int NOT NULL DEFAULT 0,
+  failed_count int NOT NULL DEFAULT 0,
+  paused_at timestamptz NULL,
+  pause_reason text NULL,
+  created_by_user_id uuid NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_campaigns_status ON public.email_campaigns (send_status);
+CREATE INDEX IF NOT EXISTS idx_email_campaigns_scheduled_for ON public.email_campaigns (scheduled_for) WHERE send_status = 'scheduled';
+CREATE INDEX IF NOT EXISTS idx_email_campaigns_created_at ON public.email_campaigns (created_at DESC);
+
+-- updated_at trigger
+CREATE OR REPLACE FUNCTION public.fn_email_campaigns_set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at = now(); RETURN NEW; END $$;
+
+DROP TRIGGER IF EXISTS trg_email_campaigns_updated_at ON public.email_campaigns;
+CREATE TRIGGER trg_email_campaigns_updated_at
+  BEFORE UPDATE ON public.email_campaigns
+  FOR EACH ROW EXECUTE FUNCTION public.fn_email_campaigns_set_updated_at();
+
+COMMENT ON TABLE public.email_campaigns IS
+  'Marketing and lifecycle email campaigns. Scheduled by admin, dispatched by /api/cron/email/dispatcher, worked by /api/cron/email/worker. Counters are atomically updated via increment_campaign_counter RPC.';
+COMMENT ON COLUMN public.email_campaigns.audience_filter IS
+  'JSONB filter resolved by PR 5 audience RPC. PR 3 supports starter shapes: {segment:"all_users"}, {segment:"trial_users"}, {segment:"active_subscribers"}.';
+COMMENT ON COLUMN public.email_campaigns.audience_template_id IS
+  'Optional FK to email_audience_templates (added by PR 5). When set, dispatcher uses the template filter and increments last_used_count.';

--- a/supabase/migrations/087_email_jobs.sql
+++ b/supabase/migrations/087_email_jobs.sql
@@ -1,0 +1,43 @@
+-- 087_email_jobs.sql
+-- One row per recipient per campaign. Worker cron claims pending → calls gatedSend → updates terminal.
+
+DO $$ BEGIN
+  CREATE TYPE email_job_status AS ENUM (
+    'pending', 'dispatching', 'sent', 'bounced',
+    'failed', 'cancelled', 'skipped_suppressed'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS public.email_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  campaign_id uuid NOT NULL REFERENCES public.email_campaigns (id) ON DELETE CASCADE,
+  recipient_email text NOT NULL,
+  recipient_user_id uuid NULL,
+  status email_job_status NOT NULL DEFAULT 'pending',
+  template_payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  sg_message_id text NULL,
+  sent_at timestamptz NULL,
+  last_error text NULL,
+  retry_count int NOT NULL DEFAULT 0,
+  event_count int NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_email_jobs_campaign_recipient
+  ON public.email_jobs (campaign_id, lower(recipient_email));
+
+CREATE INDEX IF NOT EXISTS idx_email_jobs_campaign_status ON public.email_jobs (campaign_id, status);
+CREATE INDEX IF NOT EXISTS idx_email_jobs_status_created
+  ON public.email_jobs (status, created_at) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_email_jobs_sg_message_id ON public.email_jobs (sg_message_id) WHERE sg_message_id IS NOT NULL;
+
+DROP TRIGGER IF EXISTS trg_email_jobs_updated_at ON public.email_jobs;
+CREATE TRIGGER trg_email_jobs_updated_at
+  BEFORE UPDATE ON public.email_jobs
+  FOR EACH ROW EXECUTE FUNCTION public.fn_email_campaigns_set_updated_at();
+
+COMMENT ON TABLE public.email_jobs IS
+  'One row per (campaign, recipient). Idempotent unique key (campaign_id, lower(email)) prevents duplicate dispatch on dispatcher retry.';
+COMMENT ON COLUMN public.email_jobs.template_payload IS
+  'Per-recipient template variables (firstName, companyName, unsubscribeToken, etc). Resolved by dispatcher before enqueue, consumed by worker.';

--- a/supabase/migrations/088_email_log_campaign_link.sql
+++ b/supabase/migrations/088_email_log_campaign_link.sql
@@ -1,0 +1,10 @@
+-- 088_email_log_campaign_link.sql
+ALTER TABLE public.email_log
+  ADD COLUMN IF NOT EXISTS campaign_id uuid NULL
+  REFERENCES public.email_campaigns (id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_email_log_campaign_id
+  ON public.email_log (campaign_id) WHERE campaign_id IS NOT NULL;
+
+COMMENT ON COLUMN public.email_log.campaign_id IS
+  'Set by worker when dispatching campaign emails. NULL for transactional sends. ON DELETE SET NULL preserves log when campaign is hard-deleted.';

--- a/supabase/migrations/089_increment_campaign_counter_rpc.sql
+++ b/supabase/migrations/089_increment_campaign_counter_rpc.sql
@@ -1,0 +1,32 @@
+-- 089_increment_campaign_counter_rpc.sql
+-- Atomic counter increment. Avoids read-modify-write race when two worker
+-- batches finalize jobs for the same campaign concurrently.
+
+CREATE OR REPLACE FUNCTION public.increment_campaign_counter(
+  p_campaign_id uuid,
+  p_field text,
+  p_delta int DEFAULT 1
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_field NOT IN (
+    'sent_count','delivered_count','bounced_count','opened_count',
+    'clicked_count','suppressed_skipped_count','failed_count'
+  ) THEN
+    RAISE EXCEPTION 'increment_campaign_counter: invalid field %', p_field;
+  END IF;
+
+  EXECUTE format(
+    'UPDATE public.email_campaigns SET %I = COALESCE(%I,0) + $1 WHERE id = $2',
+    p_field, p_field
+  ) USING p_delta, p_campaign_id;
+END $$;
+
+REVOKE ALL ON FUNCTION public.increment_campaign_counter(uuid, text, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.increment_campaign_counter(uuid, text, int) TO service_role;
+
+COMMENT ON FUNCTION public.increment_campaign_counter IS
+  'Atomic counter increment for email_campaigns. Field allowlist prevents SQL injection. Service-role only.';

--- a/supabase/migrations/090_claim_email_jobs_rpc.sql
+++ b/supabase/migrations/090_claim_email_jobs_rpc.sql
@@ -1,0 +1,44 @@
+-- 090_claim_email_jobs_rpc.sql
+-- Atomic FOR UPDATE SKIP LOCKED claim of pending jobs. Returns claimed rows
+-- after transitioning them to 'dispatching' so a parallel worker invocation
+-- skips them.
+
+CREATE OR REPLACE FUNCTION public.claim_email_jobs(
+  p_limit int DEFAULT 200
+) RETURNS TABLE(
+  id uuid,
+  campaign_id uuid,
+  recipient_email text,
+  recipient_user_id uuid,
+  template_payload jsonb,
+  retry_count int
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH claimed AS (
+    SELECT j.id
+    FROM public.email_jobs j
+    JOIN public.email_campaigns c ON c.id = j.campaign_id
+    WHERE j.status = 'pending'
+      AND c.send_status = 'in_flight'
+    ORDER BY j.created_at ASC
+    LIMIT p_limit
+    FOR UPDATE OF j SKIP LOCKED
+  )
+  UPDATE public.email_jobs j
+  SET status = 'dispatching', updated_at = now()
+  FROM claimed
+  WHERE j.id = claimed.id
+  RETURNING j.id, j.campaign_id, j.recipient_email, j.recipient_user_id,
+            j.template_payload, j.retry_count;
+END $$;
+
+REVOKE ALL ON FUNCTION public.claim_email_jobs(int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.claim_email_jobs(int) TO service_role;
+
+COMMENT ON FUNCTION public.claim_email_jobs IS
+  'Atomically claims up to p_limit pending jobs from in-flight campaigns by transitioning to dispatching. SKIP LOCKED ensures parallel workers do not double-dispatch.';

--- a/supabase/migrations/091_email_jobs_unique_constraint.sql
+++ b/supabase/migrations/091_email_jobs_unique_constraint.sql
@@ -1,0 +1,17 @@
+-- 091_email_jobs_unique_constraint.sql
+-- supabase-js upsert with `onConflict` only resolves plain column-based UNIQUE
+-- constraints, not expression indexes. Switch to a column UNIQUE constraint
+-- so enqueueCampaignJobs can use ignoreDuplicates upsert. Email is always
+-- pre-lowercased by enqueueCampaignJobs so the lower() expression was redundant.
+
+ALTER TABLE public.email_jobs
+  DROP CONSTRAINT IF EXISTS uq_email_jobs_campaign_recipient;
+
+DROP INDEX IF EXISTS public.uq_email_jobs_campaign_recipient;
+
+ALTER TABLE public.email_jobs
+  ADD CONSTRAINT uq_email_jobs_campaign_recipient
+  UNIQUE (campaign_id, recipient_email);
+
+COMMENT ON CONSTRAINT uq_email_jobs_campaign_recipient ON public.email_jobs IS
+  'Idempotent unique key. Caller (enqueueCampaignJobs) lowercases recipient_email before insert so case-folding is enforced upstream.';

--- a/tests/e2e/email-campaign.spec.ts
+++ b/tests/e2e/email-campaign.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * E2E test for the campaign pipeline. Skipped by default — flips on when
+ * E2E_ADMIN_EMAIL + E2E_ADMIN_PASSWORD are set in the env, AND a tiny
+ * test audience (1-2 recipients) is seeded on the staging Supabase.
+ *
+ * Verifies the full path: admin clicks NEW CAMPAIGN → schedules for ~1
+ * minute out → status pill flips through SCHEDULED → SENDING → SENT
+ * within ~5 minutes for a tiny audience.
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.E2E_BASE_URL ?? "http://localhost:3000";
+
+const skipReason =
+  "Requires E2E_ADMIN_EMAIL/PASSWORD + seeded staging audience";
+
+test.describe.skip(`Campaign pipeline E2E (${skipReason})`, () => {
+  test("create → schedule → dispatcher fires → worker dispatches → completion", async ({ page }) => {
+    // 1. Sign in as admin (auth flow specific — fill once admin login fixture exists)
+    await page.goto(`${BASE}/login`);
+
+    // 2. Open admin email page → Scheduled Sends tab
+    await page.goto(`${BASE}/admin/email`);
+    await page.getByRole("tab", { name: /scheduled sends/i }).click();
+
+    // 3. New campaign modal
+    await page.getByRole("button", { name: /new campaign/i }).click();
+    await page
+      .getByRole("dialog")
+      .getByLabel(/name/i)
+      .fill("E2E Smoke Test");
+
+    // Template + Audience selectors are <select> elements.
+    await page.locator("select").nth(0).selectOption("product_update");
+    await page.locator("select").nth(1).selectOption("all_users");
+
+    // Schedule for ~1 min in the future.
+    const inOneMin = new Date(Date.now() + 60_000)
+      .toISOString()
+      .slice(0, 16);
+    await page.locator('input[type="datetime-local"]').fill(inOneMin);
+    await page.getByRole("button", { name: /schedule send/i }).click();
+
+    // 4. Detail modal opens → status pill should hit SENDING within 90s
+    //    (dispatcher cron fires every minute).
+    await expect(page.getByText(/SENDING/i)).toBeVisible({ timeout: 90_000 });
+
+    // 5. Worker drains the (tiny) audience within ~5 min and the pill
+    //    flips to SENT.
+    await expect(page.getByText(/SENT/i)).toBeVisible({ timeout: 240_000 });
+  });
+});

--- a/tests/integration/admin-email-suppressions.test.ts
+++ b/tests/integration/admin-email-suppressions.test.ts
@@ -122,7 +122,7 @@ describe("admin email suppressions API", () => {
     expect(store).toHaveLength(1);
     const res = await itemDELETE(
       new NextRequest(new URL("https://example.com/api/admin/email/suppressions/a%40x.com")),
-      { params: { email: "a%40x.com" } }
+      { params: Promise.resolve({ email: "a%40x.com" }) }
     );
     expect(res.status).toBe(200);
     expect((await res.json()).removed).toBe(true);

--- a/tests/integration/email-dispatcher-cron.test.ts
+++ b/tests/integration/email-dispatcher-cron.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Integration tests for /api/cron/email/dispatcher.
+ *
+ * Covers: auth gating, no-op when no scheduled campaigns, audience
+ * resolution + enqueue path, and failure → mark campaign 'failed'.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const enqueueCampaignJobsMock = vi.fn();
+const resolveAudienceMock = vi.fn();
+const fromMock = vi.fn();
+
+vi.mock("@/lib/email/campaigns", () => ({
+  enqueueCampaignJobs: (...args: unknown[]) =>
+    enqueueCampaignJobsMock(...args),
+}));
+
+vi.mock("@/lib/email/audiences", () => ({
+  resolveAudience: (...args: unknown[]) => resolveAudienceMock(...args),
+}));
+
+vi.mock("@/lib/supabase/server-client", () => ({
+  getServiceRoleClient: () => ({ from: fromMock, rpc: vi.fn() }),
+}));
+
+import { GET } from "@/app/api/cron/email/dispatcher/route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.CRON_SECRET = "test-secret";
+});
+
+function buildRequest(authHeader?: string): NextRequest {
+  const headers = new Headers();
+  if (authHeader) headers.set("authorization", authHeader);
+  return new NextRequest(
+    new URL("https://example.com/api/cron/email/dispatcher"),
+    { headers }
+  );
+}
+
+function mockReadyCampaigns(rows: Array<{ id: string; audience_filter?: unknown; audience_template_id?: string | null; name?: string }>) {
+  fromMock.mockImplementation((table: string) => {
+    if (table === "email_campaigns") {
+      return {
+        select: () => ({
+          eq: () => ({
+            lte: () => ({
+              order: () => ({
+                limit: async () => ({ data: rows, error: null }),
+              }),
+            }),
+          }),
+        }),
+        update: () => ({
+          eq: async () => ({ data: null, error: null }),
+        }),
+      };
+    }
+    throw new Error(`unexpected table: ${table}`);
+  });
+}
+
+describe("email dispatcher cron", () => {
+  it("rejects requests without bearer auth", async () => {
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects requests with the wrong secret", async () => {
+    const res = await GET(buildRequest("Bearer wrong"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns processed=0 when no scheduled campaigns are ready", async () => {
+    mockReadyCampaigns([]);
+    const res = await GET(buildRequest("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.processed).toBe(0);
+  });
+
+  it("resolves audience and enqueues jobs for each ready campaign", async () => {
+    mockReadyCampaigns([
+      { id: "c1", audience_filter: { segment: "all_users" }, audience_template_id: null, name: "X" },
+    ]);
+    resolveAudienceMock.mockResolvedValue({
+      recipients: [
+        { email: "a@example.com", userId: "u1" },
+        { email: "b@example.com", userId: "u2" },
+      ],
+    });
+    enqueueCampaignJobsMock.mockResolvedValue({ enqueued: 2, suppressedSkipped: 0 });
+
+    const res = await GET(buildRequest("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.processed).toBe(1);
+    expect(body.results[0].enqueued).toBe(2);
+    expect(resolveAudienceMock).toHaveBeenCalledWith(
+      { segment: "all_users" },
+      expect.anything()
+    );
+    expect(enqueueCampaignJobsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks campaign failed when audience resolution throws", async () => {
+    const updateSpy = vi.fn(() => ({
+      eq: async () => ({ data: null, error: null }),
+    }));
+    fromMock.mockImplementation((table: string) => {
+      if (table === "email_campaigns") {
+        return {
+          select: () => ({
+            eq: () => ({
+              lte: () => ({
+                order: () => ({
+                  limit: async () => ({
+                    data: [{ id: "c1", audience_filter: {}, audience_template_id: null }],
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          }),
+          update: updateSpy,
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    });
+    resolveAudienceMock.mockRejectedValue(new Error("audience boom"));
+
+    const res = await GET(buildRequest("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results[0].error).toContain("audience boom");
+    // Campaign should be marked failed.
+    const failedCall = updateSpy.mock.calls.find(
+      ([payload]) => (payload as { send_status?: string }).send_status === "failed"
+    );
+    expect(failedCall).toBeTruthy();
+  });
+});

--- a/tests/integration/email-dispatcher-cron.test.ts
+++ b/tests/integration/email-dispatcher-cron.test.ts
@@ -136,9 +136,10 @@ describe("email dispatcher cron", () => {
     const body = await res.json();
     expect(body.results[0].error).toContain("audience boom");
     // Campaign should be marked failed.
-    const failedCall = updateSpy.mock.calls.find(
-      ([payload]) => (payload as { send_status?: string }).send_status === "failed"
-    );
+    const failedCall = updateSpy.mock.calls.find((call) => {
+      const payload = (call as unknown[])[0] as { send_status?: string };
+      return payload?.send_status === "failed";
+    });
     expect(failedCall).toBeTruthy();
   });
 });

--- a/tests/integration/email-worker-cron.test.ts
+++ b/tests/integration/email-worker-cron.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Integration tests for /api/cron/email/worker.
+ *
+ * Covers: auth gating, claimed jobs dispatch via gatedSend, suppressed
+ * jobs increment the suppressed counter, completion fires a notification.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const rpcMock = vi.fn();
+const fromMock = vi.fn();
+const completeCampaignIfDoneMock = vi.fn();
+const senderMock = vi.fn();
+
+const inserts: Array<{ table: string; payload: unknown }> = [];
+const updates: Array<{ table: string; payload: unknown }> = [];
+
+vi.mock("@/lib/supabase/server-client", () => ({
+  getServiceRoleClient: () => ({ rpc: rpcMock, from: fromMock }),
+}));
+
+vi.mock("@/lib/email/campaigns", () => ({
+  completeCampaignIfDone: (...args: unknown[]) =>
+    completeCampaignIfDoneMock(...args),
+}));
+
+vi.mock("@/lib/email/campaign-templates-bootstrap", () => ({
+  bootstrapCampaignTemplates: vi.fn(),
+}));
+
+vi.mock("@/lib/email/campaign-templates", () => ({
+  getCampaignTemplate: () => ({
+    id: "product_update",
+    label: "X",
+    description: "X",
+    sender: senderMock,
+  }),
+}));
+
+import { GET } from "@/app/api/cron/email/worker/route";
+
+function buildRequest(authHeader?: string): NextRequest {
+  const headers = new Headers();
+  if (authHeader) headers.set("authorization", authHeader);
+  return new NextRequest(
+    new URL("https://example.com/api/cron/email/worker"),
+    { headers }
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  inserts.length = 0;
+  updates.length = 0;
+  process.env.CRON_SECRET = "test-secret";
+  completeCampaignIfDoneMock.mockResolvedValue(true);
+});
+
+function buildBuilder(table: string) {
+  const builder = {
+    select() {
+      return builder;
+    },
+    eq() {
+      return builder;
+    },
+    in() {
+      // For email_campaigns lookup by ids
+      if (table === "email_campaigns") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "c1",
+              template_id: "product_update",
+              send_status: "in_flight",
+              name: "Test Campaign",
+              created_by_user_id: "operator-uid",
+            },
+          ],
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: [], error: null });
+    },
+    single() {
+      // Used after .insert(...).select() and after the per-cid completion select
+      if (table === "email_campaigns") {
+        return Promise.resolve({
+          data: {
+            id: "c1",
+            name: "Test Campaign",
+            send_status: "completed",
+            completed_at: "2026-04-27T00:00:00Z",
+            created_by_user_id: "operator-uid",
+          },
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+    maybeSingle() {
+      if (table === "users") {
+        return Promise.resolve({
+          data: { company_id: "co1" },
+          error: null,
+        });
+      }
+      if (table === "email_campaigns") {
+        return Promise.resolve({
+          data: {
+            id: "c1",
+            name: "Test Campaign",
+            send_status: "completed",
+            completed_at: "2026-04-27T00:00:00Z",
+            created_by_user_id: "operator-uid",
+          },
+          error: null,
+        });
+      }
+      if (table === "notifications") {
+        return Promise.resolve({ data: null, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+    update(payload: unknown) {
+      updates.push({ table, payload });
+      return builder;
+    },
+    insert(payload: unknown) {
+      inserts.push({ table, payload });
+      return builder;
+    },
+  };
+  return builder;
+}
+
+describe("email worker cron", () => {
+  it("rejects requests without bearer auth", async () => {
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("dispatches claimed jobs and increments sent_count", async () => {
+    rpcMock.mockImplementation((name: string, args: unknown) => {
+      if (name === "claim_email_jobs") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "j1",
+              campaign_id: "c1",
+              recipient_email: "a@example.com",
+              recipient_user_id: "u1",
+              template_payload: {},
+              retry_count: 0,
+            },
+          ],
+          error: null,
+        });
+      }
+      if (name === "increment_campaign_counter") {
+        return Promise.resolve({ data: null, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    });
+    fromMock.mockImplementation((table: string) => buildBuilder(table));
+    senderMock.mockResolvedValue({ status: "sent", messageId: "msg-1" });
+
+    const res = await GET(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+    // Counter RPC was called for sent_count
+    const incCall = rpcMock.mock.calls.find(
+      ([name, args]) =>
+        name === "increment_campaign_counter" &&
+        (args as { p_field?: string }).p_field === "sent_count"
+    );
+    expect(incCall).toBeTruthy();
+    // sg_message_id propagated
+    const sentUpdate = updates.find(
+      (u) =>
+        u.table === "email_jobs" &&
+        (u.payload as { status?: string }).status === "sent"
+    );
+    expect(sentUpdate).toBeTruthy();
+    expect(
+      (sentUpdate?.payload as { sg_message_id: string }).sg_message_id
+    ).toBe("msg-1");
+    // Notification rail entry on completion
+    const notif = inserts.find((i) => i.table === "notifications");
+    expect(notif).toBeTruthy();
+    expect(
+      (notif?.payload as { type?: string }).type
+    ).toBe("campaign_done");
+  });
+
+  it("marks suppressed jobs and increments suppressed_skipped_count", async () => {
+    rpcMock.mockImplementation((name: string) => {
+      if (name === "claim_email_jobs") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "j2",
+              campaign_id: "c1",
+              recipient_email: "blocked@example.com",
+              recipient_user_id: null,
+              template_payload: {},
+              retry_count: 0,
+            },
+          ],
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    });
+    fromMock.mockImplementation((table: string) => buildBuilder(table));
+    senderMock.mockResolvedValue({ status: "suppression_skipped", reason: "suppressed" });
+
+    const res = await GET(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+    expect(body.skipped).toBe(1);
+    expect(body.sent).toBe(0);
+    const incCall = rpcMock.mock.calls.find(
+      ([name, args]) =>
+        name === "increment_campaign_counter" &&
+        (args as { p_field?: string }).p_field === "suppressed_skipped_count"
+    );
+    expect(incCall).toBeTruthy();
+  });
+
+  it("retries transient errors and finalises after MAX_RETRIES", async () => {
+    rpcMock.mockImplementation((name: string) => {
+      if (name === "claim_email_jobs") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "j3",
+              campaign_id: "c1",
+              recipient_email: "c@example.com",
+              recipient_user_id: "u3",
+              template_payload: {},
+              retry_count: 2, // 3rd attempt → final
+            },
+          ],
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    });
+    fromMock.mockImplementation((table: string) => buildBuilder(table));
+    senderMock.mockRejectedValue(new Error("transient"));
+
+    const res = await GET(buildRequest("Bearer test-secret"));
+    const body = await res.json();
+    expect(body.failed).toBe(1);
+    const failedUpdate = updates.find(
+      (u) =>
+        u.table === "email_jobs" &&
+        (u.payload as { status?: string }).status === "failed"
+    );
+    expect(failedUpdate).toBeTruthy();
+    const incCall = rpcMock.mock.calls.find(
+      ([name, args]) =>
+        name === "increment_campaign_counter" &&
+        (args as { p_field?: string }).p_field === "failed_count"
+    );
+    expect(incCall).toBeTruthy();
+  });
+});

--- a/tests/unit/email/campaigns.test.ts
+++ b/tests/unit/email/campaigns.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Unit tests for the campaign service module. Uses a hand-rolled
+ * Supabase chain mock that records the last-resolved data + error per
+ * builder so each state transition can assert on its result.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createCampaign,
+  scheduleCampaign,
+  cancelCampaign,
+  pauseCampaign,
+  resumeCampaign,
+  completeCampaignIfDone,
+  getCampaignStats,
+  listCampaigns,
+  enqueueCampaignJobs,
+} from "@/lib/email/campaigns";
+
+vi.mock("@/lib/email/suppressions", () => ({
+  filterSuppressed: vi.fn(async (_emails: string[]) => new Set<string>()),
+}));
+
+import { filterSuppressed } from "@/lib/email/suppressions";
+
+interface Recorder {
+  table: string;
+  inserts: unknown[];
+  updates: unknown[];
+  upserts: unknown[];
+  filters: Array<{ kind: string; col: string; val: unknown }>;
+  upsertOptions: unknown[];
+}
+
+function buildClient(opts: {
+  /** rows returned by .single() or .maybeSingle() */
+  single?: { data: unknown; error: unknown };
+  /** rows returned for list queries (await final builder) */
+  list?: { data: unknown[]; count: number; error: unknown };
+  /** rows returned for count head queries */
+  countHead?: { count: number; error: unknown };
+  /** rows returned for await on the builder itself (terminal await) */
+  terminal?: { data?: unknown[]; count?: number; error: unknown };
+}): { client: unknown; rec: Recorder } {
+  const rec: Recorder = {
+    table: "",
+    inserts: [],
+    updates: [],
+    upserts: [],
+    filters: [],
+    upsertOptions: [],
+  };
+
+  // Per-from() flags. Most are set by select() and consumed by `then`.
+  let isHead = false;
+
+  const builder: Record<string, unknown> = {};
+  const ensure = () => builder;
+
+  Object.assign(builder, {
+    insert(payload: unknown) {
+      rec.inserts.push(payload);
+      return ensure();
+    },
+    update(payload: unknown) {
+      rec.updates.push(payload);
+      return ensure();
+    },
+    upsert(payload: unknown, options?: unknown) {
+      rec.upserts.push(payload);
+      if (options !== undefined) rec.upsertOptions.push(options);
+      return Promise.resolve({ error: null });
+    },
+    select(_cols?: string, options?: { count?: string; head?: boolean }) {
+      if (options?.head) isHead = true;
+      return ensure();
+    },
+    eq(col: string, val: unknown) {
+      rec.filters.push({ kind: "eq", col, val });
+      return ensure();
+    },
+    in(col: string, val: unknown) {
+      rec.filters.push({ kind: "in", col, val });
+      return ensure();
+    },
+    not(col: string, _op: string, val: unknown) {
+      rec.filters.push({ kind: "not", col, val });
+      return ensure();
+    },
+    or(expr: string) {
+      rec.filters.push({ kind: "or", col: "or", val: expr });
+      return ensure();
+    },
+    order(_col: string, _opts?: unknown) {
+      return ensure();
+    },
+    range(_a: number, _b: number) {
+      if (opts.list) return Promise.resolve(opts.list);
+      return Promise.resolve({ data: [], count: 0, error: null });
+    },
+    limit(_n: number) {
+      if (opts.list) return Promise.resolve(opts.list);
+      return Promise.resolve({ data: [], error: null });
+    },
+    single() {
+      return Promise.resolve(opts.single ?? { data: null, error: null });
+    },
+    maybeSingle() {
+      return Promise.resolve(opts.single ?? { data: null, error: null });
+    },
+    // Thenable so `await db.from(...).select(...).eq(...)` resolves to count
+    // when head:true was set, or to {data, error} otherwise.
+    then<TFulfilled = unknown>(
+      onFulfilled?: (v: unknown) => TFulfilled
+    ): Promise<TFulfilled> {
+      const result =
+        isHead && opts.countHead
+          ? opts.countHead
+          : opts.terminal ?? { data: [], error: null };
+      // Reset for the next call to from() — the thenable was consumed.
+      isHead = false;
+      return Promise.resolve(result).then(onFulfilled as never);
+    },
+  });
+
+  const client = {
+    from: (table: string) => {
+      rec.table = table;
+      isHead = false;
+      return builder;
+    },
+  };
+  return { client, rec };
+}
+
+const baseRow = {
+  id: "c1",
+  name: "X",
+  slug: "x",
+  template_id: "product_update",
+  audience_filter: {},
+  audience_template_id: null,
+  scheduled_for: null,
+  send_status: "draft",
+  recipient_count_estimate: 0,
+  recipient_count_actual: null,
+  sent_count: 0,
+  delivered_count: 0,
+  bounced_count: 0,
+  opened_count: 0,
+  clicked_count: 0,
+  suppressed_skipped_count: 0,
+  failed_count: 0,
+  paused_at: null,
+  pause_reason: null,
+  created_by_user_id: null,
+  created_at: "2026-04-27T00:00:00Z",
+  updated_at: "2026-04-27T00:00:00Z",
+  completed_at: null,
+};
+
+beforeEach(() => {
+  vi.mocked(filterSuppressed).mockClear();
+  vi.mocked(filterSuppressed).mockImplementation(
+    async (_emails: string[]) => new Set<string>()
+  );
+});
+
+describe("createCampaign", () => {
+  it("inserts with defaults and returns a typed Campaign", async () => {
+    const { client, rec } = buildClient({ single: { data: baseRow, error: null } });
+    const c = await createCampaign({
+      name: "X",
+      slug: "x",
+      templateId: "product_update",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+    });
+    expect(c.id).toBe("c1");
+    expect(rec.table).toBe("email_campaigns");
+    expect(rec.inserts).toHaveLength(1);
+    expect((rec.inserts[0] as { send_status: string }).send_status).toBe(
+      "draft"
+    );
+  });
+
+  it("throws on insert error", async () => {
+    const { client } = buildClient({
+      single: { data: null, error: { message: "boom" } },
+    });
+    await expect(
+      createCampaign({
+        name: "X",
+        slug: "x",
+        templateId: "product_update",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        client: client as any,
+      })
+    ).rejects.toThrow(/createCampaign/);
+  });
+});
+
+describe("scheduleCampaign", () => {
+  it("sets scheduled_for + send_status='scheduled'", async () => {
+    const when = new Date("2026-05-01T10:00:00Z");
+    const updated = { ...baseRow, send_status: "scheduled", scheduled_for: when.toISOString() };
+    const { client, rec } = buildClient({ single: { data: updated, error: null } });
+    const c = await scheduleCampaign(
+      "c1",
+      when,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any
+    );
+    expect(c.sendStatus).toBe("scheduled");
+    expect((rec.updates[0] as { send_status: string }).send_status).toBe(
+      "scheduled"
+    );
+  });
+});
+
+describe("cancelCampaign", () => {
+  it("flips status to cancelled and cancels pending jobs", async () => {
+    const cancelled = { ...baseRow, send_status: "cancelled" };
+    const { client, rec } = buildClient({ single: { data: cancelled, error: null } });
+    const c = await cancelCampaign(
+      "c1",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any
+    );
+    expect(c.sendStatus).toBe("cancelled");
+    // First update is the campaign, second is the jobs sweep.
+    expect(rec.updates.length).toBeGreaterThanOrEqual(2);
+    expect(
+      (rec.updates[1] as { status: string }).status
+    ).toBe("cancelled");
+  });
+});
+
+describe("pauseCampaign", () => {
+  it("only acts when send_status is in_flight", async () => {
+    const paused = {
+      ...baseRow,
+      send_status: "paused",
+      pause_reason: "manual",
+      paused_at: "2026-04-27T00:00:00Z",
+    };
+    const { client, rec } = buildClient({ single: { data: paused, error: null } });
+    const c = await pauseCampaign(
+      "c1",
+      "manual",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any
+    );
+    expect(c.sendStatus).toBe("paused");
+    // pause asserts both id and prior-status filter
+    expect(rec.filters.some((f) => f.col === "send_status" && f.val === "in_flight")).toBe(true);
+  });
+});
+
+describe("resumeCampaign", () => {
+  it("flips paused → in_flight and clears pause fields", async () => {
+    const resumed = {
+      ...baseRow,
+      send_status: "in_flight",
+      pause_reason: null,
+      paused_at: null,
+    };
+    const { client, rec } = buildClient({ single: { data: resumed, error: null } });
+    const c = await resumeCampaign(
+      "c1",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any
+    );
+    expect(c.sendStatus).toBe("in_flight");
+    const upd = rec.updates[0] as { send_status: string; paused_at: null; pause_reason: null };
+    expect(upd.send_status).toBe("in_flight");
+    expect(upd.paused_at).toBe(null);
+    expect(upd.pause_reason).toBe(null);
+  });
+});
+
+describe("completeCampaignIfDone", () => {
+  it("returns false when there are still pending jobs", async () => {
+    const { client } = buildClient({ countHead: { count: 3, error: null } });
+    const done = await completeCampaignIfDone(
+      "c1",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any
+    );
+    expect(done).toBe(false);
+  });
+
+  it("flips to completed when no pending and not already terminal", async () => {
+    const { client, rec } = buildClient({
+      countHead: { count: 0, error: null },
+      single: { data: { send_status: "in_flight" }, error: null },
+    });
+    const done = await completeCampaignIfDone(
+      "c1",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any
+    );
+    expect(done).toBe(true);
+    // Final update flips to completed.
+    const lastUpdate = rec.updates[rec.updates.length - 1] as {
+      send_status: string;
+    };
+    expect(lastUpdate.send_status).toBe("completed");
+  });
+
+  it("returns false when campaign already in a terminal state", async () => {
+    const { client } = buildClient({
+      countHead: { count: 0, error: null },
+      single: { data: { send_status: "completed" }, error: null },
+    });
+    const done = await completeCampaignIfDone(
+      "c1",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any
+    );
+    expect(done).toBe(false);
+  });
+});
+
+describe("getCampaignStats", () => {
+  it("returns null when no row found", async () => {
+    const { client } = buildClient({ single: { data: null, error: null } });
+    const c = await getCampaignStats(
+      "missing",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any
+    );
+    expect(c).toBeNull();
+  });
+
+  it("returns row mapped to Campaign shape", async () => {
+    const { client } = buildClient({ single: { data: baseRow, error: null } });
+    const c = await getCampaignStats(
+      "c1",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client as any
+    );
+    expect(c?.id).toBe("c1");
+    expect(c?.templateId).toBe("product_update");
+  });
+});
+
+describe("listCampaigns", () => {
+  it("returns rows + total", async () => {
+    const { client } = buildClient({
+      list: { data: [baseRow, baseRow], count: 2, error: null },
+    });
+    const r = await listCampaigns({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+    });
+    expect(r.rows.length).toBe(2);
+    expect(r.total).toBe(2);
+  });
+});
+
+describe("enqueueCampaignJobs", () => {
+  it("inserts pending jobs, marks campaign in_flight when audience non-empty", async () => {
+    const { client, rec } = buildClient({});
+    const r = await enqueueCampaignJobs({
+      campaignId: "c1",
+      recipients: [
+        { email: "A@example.com", userId: "u1" },
+        { email: "b@example.com", userId: "u2" },
+      ],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+    });
+    expect(r.enqueued).toBe(2);
+    expect(r.suppressedSkipped).toBe(0);
+    expect(rec.upserts).toHaveLength(1);
+    const rows = rec.upserts[0] as Array<{ recipient_email: string }>;
+    // Lowercase enforcement
+    expect(rows.map((r) => r.recipient_email).sort()).toEqual([
+      "a@example.com",
+      "b@example.com",
+    ]);
+    // Final campaign update sets in_flight (rows present)
+    const lastUpdate = rec.updates[rec.updates.length - 1] as {
+      send_status: string;
+      recipient_count_actual: number;
+    };
+    expect(lastUpdate.send_status).toBe("in_flight");
+    expect(lastUpdate.recipient_count_actual).toBe(2);
+  });
+
+  it("flips straight to completed when audience is fully suppressed", async () => {
+    vi.mocked(filterSuppressed).mockResolvedValueOnce(
+      new Set(["a@example.com", "b@example.com"])
+    );
+    const { client, rec } = buildClient({});
+    const r = await enqueueCampaignJobs({
+      campaignId: "c1",
+      recipients: [
+        { email: "a@example.com" },
+        { email: "b@example.com" },
+      ],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+    });
+    expect(r.enqueued).toBe(0);
+    expect(r.suppressedSkipped).toBe(2);
+    const lastUpdate = rec.updates[rec.updates.length - 1] as {
+      send_status: string;
+    };
+    expect(lastUpdate.send_status).toBe("completed");
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -122,6 +122,14 @@
     {
       "path": "/api/cron/pmf/cleanup-snapshots",
       "schedule": "30 14 * * *"
+    },
+    {
+      "path": "/api/cron/email/dispatcher",
+      "schedule": "*/1 * * * *"
+    },
+    {
+      "path": "/api/cron/email/worker",
+      "schedule": "*/1 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Ships the marketing-and-lifecycle email campaign system. After this PR an admin can create a campaign with template + audience, schedule it, watch a dispatcher cron enqueue jobs, watch a worker cron call `gatedSend` for each recipient at a controlled rate, see real-time delivery / bounce / open / click counters in the admin UI, pause / cancel mid-send, and be notified when the campaign completes via the notification rail. Suppression-safe (PR 1 chokepoint), idempotent (`(campaign_id, recipient_email)` unique key), and atomic (counter + claim RPCs).

## Architecture

Two-stage pipeline.

- **Dispatcher** cron (every 1 min) — picks `email_campaigns` with `send_status='scheduled'` and `scheduled_for <= now()`, resolves audience, calls `filterSuppressed`, enqueues one `email_jobs` row per recipient with `status='pending'`, transitions to `in_flight` (or directly to `completed` when the audience is fully suppressed).
- **Worker** cron (every 1 min) — claims up to 200 `pending` jobs via `claim_email_jobs` (FOR UPDATE SKIP LOCKED), calls `gatedSend` for each (with 10ms inter-send pace), atomically increments campaign counters via `increment_campaign_counter` RPC, marks each job `sent | bounced | failed | cancelled | skipped_suppressed`. When all jobs are terminal, `completeCampaignIfDone` flips the campaign to `completed` and inserts a `campaign_done` notification.

## Migrations applied (production Supabase `ijeekuhbatykdomumfjx`)

| File | Purpose |
|------|---------|
| `086_email_campaigns.sql` | Marketing/lifecycle campaign table + enum + updated_at trigger |
| `087_email_jobs.sql` | Per-(campaign, recipient) job table + indexes |
| `088_email_log_campaign_link.sql` | `email_log.campaign_id` FK + index |
| `089_increment_campaign_counter_rpc.sql` | Allowlisted atomic counter RPC |
| `090_claim_email_jobs_rpc.sql` | FOR UPDATE SKIP LOCKED batch claim |
| `091_email_jobs_unique_constraint.sql` | Switch to column-based UNIQUE for PostgREST upsert support |

## What changed beyond the plan

- **PR β had only one of the four senders the plan named.** Added `sendProductUpdate`, `sendFeatureAnnouncement`, `sendReengagement` to `sendgrid.tsx` plus three new React Email templates (`ProductUpdate`, `FeatureAnnouncement`, `Reengagement`) on the `OpsEmailLayout`. Existing `sendTrialExpiryWarning` widened to accept `campaignId`.
- **`gatedSend` chokepoint extended** to accept `campaignId` and propagate it both to `email_log.campaign_id` and to SendGrid `customArgs.campaign_id` (for PR 6 webhook attribution). Now returns SendGrid `messageId` so the worker can persist `sg_message_id`. Outcome type exposed as `GatedSendResult`.
- **Subscription status values verified** against production schema before writing the audience resolver — real values are `trial`, `active`, `grace`, `cancelled`, `expired` (NOT `trialing` / `past_due` as the plan assumed).
- **Pre-existing `tests/integration/admin-email-suppressions.test.ts` failure fixed** — PR #15 changed dynamic-route handlers to `params: Promise<{...}>` but missed updating the test, which was breaking type-check on main.
- **Auto-complete short-circuit** in `enqueueCampaignJobs` — when the audience resolves to zero (or is fully suppressed), the campaign goes straight to `completed` instead of sitting indefinitely in `in_flight` waiting for jobs that never get enqueued.
- **`email_jobs` unique constraint switched** from expression index to column UNIQUE — supabase-js's `upsert` with `onConflict` only matches plain UNIQUE constraints. Emails are pre-lowercased upstream so case-folding still works.

## Cron schedule (Vercel Pro tier — verified)

| Path | Schedule |
|------|----------|
| `/api/cron/email/dispatcher` | `*/1 * * * *` |
| `/api/cron/email/worker` | `*/1 * * * *` |

Pro tier already in use by existing `*/5` and `*/15` crons in `vercel.json` — no billing change required.

## Admin API surface (`withAdmin` + `requireAdmin`-gated)

- `GET  /api/admin/email/campaigns` — paginated list
- `POST /api/admin/email/campaigns` — create draft
- `GET  /api/admin/email/campaigns/[id]` — detail + jobs slice
- `POST /api/admin/email/campaigns/[id]/schedule` — set `scheduled_for`
- `POST /api/admin/email/campaigns/[id]/cancel` — terminal cancel
- `POST /api/admin/email/campaigns/[id]/pause` — `in_flight → paused`
- `POST /api/admin/email/campaigns/[id]/resume` — `paused → in_flight`
- `POST /api/admin/email/campaigns/audience-estimate` — live recipient count

All `[id]` routes use Next.js 15's `params: Promise<{...}>` shape — referenced the post-#15 working pattern.

## Admin UI — `Admin → Email → Scheduled Sends` (new tab)

Components under `src/app/admin/email/_components/`:

- `campaign-status-pill.tsx` — 7 states, Cake Mono Light 11px, earth-tone palette
- `campaign-progress-bar.tsx` — segmented olive (sent) / rose (bounced) / brick (failed) on 2px rail
- `campaign-create-modal.tsx` — name → slug auto-suggest, template select, segment select with live audience count, schedule datetime
- `campaign-detail-modal.tsx` — 5s polling while `scheduled` or `in_flight`, animated counters, Pause/Resume/Cancel actions
- `scheduled-sends-tab.tsx` — list with stagger entry + 8s background refetch

All animations use `EASE_SMOOTH` curve with reduced-motion fallbacks centralized in `src/lib/utils/motion.ts`.

## Tests

- **Unit** (`tests/unit/email/campaigns.test.ts`) — 14 tests covering CRUD + state machine + zero-audience auto-complete + full-suppression case
- **Integration**:
  - `tests/integration/email-dispatcher-cron.test.ts` — 5 tests (auth, no-op, enqueue, failure-marks-failed)
  - `tests/integration/email-worker-cron.test.ts` — 4 tests (auth, sent + sg_message_id + notification, suppressed, retry-final-fail)
- **E2E** (`tests/e2e/email-campaign.spec.ts`) — skipped by default; flips on with `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` + seeded staging audience

Local verification:

- `npm run type-check` — ✅ clean
- `npm run build` — ✅ all routes compile
- `npx vitest run` — 689/689 tests pass; same 2 baseline suite failures as `main` (Firebase env)

## Cost notes

- 2 new crons × 24×60 = **2880 invocations/day** — Pro tier headroom.
- Worker batch: `LIMIT 200` × 2 crons × 1440 = up to 576k claim attempts/day; trivial for Postgres at our scale.
- SendGrid: one API call per `gatedSend`. ~3 campaigns/day × ~1k recipients = 3k sends/day, well within Essentials ($19.95/mo).
- DB: 1k-recipient campaign creates 1k `email_jobs` + 1k `email_log` + ~3k `email_events` rows. Negligible.

## Out of scope (later PRs)

- PR 4 — Pause/killswitch state machine + `email_pause_state`
- PR 5 — Saved audience templates + full predicate engine
- PR 6 — Campaign engagement RPC + funnel chart + webhook attribution consumption
- PR 7 — Versioned template registry
- PR 8 — Anomaly auto-pause on bounce spike

## Test plan

- [ ] Vercel preview deploy succeeds
- [ ] Smoke: navigate to `Admin → Email → Scheduled Sends`, click `NEW CAMPAIGN`, fill form, schedule for ~1 min, confirm status pill flips `SCHEDULED → SENDING → SENT`
- [ ] Smoke: pause an in-flight campaign — verify in-flight batch still drains but no new claims happen until resume
- [ ] Smoke: cancel a scheduled campaign — pending jobs are swept to `cancelled`
- [ ] Verify completion notification appears on the rail with `VIEW CAMPAIGN` action button

🤖 Generated with [Claude Code](https://claude.com/claude-code)