### PR TITLE
PR 4: Email Killswitches — pause state + audit log

### DIFF
--- a/src/app/admin/email/_components/active-pause-banner.tsx
+++ b/src/app/admin/email/_components/active-pause-banner.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * ActivePauseBanner — sticky banner shown across the email-admin tab when
+ * ANY scope is paused. Polls /api/admin/email/pauses every 10s.
+ *
+ * Visual spec:
+ *   - olive #9DB582 border at low alpha (warning, not error — pauses are
+ *     reversible operator actions, not crashes).
+ *   - tan #C4A868 for the // PAUSED eyebrow.
+ *   - sentence-case body, no emoji, no exclamation points.
+ *
+ * Tactical voice: `// PAUSED  GLOBAL is paused  [reason]`.
+ */
+import * as React from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { useQuery } from "@tanstack/react-query";
+import { activePauseBannerVariants } from "@/lib/utils/motion";
+
+interface ActivePauseRow {
+  scope: string;
+  isPaused: boolean;
+  pauseReason: string | null;
+  pausedUntil: string | null;
+  pausedAt: string | null;
+  pausedBy: string | null;
+}
+
+interface PausesResponse {
+  ok: boolean;
+  active: ActivePauseRow[];
+}
+
+async function fetchActivePauses(): Promise<ActivePauseRow[]> {
+  const r = await fetch("/api/admin/email/pauses", { cache: "no-store" });
+  if (!r.ok) return [];
+  const j = (await r.json()) as PausesResponse;
+  return j.active ?? [];
+}
+
+function formatScope(scope: string): string {
+  if (scope === "global") return "ALL EMAIL";
+  if (scope.startsWith("bucket:")) {
+    const name = scope.split(":")[1] ?? "";
+    return `BUCKET / ${name.toUpperCase()}`;
+  }
+  if (scope.startsWith("campaign:")) {
+    const id = scope.split(":")[1] ?? "";
+    return `CAMPAIGN / ${id.slice(0, 8)}`;
+  }
+  return scope.toUpperCase();
+}
+
+export function ActivePauseBanner() {
+  const reduced = useReducedMotion();
+  const { data } = useQuery({
+    queryKey: ["email-active-pauses"],
+    queryFn: fetchActivePauses,
+    refetchInterval: 10_000,
+  });
+
+  const pauses = data ?? [];
+
+  return (
+    <AnimatePresence>
+      {pauses.length > 0 && (
+        <motion.div
+          key="active-pause-banner"
+          variants={reduced ? undefined : activePauseBannerVariants}
+          initial={reduced ? false : "initial"}
+          animate={reduced ? false : "animate"}
+          exit={reduced ? undefined : "exit"}
+          className="sticky top-0 z-30 border-b border-[#9DB582]/40 px-6 py-3"
+          style={{
+            background: "rgba(157, 181, 130, 0.08)",
+            backdropFilter: "blur(20px) saturate(1.2)",
+            WebkitBackdropFilter: "blur(20px) saturate(1.2)",
+          }}
+        >
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="font-mono text-[11px] uppercase tracking-[0.18em] text-[#C4A868] shrink-0">
+                {"// PAUSED"}
+              </div>
+              <div className="font-mohave text-[14px] text-[#EDEDED] truncate">
+                {pauses.length === 1
+                  ? `${formatScope(pauses[0].scope)} is paused`
+                  : `${pauses.length} scopes paused`}
+              </div>
+              {pauses[0]?.pauseReason && (
+                <div className="font-mono text-[11px] text-[#8A8A8A] truncate">
+                  [{pauses[0].pauseReason}]
+                </div>
+              )}
+            </div>
+            <a
+              href="/admin/email?tab=killswitches"
+              className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#6F94B0] hover:text-[#EDEDED] shrink-0"
+            >
+              {"Manage →"}
+            </a>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/app/admin/email/_components/email-content.tsx
+++ b/src/app/admin/email/_components/email-content.tsx
@@ -8,6 +8,8 @@ import { NewsletterTab } from "./newsletter-tab";
 import { TriggersTab } from "./triggers-tab";
 import { ScheduleTab } from "./schedule-tab";
 import { ScheduledSendsTab } from "./scheduled-sends-tab";
+import { KillswitchesTab } from "./killswitches-tab";
+import { ActivePauseBanner } from "./active-pause-banner";
 import type {
   EmailOverviewStats,
   EmailEngagementStats,
@@ -26,17 +28,32 @@ interface EmailContentProps {
 
 export function EmailContent({ overview, engagement, funnels, emailLog, newsletters }: EmailContentProps) {
   return (
-    <SubTabs tabs={["Overview", "Scheduled Sends", "Funnels", "Email Log", "Newsletter", "Lifecycle", "Triggers"]}>
-      {(tab) => {
-        if (tab === "Overview") return <OverviewTab stats={overview} engagement={engagement} />;
-        if (tab === "Scheduled Sends") return <ScheduledSendsTab />;
-        if (tab === "Funnels") return <FunnelsTab data={funnels} />;
-        if (tab === "Email Log") return <EmailLogTab entries={emailLog} />;
-        if (tab === "Newsletter") return <NewsletterTab newsletters={newsletters} />;
-        if (tab === "Lifecycle") return <ScheduleTab />;
-        if (tab === "Triggers") return <TriggersTab />;
-        return null;
-      }}
-    </SubTabs>
+    <>
+      <ActivePauseBanner />
+      <SubTabs
+        tabs={[
+          "Overview",
+          "Scheduled Sends",
+          "Funnels",
+          "Email Log",
+          "Newsletter",
+          "Lifecycle",
+          "Triggers",
+          "Killswitches",
+        ]}
+      >
+        {(tab) => {
+          if (tab === "Overview") return <OverviewTab stats={overview} engagement={engagement} />;
+          if (tab === "Scheduled Sends") return <ScheduledSendsTab />;
+          if (tab === "Funnels") return <FunnelsTab data={funnels} />;
+          if (tab === "Email Log") return <EmailLogTab entries={emailLog} />;
+          if (tab === "Newsletter") return <NewsletterTab newsletters={newsletters} />;
+          if (tab === "Lifecycle") return <ScheduleTab />;
+          if (tab === "Triggers") return <TriggersTab />;
+          if (tab === "Killswitches") return <KillswitchesTab />;
+          return null;
+        }}
+      </SubTabs>
+    </>
   );
 }

--- a/src/app/admin/email/_components/killswitches-tab.tsx
+++ b/src/app/admin/email/_components/killswitches-tab.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+/**
+ * KillswitchesTab — operator's one-click email shut-off.
+ * Three sections:
+ *   1. GLOBAL — hard stop, all email.
+ *   2. SENDER BUCKETS — DISPATCH / GATE / FIELD_NOTES / PORTAL toggles.
+ *   3. CAMPAIGNS — note pointing operators to the Scheduled Sends tab
+ *      for per-campaign pauses (which write campaign:<uuid> rows).
+ *
+ * Switch design: outlined steel-blue when paused, gray when off. The pill
+ * uses `radius: 12` (just shy of the panel radius) so it reads as a control
+ * rather than a content surface.
+ */
+import * as React from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { motion, useReducedMotion } from "framer-motion";
+import { switchToggleVariants } from "@/lib/utils/motion";
+import { PauseConfirmationModal } from "./pause-confirmation-modal";
+
+type BucketScope =
+  | "bucket:dispatch"
+  | "bucket:gate"
+  | "bucket:field_notes"
+  | "bucket:portal";
+
+type AdminPauseScope = "global" | BucketScope;
+
+interface ActivePauseRow {
+  scope: string;
+  isPaused: boolean;
+  pauseReason: string | null;
+  pausedUntil: string | null;
+  pausedAt: string | null;
+  pausedBy: string | null;
+}
+
+interface PausesResponse {
+  ok: boolean;
+  active: ActivePauseRow[];
+}
+
+const BUCKETS: BucketScope[] = [
+  "bucket:dispatch",
+  "bucket:gate",
+  "bucket:field_notes",
+  "bucket:portal",
+];
+
+function bucketLabel(scope: AdminPauseScope): string {
+  if (scope === "global") return "GLOBAL — ALL EMAIL";
+  return scope.split(":")[1].toUpperCase();
+}
+
+interface PauseSwitchProps {
+  scope: AdminPauseScope;
+  state: ActivePauseRow | null;
+  onPause: () => void;
+  onResume: () => void;
+  busy: boolean;
+}
+
+function PauseSwitch({ scope, state, onPause, onResume, busy }: PauseSwitchProps) {
+  const reduced = useReducedMotion();
+  const isOn = !!state?.isPaused;
+  return (
+    <div
+      className="flex items-center justify-between border border-white/[0.09] px-5 py-4 gap-4"
+      style={{ borderRadius: 10 }}
+    >
+      <div className="min-w-0">
+        <div className="font-cakemono font-light text-[16px] uppercase tracking-[0.04em] text-[#EDEDED]">
+          {bucketLabel(scope)}
+        </div>
+        {state?.pauseReason && (
+          <div className="mt-1 font-mono text-[11px] text-[#8A8A8A] truncate">
+            [{state.pauseReason}]
+          </div>
+        )}
+        {state?.pausedUntil && (
+          <div className="mt-1 font-mono text-[11px] text-[#6A6A6A]">
+            [auto-resume {new Date(state.pausedUntil).toLocaleString()}]
+          </div>
+        )}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={isOn}
+        aria-label={`${bucketLabel(scope)} pause toggle`}
+        disabled={busy}
+        onClick={() => (isOn ? onResume() : onPause())}
+        className="relative w-[42px] h-[24px] border transition-colors shrink-0 disabled:opacity-50"
+        style={{
+          background: isOn ? "rgba(111, 148, 176, 0.2)" : "transparent",
+          borderColor: isOn ? "#6F94B0" : "rgba(255,255,255,0.18)",
+          borderRadius: 12,
+        }}
+      >
+        <motion.div
+          className="absolute top-[2px] left-[2px] w-[18px] h-[18px]"
+          style={{ background: isOn ? "#6F94B0" : "#8A8A8A", borderRadius: 9 }}
+          variants={reduced ? undefined : switchToggleVariants}
+          animate={isOn ? "on" : "off"}
+          initial={false}
+        />
+      </button>
+    </div>
+  );
+}
+
+export function KillswitchesTab() {
+  const qc = useQueryClient();
+  const { data: pauses = [] } = useQuery<ActivePauseRow[]>({
+    queryKey: ["email-active-pauses"],
+    queryFn: async () => {
+      const r = await fetch("/api/admin/email/pauses", { cache: "no-store" });
+      if (!r.ok) return [];
+      const j = (await r.json()) as PausesResponse;
+      return j.active ?? [];
+    },
+    refetchInterval: 5_000,
+  });
+
+  const stateByScope = new Map<string, ActivePauseRow>(
+    pauses.map((p) => [p.scope, p])
+  );
+
+  const [pendingPause, setPendingPause] = React.useState<AdminPauseScope | null>(
+    null
+  );
+
+  const pauseMut = useMutation({
+    mutationFn: async (input: {
+      scope: AdminPauseScope;
+      reason: string;
+      paused_until: string | null;
+    }) => {
+      const r = await fetch("/api/admin/email/pause", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (!r.ok) {
+        const j = (await r.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? `pause failed (${r.status})`);
+      }
+      return r.json();
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["email-active-pauses"] }),
+  });
+
+  const resumeMut = useMutation({
+    mutationFn: async (scope: AdminPauseScope) => {
+      const r = await fetch("/api/admin/email/resume", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ scope }),
+      });
+      if (!r.ok) {
+        const j = (await r.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? `resume failed (${r.status})`);
+      }
+      return r.json();
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["email-active-pauses"] }),
+  });
+
+  const onPause = (scope: AdminPauseScope) => setPendingPause(scope);
+  const onResume = (scope: AdminPauseScope) => resumeMut.mutate(scope);
+  const busyScope = (scope: AdminPauseScope) =>
+    (pauseMut.isPending && pendingPause === scope) ||
+    (resumeMut.isPending && resumeMut.variables === scope);
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <h2 className="font-cakemono font-light text-[20px] uppercase tracking-[0.04em] text-[#EDEDED]">
+          {"// GLOBAL"}
+        </h2>
+        <p className="mt-1 font-mohave text-[13px] text-[#B5B5B5]">
+          Hard stop. Every email send returns paused_skipped while this is on.
+        </p>
+        <div className="mt-4">
+          <PauseSwitch
+            scope="global"
+            state={stateByScope.get("global") ?? null}
+            onPause={() => onPause("global")}
+            onResume={() => onResume("global")}
+            busy={busyScope("global")}
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="font-cakemono font-light text-[20px] uppercase tracking-[0.04em] text-[#EDEDED]">
+          {"// SENDER BUCKETS"}
+        </h2>
+        <p className="mt-1 font-mohave text-[13px] text-[#B5B5B5]">
+          Pause one bucket without affecting others. Use when DNS misalignment is
+          bucket-specific.
+        </p>
+        <div className="mt-4 space-y-3">
+          {BUCKETS.map((b) => (
+            <PauseSwitch
+              key={b}
+              scope={b}
+              state={stateByScope.get(b) ?? null}
+              onPause={() => onPause(b)}
+              onResume={() => onResume(b)}
+              busy={busyScope(b)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="font-cakemono font-light text-[20px] uppercase tracking-[0.04em] text-[#EDEDED]">
+          {"// CAMPAIGNS"}
+        </h2>
+        <p className="mt-1 font-mohave text-[13px] text-[#B5B5B5]">
+          Pause individual campaigns from the Scheduled Sends tab. Pending jobs
+          stay queued and resume automatically when lifted.
+        </p>
+      </section>
+
+      <PauseConfirmationModal
+        open={pendingPause !== null}
+        onClose={() => setPendingPause(null)}
+        onConfirm={async (reason, paused_until) => {
+          if (!pendingPause) return;
+          await pauseMut.mutateAsync({ scope: pendingPause, reason, paused_until });
+        }}
+        scopeLabel={pendingPause ? bucketLabel(pendingPause) : ""}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/email/_components/pause-confirmation-modal.tsx
+++ b/src/app/admin/email/_components/pause-confirmation-modal.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+/**
+ * PauseConfirmationModal — operator must enter a reason (>= 3 chars) and
+ * pick an auto-resume duration (Indefinite / 1h / 24h) before a pause is
+ * applied. Mounted at z-3000 (modal layer).
+ *
+ * Visual spec:
+ *   - .glass-dense surface (rgba(18,18,20,0.78) + backdrop-blur(28px)).
+ *   - destructive button outlined in brick #93321A — red is reserved for
+ *     hard errors but borderless brick on the action button reads as
+ *     "this is a deliberate destructive thing", which is what a pause is.
+ */
+import * as React from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { confirmationModalVariants } from "@/lib/utils/motion";
+
+interface PauseConfirmationModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (reason: string, pausedUntil: string | null) => Promise<void>;
+  scopeLabel: string;
+}
+
+type Duration = "forever" | "1h" | "24h";
+
+export function PauseConfirmationModal({
+  open,
+  onClose,
+  onConfirm,
+  scopeLabel,
+}: PauseConfirmationModalProps) {
+  const reduced = useReducedMotion();
+  const [reason, setReason] = React.useState("");
+  const [duration, setDuration] = React.useState<Duration>("forever");
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // Reset state every time the modal opens for a new scope.
+  React.useEffect(() => {
+    if (open) {
+      setReason("");
+      setDuration("forever");
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [open, scopeLabel]);
+
+  if (!open) return null;
+
+  const submit = async () => {
+    if (reason.trim().length < 3) {
+      setError("Reason must be at least 3 characters.");
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    const pausedUntil =
+      duration === "1h"
+        ? new Date(Date.now() + 60 * 60 * 1000).toISOString()
+        : duration === "24h"
+        ? new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+        : null;
+    try {
+      await onConfirm(reason, pausedUntil);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Pause failed.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center px-4"
+      style={{ zIndex: 3000, background: "rgba(0,0,0,0.7)" }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="pause-confirmation-title"
+    >
+      <motion.div
+        variants={reduced ? undefined : confirmationModalVariants}
+        initial={reduced ? false : "initial"}
+        animate={reduced ? false : "animate"}
+        className="w-full max-w-[480px] border border-[#93321A]/40 px-6 py-6"
+        style={{
+          background: "rgba(18,18,20,0.78)",
+          backdropFilter: "blur(28px) saturate(1.3)",
+          WebkitBackdropFilter: "blur(28px) saturate(1.3)",
+          borderRadius: 12,
+        }}
+      >
+        <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#C4A868]">
+          {"// CONFIRM PAUSE"}
+        </div>
+        <h2
+          id="pause-confirmation-title"
+          className="mt-3 font-cakemono font-light text-[22px] uppercase text-[#EDEDED]"
+        >
+          Pause {scopeLabel}?
+        </h2>
+        <p className="mt-3 font-mohave text-[14px] text-[#B5B5B5]">
+          This stops every matching send until you resume. In-flight campaign jobs
+          stay queued and resume automatically when you lift the pause.
+        </p>
+
+        <label className="mt-6 block font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A]">
+          {"// REASON"}
+        </label>
+        <textarea
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          rows={3}
+          placeholder="e.g. SendGrid 5xx storm at 14:32 UTC"
+          className="mt-2 w-full bg-transparent border border-white/[0.09] px-3 py-2 font-mohave text-[14px] text-[#EDEDED] placeholder:text-[#6A6A6A] focus:outline-none focus:border-[#6F94B0]"
+          style={{ borderRadius: 5 }}
+          autoFocus
+        />
+
+        <label className="mt-5 block font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A]">
+          {"// AUTO-RESUME"}
+        </label>
+        <div className="mt-2 flex gap-2">
+          {(["forever", "1h", "24h"] as const).map((d) => (
+            <button
+              key={d}
+              type="button"
+              onClick={() => setDuration(d)}
+              className={`px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] border transition-colors ${
+                duration === d
+                  ? "border-[#6F94B0] text-[#6F94B0]"
+                  : "border-white/[0.09] text-[#8A8A8A] hover:text-[#EDEDED]"
+              }`}
+              style={{ borderRadius: 5 }}
+            >
+              {d === "forever" ? "Indefinite" : `In ${d}`}
+            </button>
+          ))}
+        </div>
+
+        {error && (
+          <div className="mt-4 font-mono text-[11px] text-[#B58289]">
+            [{error}]
+          </div>
+        )}
+
+        <div className="mt-8 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="px-5 py-2 font-mono text-[11px] uppercase tracking-[0.16em] text-[#B5B5B5] hover:text-[#EDEDED] disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting || reason.trim().length < 3}
+            className="px-5 py-2 border border-[#93321A] text-[#EDEDED] font-mono text-[11px] uppercase tracking-[0.16em] hover:bg-[#93321A] disabled:opacity-40"
+            style={{ borderRadius: 5 }}
+          >
+            {submitting ? "PAUSING…" : "PAUSE"}
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/app/api/admin/email/pause/route.ts
+++ b/src/app/api/admin/email/pause/route.ts
@@ -1,0 +1,77 @@
+/**
+ * POST /api/admin/email/pause
+ *
+ * Pause one of three scopes: global | bucket:<name> | campaign:<uuid>.
+ * Reason is mandatory (>= 3 chars). Optional ISO `paused_until` for
+ * auto-resume; null/missing = indefinite.
+ *
+ * Admin-only via withAdmin + requireAdmin.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin, withAdmin } from "@/lib/admin/api-auth";
+import { pause, type PauseScope } from "@/lib/email/pause";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface PauseBody {
+  scope?: string;
+  reason?: string;
+  paused_until?: string | null;
+}
+
+const SCOPE_RE =
+  /^(global|bucket:(dispatch|gate|field_notes|portal)|campaign:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+
+export const POST = withAdmin(async (req: NextRequest) => {
+  const admin = await requireAdmin(req);
+
+  let body: PauseBody | null = null;
+  try {
+    body = (await req.json()) as PauseBody;
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body || typeof body.scope !== "string" || typeof body.reason !== "string") {
+    return NextResponse.json({ ok: false, error: "scope and reason required" }, { status: 400 });
+  }
+  if (!SCOPE_RE.test(body.scope)) {
+    return NextResponse.json(
+      { ok: false, error: "scope must be 'global', 'bucket:<name>', or 'campaign:<uuid>'" },
+      { status: 400 }
+    );
+  }
+  if (body.reason.trim().length < 3) {
+    return NextResponse.json(
+      { ok: false, error: "reason must be >= 3 chars" },
+      { status: 400 }
+    );
+  }
+
+  const pausedUntil = body.paused_until ?? null;
+  if (pausedUntil !== null && (typeof pausedUntil !== "string" || Number.isNaN(Date.parse(pausedUntil)))) {
+    return NextResponse.json(
+      { ok: false, error: "paused_until must be a valid ISO timestamp or null" },
+      { status: 400 }
+    );
+  }
+
+  if (!admin.email) {
+    return NextResponse.json({ ok: false, error: "admin missing email claim" }, { status: 500 });
+  }
+
+  try {
+    const result = await pause({
+      scope: body.scope as PauseScope,
+      reason: body.reason,
+      pausedUntil,
+      actorUserId: admin.uid,
+      actorEmail: admin.email,
+    });
+    return NextResponse.json({ ok: true, paused: result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+});

--- a/src/app/api/admin/email/pauses/route.ts
+++ b/src/app/api/admin/email/pauses/route.ts
@@ -1,0 +1,25 @@
+/**
+ * GET /api/admin/email/pauses
+ *
+ * Returns all currently active pauses. Pass `?audit=1` to additionally
+ * include the most recent 100 audit-log rows (pause/resume/auto_resume).
+ *
+ * Admin-only via withAdmin + requireAdmin.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin, withAdmin } from "@/lib/admin/api-auth";
+import { getActivePauses, listAuditLog } from "@/lib/email/pause";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+  const url = new URL(req.url);
+  const includeAudit = url.searchParams.get("audit") === "1";
+  const [active, audit] = await Promise.all([
+    getActivePauses(),
+    includeAudit ? listAuditLog({ limit: 100 }) : Promise.resolve(null),
+  ]);
+  return NextResponse.json({ ok: true, active, audit });
+});

--- a/src/app/api/admin/email/resume/route.ts
+++ b/src/app/api/admin/email/resume/route.ts
@@ -1,0 +1,58 @@
+/**
+ * POST /api/admin/email/resume
+ *
+ * Resume a previously paused scope. Optional reason for the audit trail.
+ * Admin-only via withAdmin + requireAdmin.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin, withAdmin } from "@/lib/admin/api-auth";
+import { resume, type PauseScope } from "@/lib/email/pause";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface ResumeBody {
+  scope?: string;
+  reason?: string;
+}
+
+const SCOPE_RE =
+  /^(global|bucket:(dispatch|gate|field_notes|portal)|campaign:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+
+export const POST = withAdmin(async (req: NextRequest) => {
+  const admin = await requireAdmin(req);
+
+  let body: ResumeBody | null = null;
+  try {
+    body = (await req.json()) as ResumeBody;
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body || typeof body.scope !== "string") {
+    return NextResponse.json({ ok: false, error: "scope required" }, { status: 400 });
+  }
+  if (!SCOPE_RE.test(body.scope)) {
+    return NextResponse.json(
+      { ok: false, error: "scope must be 'global', 'bucket:<name>', or 'campaign:<uuid>'" },
+      { status: 400 }
+    );
+  }
+
+  if (!admin.email) {
+    return NextResponse.json({ ok: false, error: "admin missing email claim" }, { status: 500 });
+  }
+
+  try {
+    await resume({
+      scope: body.scope as PauseScope,
+      reason: typeof body.reason === "string" ? body.reason : undefined,
+      actorUserId: admin.uid,
+      actorEmail: admin.email,
+    });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+});

--- a/src/app/api/cron/email/auto-resume/route.ts
+++ b/src/app/api/cron/email/auto-resume/route.ts
@@ -1,0 +1,65 @@
+/**
+ * /api/cron/email/auto-resume
+ *
+ * Runs every 5 minutes. Reads `email_pause_state` for any rows where
+ * `is_paused = true` AND `paused_until < now()`, then calls `autoResume()`
+ * on each — which writes an `auto_resume` audit row, clears the pause flag,
+ * and resolves any persistent rail notifications for that scope.
+ *
+ * Auth: Bearer ${CRON_SECRET}.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import { autoResume, type PauseScope } from "@/lib/email/pause";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json(
+      { ok: false, error: "CRON_SECRET not configured" },
+      { status: 500 }
+    );
+  }
+  if (req.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const supabase = getServiceRoleClient();
+  const nowIso = new Date().toISOString();
+
+  const { data: expired, error } = await supabase
+    .from("email_pause_state")
+    .select("scope")
+    .eq("is_paused", true)
+    .not("paused_until", "is", null)
+    .lt("paused_until", nowIso);
+
+  if (error) {
+    console.error("[auto-resume] read failed:", error);
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+
+  const resumed: string[] = [];
+  const failures: { scope: string; error: string }[] = [];
+
+  for (const row of expired ?? []) {
+    try {
+      await autoResume(row.scope as PauseScope);
+      resumed.push(row.scope);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error("[auto-resume]", row.scope, msg);
+      failures.push({ scope: row.scope, error: msg });
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    checked: (expired ?? []).length,
+    resumed,
+    failures,
+  });
+}

--- a/src/app/api/cron/email/worker/route.ts
+++ b/src/app/api/cron/email/worker/route.ts
@@ -178,6 +178,13 @@ export async function GET(request: NextRequest) {
         });
         tally(job.campaign_id).skipped++;
         totalSkipped++;
+      } else if (result.status === "paused_skipped") {
+        // Killswitch fired between the campaign-pause batch read and this
+        // dispatch (eg. global pause flipped on, or a bucket pause matched
+        // this kind). Pause is reversible — leave the job pending so it's
+        // reconsidered next minute. The email_log row already records the
+        // paused_skipped attempt with the resolving scope.
+        await db.from("email_jobs").update({ status: "pending" }).eq("id", job.id);
       } else {
         await db
           .from("email_jobs")

--- a/src/app/api/cron/email/worker/route.ts
+++ b/src/app/api/cron/email/worker/route.ts
@@ -15,6 +15,7 @@ import { getServiceRoleClient } from "@/lib/supabase/server-client";
 import { completeCampaignIfDone } from "@/lib/email/campaigns";
 import { bootstrapCampaignTemplates } from "@/lib/email/campaign-templates-bootstrap";
 import { getCampaignTemplate } from "@/lib/email/campaign-templates";
+import { getPauseState, type PauseScope } from "@/lib/email/pause";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -82,6 +83,17 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  // PR 4 — campaign-scope killswitch. For every campaign in this batch,
+  // resolve whether `email_pause_state` has an active `campaign:<uuid>`
+  // pause. We check once per campaign (not per job) to keep this fast.
+  // Paused jobs stay in 'pending' so they're reconsidered next minute —
+  // pauses are reversible, so we never flip them to a terminal status here.
+  const campaignPauseMap = new Map<string, boolean>();
+  for (const cid of campaignIds) {
+    const ps = await getPauseState(`campaign:${cid}` as PauseScope);
+    campaignPauseMap.set(cid, !!ps?.isPaused);
+  }
+
   // Per-campaign tallies for notification body.
   const tallies = new Map<
     string,
@@ -108,12 +120,15 @@ export async function GET(request: NextRequest) {
     const campaign = campaignMap.get(job.campaign_id);
 
     // Campaign was paused or cancelled while this batch was claimed —
-    // re-pend (paused) or finalise as cancelled (cancelled). Pause logic
-    // hardens in PR 4 with the killswitch state machine.
+    // re-pend (paused) or finalise as cancelled (cancelled). PR 4 adds the
+    // `email_pause_state` killswitch as an additional pause source — the
+    // operator can pause a campaign without touching `email_campaigns.send_status`.
+    const killswitchPaused = campaignPauseMap.get(job.campaign_id) === true;
     if (
       !campaign ||
       campaign.send_status === "paused" ||
-      campaign.send_status === "cancelled"
+      campaign.send_status === "cancelled" ||
+      killswitchPaused
     ) {
       await db
         .from("email_jobs")

--- a/src/lib/email/pause.ts
+++ b/src/lib/email/pause.ts
@@ -1,0 +1,386 @@
+/**
+ * Email Killswitch — Pause Service
+ *
+ * Single API surface for pause / resume across three scopes:
+ *
+ *   global                — hard stop, all email
+ *   bucket:<name>         — pause one sender bucket (DISPATCH / GATE / FIELD_NOTES / PORTAL)
+ *   campaign:<uuid>       — pause an individual campaign
+ *
+ * Reads NEVER throw — gatedSend reads on every call and a transient DB
+ * failure must not crash a send. Writes throw on error so the admin route
+ * surfaces the failure to the operator.
+ */
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import { getAdminEmails } from "@/lib/admin/admin-queries";
+
+export type BucketName = "dispatch" | "gate" | "field_notes" | "portal";
+
+export type PauseScope =
+  | "global"
+  | `bucket:${BucketName}`
+  | `campaign:${string}`;
+
+export interface PauseState {
+  scope: PauseScope;
+  isPaused: boolean;
+  pauseReason: string | null;
+  pausedUntil: string | null;
+  pausedAt: string | null;
+  pausedBy: string | null;
+}
+
+const READ_FAIL_LOG_PREFIX = "[email-pause] read failure";
+
+/**
+ * Resolve which sender bucket an email kind routes to. Used by the
+ * chokepoint to decide which `bucket:<name>` pause to consult.
+ *
+ * Keep in lockstep with src/lib/email/senders.ts. The default bucket is
+ * DISPATCH so any unmapped kind still gets some pause coverage.
+ */
+export function resolveEmailBucket(kind: string): BucketName {
+  switch (kind) {
+    case "password_reset":
+    case "email_verification":
+    case "email_change_confirmation":
+      return "gate";
+    case "field_notes_newsletter":
+    case "blog_newsletter":
+      return "field_notes";
+    case "portal_estimate_ready":
+    case "portal_invoice_ready":
+    case "portal_magic_link":
+    case "portal_questions_reminder":
+      return "portal";
+    default:
+      return "dispatch";
+  }
+}
+
+function rowToState(r: {
+  scope: string;
+  is_paused: boolean;
+  pause_reason: string | null;
+  paused_until: string | null;
+  paused_at: string | null;
+  paused_by: string | null;
+}): PauseState {
+  return {
+    scope: r.scope as PauseScope,
+    isPaused: r.is_paused,
+    pauseReason: r.pause_reason,
+    pausedUntil: r.paused_until,
+    pausedAt: r.paused_at,
+    pausedBy: r.paused_by,
+  };
+}
+
+/** Read every active pause row. Used by the banner. NEVER throws. */
+export async function getActivePauses(): Promise<PauseState[]> {
+  try {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("email_pause_state")
+      .select("scope, is_paused, pause_reason, paused_until, paused_at, paused_by")
+      .eq("is_paused", true)
+      .order("paused_at", { ascending: false });
+    if (error) {
+      console.error(READ_FAIL_LOG_PREFIX, error);
+      return [];
+    }
+    return (data ?? []).map(rowToState);
+  } catch (err) {
+    console.error(READ_FAIL_LOG_PREFIX, err);
+    return [];
+  }
+}
+
+/** Read a single scope's pause state. NEVER throws. */
+export async function getPauseState(scope: PauseScope): Promise<PauseState | null> {
+  try {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("email_pause_state")
+      .select("scope, is_paused, pause_reason, paused_until, paused_at, paused_by")
+      .eq("scope", scope)
+      .maybeSingle();
+    if (error) {
+      console.error(READ_FAIL_LOG_PREFIX, error);
+      return null;
+    }
+    if (!data) return null;
+    return rowToState(data);
+  } catch (err) {
+    console.error(READ_FAIL_LOG_PREFIX, err);
+    return null;
+  }
+}
+
+/**
+ * Resolve the FIRST active pause scope that applies to a given send.
+ * Order: global → bucket → campaign. Returns null if no active pause.
+ *
+ * Used by gatedSend before the suppression check.
+ *
+ * NEVER throws — read failures fail open (no pause). Trade-off: if Supabase
+ * is unreachable we'd rather send than block. Audit log records any send
+ * during a misconfigured-state window.
+ */
+export async function getActivePauseScope(opts: {
+  kind: string;
+  campaignId?: string | null;
+}): Promise<PauseState | null> {
+  const bucket = resolveEmailBucket(opts.kind);
+  const scopesToCheck: PauseScope[] = ["global", `bucket:${bucket}`];
+  if (opts.campaignId) {
+    scopesToCheck.push(`campaign:${opts.campaignId}` as PauseScope);
+  }
+
+  try {
+    const supabase = getServiceRoleClient();
+    const { data, error } = await supabase
+      .from("email_pause_state")
+      .select("scope, is_paused, pause_reason, paused_until, paused_at, paused_by")
+      .in("scope", scopesToCheck)
+      .eq("is_paused", true);
+    if (error) {
+      console.error(READ_FAIL_LOG_PREFIX, error);
+      return null;
+    }
+    if (!data || data.length === 0) return null;
+
+    const now = Date.now();
+    // Pick by resolution order: first matching scope in [global, bucket, campaign].
+    // Skip rows whose paused_until is in the past — auto-resume cron will write
+    // the audit row eventually but the send should not be blocked in the meantime.
+    for (const s of scopesToCheck) {
+      const row = data.find((r) => r.scope === s);
+      if (!row) continue;
+      if (row.paused_until && new Date(row.paused_until).getTime() < now) {
+        continue;
+      }
+      return rowToState(row);
+    }
+    return null;
+  } catch (err) {
+    console.error(READ_FAIL_LOG_PREFIX, err);
+    return null;
+  }
+}
+
+export async function isPaused(opts: { kind: string; campaignId?: string | null }): Promise<boolean> {
+  return (await getActivePauseScope(opts)) !== null;
+}
+
+interface PauseInput {
+  scope: PauseScope;
+  reason: string;
+  pausedUntil?: string | null;
+  actorUserId: string;
+  actorEmail: string;
+}
+
+export async function pause(input: PauseInput): Promise<PauseState> {
+  if (!input.reason || input.reason.trim().length < 3) {
+    throw new Error("Pause requires a reason (>= 3 chars)");
+  }
+  const supabase = getServiceRoleClient();
+  const now = new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from("email_pause_state")
+    .upsert(
+      {
+        scope: input.scope,
+        is_paused: true,
+        pause_reason: input.reason,
+        paused_until: input.pausedUntil ?? null,
+        paused_at: now,
+        paused_by: input.actorUserId,
+        resumed_at: null,
+        resumed_by: null,
+        updated_at: now,
+      },
+      { onConflict: "scope" }
+    )
+    .select("scope, is_paused, pause_reason, paused_until, paused_at, paused_by")
+    .single();
+
+  if (error) throw new Error(`Pause failed: ${error.message}`);
+
+  await supabase.from("email_pause_audit_log").insert({
+    scope: input.scope,
+    action: "pause",
+    reason: input.reason,
+    paused_until: input.pausedUntil ?? null,
+    actor_user_id: input.actorUserId,
+    actor_email: input.actorEmail,
+  });
+
+  await fanoutPauseNotifications({
+    scope: input.scope,
+    reason: input.reason,
+    actorEmail: input.actorEmail,
+  });
+
+  return rowToState(data);
+}
+
+interface ResumeInput {
+  scope: PauseScope;
+  reason?: string;
+  actorUserId: string;
+  actorEmail: string;
+}
+
+export async function resume(input: ResumeInput): Promise<void> {
+  const supabase = getServiceRoleClient();
+  const now = new Date().toISOString();
+  const { error } = await supabase
+    .from("email_pause_state")
+    .update({
+      is_paused: false,
+      resumed_at: now,
+      resumed_by: input.actorUserId,
+      updated_at: now,
+    })
+    .eq("scope", input.scope);
+  if (error) throw new Error(`Resume failed: ${error.message}`);
+
+  await supabase.from("email_pause_audit_log").insert({
+    scope: input.scope,
+    action: "resume",
+    reason: input.reason ?? null,
+    actor_user_id: input.actorUserId,
+    actor_email: input.actorEmail,
+  });
+
+  await resolvePauseNotifications(input.scope);
+}
+
+/**
+ * Mark a scope as auto-resumed when its `paused_until` has passed.
+ * Called by the email-pause-auto-resume cron.
+ */
+export async function autoResume(scope: PauseScope): Promise<void> {
+  const supabase = getServiceRoleClient();
+  const now = new Date().toISOString();
+  const { error } = await supabase
+    .from("email_pause_state")
+    .update({ is_paused: false, resumed_at: now, updated_at: now })
+    .eq("scope", scope)
+    .eq("is_paused", true);
+  if (error) throw new Error(`Auto-resume failed: ${error.message}`);
+
+  await supabase.from("email_pause_audit_log").insert({
+    scope,
+    action: "auto_resume",
+    reason: "paused_until elapsed",
+  });
+
+  await resolvePauseNotifications(scope);
+}
+
+export interface AuditLogRow {
+  id: string;
+  scope: string;
+  action: "pause" | "resume" | "auto_resume";
+  reason: string | null;
+  paused_until: string | null;
+  actor_email: string | null;
+  created_at: string;
+}
+
+export async function listAuditLog(
+  opts: { scope?: PauseScope; limit?: number; offset?: number } = {}
+): Promise<AuditLogRow[]> {
+  const supabase = getServiceRoleClient();
+  const limit = opts.limit ?? 50;
+  const offset = opts.offset ?? 0;
+  let q = supabase
+    .from("email_pause_audit_log")
+    .select("id, scope, action, reason, paused_until, actor_email, created_at")
+    .order("created_at", { ascending: false });
+  if (opts.scope) q = q.eq("scope", opts.scope);
+  q = q.range(offset, offset + limit - 1);
+  const { data, error } = await q;
+  if (error) throw new Error(`Audit log read failed: ${error.message}`);
+  return (data ?? []) as AuditLogRow[];
+}
+
+// ─── Rail notifications ────────────────────────────────────────────────────
+
+const PAUSE_NOTIFICATION_TYPE = "email_pause";
+
+/**
+ * Insert a persistent rail notification for every admin when a pause is
+ * applied. We resolve admin user rows by joining `admins.email` to
+ * `users.email`. Admins without a matching `users` row are skipped silently
+ * (notifications.user_id is NOT NULL).
+ */
+async function fanoutPauseNotifications(input: {
+  scope: PauseScope;
+  reason: string;
+  actorEmail: string;
+}): Promise<void> {
+  try {
+    const supabase = getServiceRoleClient();
+    const adminEmails = await getAdminEmails();
+    if (adminEmails.length === 0) return;
+
+    const { data: adminUsers, error: lookupErr } = await supabase
+      .from("users")
+      .select("id, company_id, email")
+      .in("email", adminEmails);
+    if (lookupErr) {
+      console.error("[email-pause] admin user lookup failed:", lookupErr);
+      return;
+    }
+    const recipients = (adminUsers ?? []).filter((u) => u.id && u.company_id);
+    if (recipients.length === 0) return;
+
+    const title = `Email paused: ${input.scope}`;
+    const body = `Reason: ${input.reason}. Paused by ${input.actorEmail}.`;
+    const rows = recipients.map((u) => ({
+      user_id: u.id,
+      company_id: u.company_id,
+      type: PAUSE_NOTIFICATION_TYPE,
+      title,
+      body,
+      is_read: false,
+      persistent: true,
+      action_url: "/admin/email?tab=killswitches",
+      action_label: "MANAGE",
+    }));
+    const { error: insertErr } = await supabase.from("notifications").insert(rows);
+    if (insertErr) {
+      console.error("[email-pause] notification insert failed:", insertErr);
+    }
+  } catch (err) {
+    // Notifications are best-effort — never throw out of a pause operation.
+    console.error("[email-pause] fanout failed:", err);
+  }
+}
+
+/**
+ * Mark every persistent pause notification for a scope as read.
+ * Called from resume() and autoResume().
+ */
+async function resolvePauseNotifications(scope: PauseScope): Promise<void> {
+  try {
+    const supabase = getServiceRoleClient();
+    const titleFragment = `Email paused: ${scope}`;
+    const { error } = await supabase
+      .from("notifications")
+      .update({ is_read: true })
+      .eq("type", PAUSE_NOTIFICATION_TYPE)
+      .eq("title", titleFragment)
+      .eq("is_read", false);
+    if (error) {
+      console.error("[email-pause] notification resolve failed:", error);
+    }
+  } catch (err) {
+    console.error("[email-pause] resolve failed:", err);
+  }
+}

--- a/src/lib/email/sendgrid.tsx
+++ b/src/lib/email/sendgrid.tsx
@@ -50,6 +50,7 @@ import { PortalQuestionsReminder } from "./react/templates/PortalQuestionsRemind
 import { DISPATCH, GATE, FIELD_NOTES, portalSender, type Sender } from "./senders";
 import type { AdBriefing } from "@/lib/admin/briefing-types";
 import { isSuppressed, filterSuppressed } from "./suppressions";
+import { getActivePauseScope } from "./pause";
 import { getServiceRoleClient } from "@/lib/supabase/server-client";
 import { buildUnsubscribeUrl } from "./unsubscribe-token";
 import { KIND_TO_LIST, OPS_SUPPORT_EMAIL } from "./constants";
@@ -101,7 +102,8 @@ function buildComplianceHeaders(opts: { email: string; kind: string }): {
  */
 export type GatedSendResult =
   | { status: "sent"; messageId: string | null }
-  | { status: "suppression_skipped"; reason: "suppressed" };
+  | { status: "suppression_skipped"; reason: "suppressed" }
+  | { status: "paused_skipped"; scope: string };
 
 /**
  * Single-recipient send chokepoint. Every typed sendXxx function below
@@ -142,6 +144,32 @@ async function gatedSend(params: {
 
   const list =
     params.list ?? (KIND_TO_LIST[params.emailType] ?? "global");
+
+  // 1) PAUSE CHECK FIRST — operator killswitch trumps everything, including
+  // suppressions. A paused send writes email_log.status='paused_skipped' and
+  // never calls SendGrid. Pauses are reversible; suppressions are not, so we
+  // want pauses to short-circuit the suppression check.
+  const activePause = await getActivePauseScope({
+    kind: params.emailType,
+    campaignId: params.campaignId ?? null,
+  });
+  if (activePause) {
+    await logEmail({
+      emailType: params.emailType,
+      recipient: lower,
+      subject: params.subject,
+      status: "paused_skipped",
+      metadata: {
+        ...(params.metadata ?? {}),
+        list,
+        pause_scope: activePause.scope,
+        pause_reason: activePause.pauseReason,
+      },
+      userId: params.userId,
+      campaignId: params.campaignId ?? null,
+    });
+    return { status: "paused_skipped", scope: activePause.scope };
+  }
 
   if (await isSuppressed(lower, list)) {
     await logEmail({
@@ -206,7 +234,7 @@ async function logEmail(params: {
   emailType: string;
   recipient: string;
   subject: string;
-  status: "sent" | "failed" | "suppression_skipped";
+  status: "sent" | "failed" | "suppression_skipped" | "paused_skipped";
   metadata?: Record<string, unknown>;
   userId?: string;
   errorMessage?: string;

--- a/src/lib/utils/motion.ts
+++ b/src/lib/utils/motion.ts
@@ -505,3 +505,25 @@ export const counterVariantsReduced: Variants = {
   hidden: { opacity: 0 },
   visible: { opacity: 1, transition: { duration: 0.15 } },
 };
+
+// ── PR 4 — Email killswitches ──
+// Switch toggle, sticky pause banner, and confirmation modal.
+// All consumers must respect useReducedMotion() — pass `undefined` variants
+// when reduced is true so framer-motion skips the transition.
+
+export const switchToggleVariants: Variants = {
+  off: { x: 0, transition: { duration: 0.22, ease: EASE_SMOOTH } },
+  on: { x: 18, transition: { duration: 0.22, ease: EASE_SMOOTH } },
+};
+
+export const activePauseBannerVariants: Variants = {
+  initial: { opacity: 0, y: -8 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.28, ease: EASE_SMOOTH } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.18, ease: EASE_SMOOTH } },
+};
+
+export const confirmationModalVariants: Variants = {
+  initial: { opacity: 0, scale: 0.96 },
+  animate: { opacity: 1, scale: 1, transition: { duration: 0.24, ease: EASE_SMOOTH } },
+  exit: { opacity: 0, scale: 0.96, transition: { duration: 0.16, ease: EASE_SMOOTH } },
+};

--- a/supabase/migrations/092_email_pause_state.sql
+++ b/supabase/migrations/092_email_pause_state.sql
@@ -1,0 +1,47 @@
+-- 092_email_pause_state.sql
+-- PR 4: Email killswitches.
+--
+-- Live pause state. One row per scope. The chokepoint reads from this table
+-- on every send. Three scope shapes:
+--
+--   'global'                                       — hard stop, all email
+--   'bucket:dispatch' / 'bucket:gate' / 'bucket:field_notes' / 'bucket:portal'
+--   'campaign:<uuid>'                              — paused individual campaign
+--
+-- Resolution order in gatedSend: global → bucket → campaign.
+
+CREATE TABLE IF NOT EXISTS public.email_pause_state (
+  scope text PRIMARY KEY,
+  is_paused boolean NOT NULL DEFAULT false,
+  pause_reason text,
+  paused_until timestamptz,
+  paused_at timestamptz,
+  paused_by uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  resumed_at timestamptz,
+  resumed_by uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT email_pause_state_scope_check CHECK (
+    scope = 'global'
+    OR scope IN ('bucket:dispatch', 'bucket:gate', 'bucket:field_notes', 'bucket:portal')
+    OR scope ~ '^campaign:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  )
+);
+
+-- Partial index — most rows are not paused; we want a fast path for
+-- "list all active pauses" used by the banner.
+CREATE INDEX IF NOT EXISTS idx_email_pause_state_active
+  ON public.email_pause_state (scope)
+  WHERE is_paused = true;
+
+-- Seed the global row so the chokepoint always has something to read.
+INSERT INTO public.email_pause_state (scope, is_paused)
+VALUES ('global', false)
+ON CONFLICT (scope) DO NOTHING;
+
+COMMENT ON TABLE public.email_pause_state IS
+  'Per-scope pause state. Read by gatedSend before every send. Single row per scope.';
+COMMENT ON COLUMN public.email_pause_state.scope IS
+  'global | bucket:<name> | campaign:<uuid>. The chokepoint resolves the active scope for a given send by checking global -> bucket -> campaign in order.';
+COMMENT ON COLUMN public.email_pause_state.paused_until IS
+  'Auto-resume time. Set to NULL for indefinite pause. Crons / send paths auto-resume when now() > paused_until.';

--- a/supabase/migrations/093_email_pause_audit_log.sql
+++ b/supabase/migrations/093_email_pause_audit_log.sql
@@ -1,0 +1,36 @@
+-- 093_email_pause_audit_log.sql
+-- PR 4: Email killswitches.
+--
+-- Append-only audit log. Every pause / resume / auto-resume writes a row.
+-- This is the legal record — never modify rows, never delete.
+
+CREATE TABLE IF NOT EXISTS public.email_pause_audit_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope text NOT NULL,
+  action text NOT NULL,
+  reason text,
+  paused_until timestamptz,
+  actor_user_id uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  actor_email text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT email_pause_audit_log_action_check
+    CHECK (action IN ('pause', 'resume', 'auto_resume'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_pause_audit_log_created_at
+  ON public.email_pause_audit_log (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_email_pause_audit_log_scope
+  ON public.email_pause_audit_log (scope, created_at DESC);
+
+-- Defense in depth: revoke UPDATE and DELETE from authenticated/anon roles.
+-- Service role bypasses these.
+REVOKE UPDATE, DELETE ON public.email_pause_audit_log FROM anon, authenticated;
+
+COMMENT ON TABLE public.email_pause_audit_log IS
+  'Immutable append-only audit log of every pause/resume action. Inserts only — UPDATE and DELETE revoked from non-service roles.';
+COMMENT ON COLUMN public.email_pause_audit_log.action IS
+  'pause | resume | auto_resume. auto_resume is written by the cron when now() > paused_until.';
+COMMENT ON COLUMN public.email_pause_audit_log.actor_email IS
+  'Email of the actor at the time of action — denormalized so the audit row remains readable even if the user is deleted.';

--- a/supabase/migrations/094_email_log_status_paused_skipped.sql
+++ b/supabase/migrations/094_email_log_status_paused_skipped.sql
@@ -1,0 +1,11 @@
+-- 094_email_log_status_paused_skipped.sql
+-- PR 4: Email killswitches.
+--
+-- Documents the status='paused_skipped' value introduced by gatedSend in PR 4.
+-- email_log.status is freeform text; this comment records the canonical values.
+
+COMMENT ON COLUMN public.email_log.status IS
+  'Canonical values: sent | suppression_skipped | paused_skipped | failed. ' ||
+  'paused_skipped: gatedSend short-circuited because email_pause_state had a matching active scope. ' ||
+  'suppression_skipped: gatedSend short-circuited because email_suppressions had a matching row. ' ||
+  'failed: SendGrid returned an error after sending was attempted.';

--- a/tests/integration/email-pause-routes.test.ts
+++ b/tests/integration/email-pause-routes.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Integration tests for the three admin pause routes.
+ * Stubs `withAdmin`/`requireAdmin` and the pause service layer.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { pauseSpy, resumeSpy, getActivePausesSpy, listAuditLogSpy } = vi.hoisted(
+  () => ({
+    pauseSpy: vi.fn(),
+    resumeSpy: vi.fn(),
+    getActivePausesSpy: vi.fn(),
+    listAuditLogSpy: vi.fn(),
+  })
+);
+
+vi.mock("@/lib/admin/api-auth", () => ({
+  withAdmin: (handler: unknown) => handler,
+  requireAdmin: vi.fn(async () => ({
+    uid: "admin-uuid",
+    email: "ops@opsapp.co",
+    claims: {},
+  })),
+}));
+
+vi.mock("@/lib/email/pause", () => ({
+  pause: (...a: unknown[]) => pauseSpy(...a),
+  resume: (...a: unknown[]) => resumeSpy(...a),
+  getActivePauses: () => getActivePausesSpy(),
+  listAuditLog: (...a: unknown[]) => listAuditLogSpy(...a),
+}));
+
+import { POST as pausePost } from "@/app/api/admin/email/pause/route";
+import { POST as resumePost } from "@/app/api/admin/email/resume/route";
+import { GET as pausesGet } from "@/app/api/admin/email/pauses/route";
+
+beforeEach(() => {
+  pauseSpy.mockReset();
+  resumeSpy.mockReset();
+  getActivePausesSpy.mockReset();
+  listAuditLogSpy.mockReset();
+  pauseSpy.mockResolvedValue({
+    scope: "global",
+    isPaused: true,
+    pauseReason: "ok",
+    pausedUntil: null,
+    pausedAt: new Date().toISOString(),
+    pausedBy: "admin-uuid",
+  });
+  resumeSpy.mockResolvedValue(undefined);
+  getActivePausesSpy.mockResolvedValue([]);
+  listAuditLogSpy.mockResolvedValue([]);
+});
+
+function postReq(body: unknown): NextRequest {
+  return new NextRequest("https://example.com/x", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function getReq(url: string): NextRequest {
+  return new NextRequest(url);
+}
+
+describe("POST /api/admin/email/pause", () => {
+  it("400 when reason missing", async () => {
+    const r = await pausePost(postReq({ scope: "global" }));
+    expect(r.status).toBe(400);
+    expect(pauseSpy).not.toHaveBeenCalled();
+  });
+
+  it("400 when reason too short", async () => {
+    const r = await pausePost(postReq({ scope: "global", reason: "ab" }));
+    expect(r.status).toBe(400);
+    expect(pauseSpy).not.toHaveBeenCalled();
+  });
+
+  it("400 when scope is invalid", async () => {
+    const r = await pausePost(
+      postReq({ scope: "bucket:typo", reason: "ok reason" })
+    );
+    expect(r.status).toBe(400);
+    expect(pauseSpy).not.toHaveBeenCalled();
+  });
+
+  it("400 when paused_until is malformed", async () => {
+    const r = await pausePost(
+      postReq({ scope: "global", reason: "ok reason", paused_until: "garbage" })
+    );
+    expect(r.status).toBe(400);
+    expect(pauseSpy).not.toHaveBeenCalled();
+  });
+
+  it("200 with valid input — calls pause()", async () => {
+    const r = await pausePost(
+      postReq({ scope: "global", reason: "test reason long enough" })
+    );
+    expect(r.status).toBe(200);
+    expect(pauseSpy).toHaveBeenCalledOnce();
+    expect(pauseSpy.mock.calls[0][0]).toMatchObject({
+      scope: "global",
+      reason: "test reason long enough",
+      actorUserId: "admin-uuid",
+      actorEmail: "ops@opsapp.co",
+    });
+  });
+
+  it("accepts bucket scope", async () => {
+    const r = await pausePost(
+      postReq({ scope: "bucket:gate", reason: "DNS misalign" })
+    );
+    expect(r.status).toBe(200);
+    expect(pauseSpy).toHaveBeenCalledOnce();
+  });
+
+  it("accepts campaign scope with valid UUID", async () => {
+    const r = await pausePost(
+      postReq({
+        scope: "campaign:11111111-2222-3333-4444-555555555555",
+        reason: "operator stopped this one",
+      })
+    );
+    expect(r.status).toBe(200);
+  });
+});
+
+describe("POST /api/admin/email/resume", () => {
+  it("400 when scope missing", async () => {
+    const r = await resumePost(postReq({}));
+    expect(r.status).toBe(400);
+    expect(resumeSpy).not.toHaveBeenCalled();
+  });
+
+  it("400 when scope invalid", async () => {
+    const r = await resumePost(postReq({ scope: "fleet:bad" }));
+    expect(r.status).toBe(400);
+    expect(resumeSpy).not.toHaveBeenCalled();
+  });
+
+  it("200 calls resume() with admin context", async () => {
+    const r = await resumePost(postReq({ scope: "bucket:dispatch" }));
+    expect(r.status).toBe(200);
+    expect(resumeSpy).toHaveBeenCalledOnce();
+    expect(resumeSpy.mock.calls[0][0]).toMatchObject({
+      scope: "bucket:dispatch",
+      actorUserId: "admin-uuid",
+      actorEmail: "ops@opsapp.co",
+    });
+  });
+});
+
+describe("GET /api/admin/email/pauses", () => {
+  it("returns active pauses without audit by default", async () => {
+    getActivePausesSpy.mockResolvedValue([
+      {
+        scope: "global",
+        isPaused: true,
+        pauseReason: "test",
+        pausedUntil: null,
+        pausedAt: null,
+        pausedBy: null,
+      },
+    ]);
+    const r = await pausesGet(getReq("https://example.com/api/admin/email/pauses"));
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.ok).toBe(true);
+    expect(body.active).toHaveLength(1);
+    expect(body.audit).toBeNull();
+    expect(listAuditLogSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns audit log when ?audit=1", async () => {
+    listAuditLogSpy.mockResolvedValue([
+      {
+        id: "x",
+        scope: "global",
+        action: "pause",
+        reason: "y",
+        paused_until: null,
+        actor_email: "ops@opsapp.co",
+        created_at: new Date().toISOString(),
+      },
+    ]);
+    const r = await pausesGet(
+      getReq("https://example.com/api/admin/email/pauses?audit=1")
+    );
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.audit).toHaveLength(1);
+    expect(listAuditLogSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/email/killswitches-tab.test.tsx
+++ b/tests/unit/email/killswitches-tab.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * KillswitchesTab — basic render test. Confirms the three required
+ * sections appear and the global switch starts in the "off" position.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { KillswitchesTab } from "@/app/admin/email/_components/killswitches-tab";
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, active: [] }),
+    })
+  );
+});
+
+function renderTab() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <KillswitchesTab />
+    </QueryClientProvider>
+  );
+}
+
+describe("KillswitchesTab", () => {
+  it("renders global, sender bucket, and campaigns sections", () => {
+    renderTab();
+    expect(screen.getByText("// GLOBAL")).toBeTruthy();
+    expect(screen.getByText("// SENDER BUCKETS")).toBeTruthy();
+    expect(screen.getByText("// CAMPAIGNS")).toBeTruthy();
+  });
+
+  it("renders all four bucket switches", () => {
+    renderTab();
+    expect(screen.getByText("DISPATCH")).toBeTruthy();
+    expect(screen.getByText("GATE")).toBeTruthy();
+    expect(screen.getByText("FIELD_NOTES")).toBeTruthy();
+    expect(screen.getByText("PORTAL")).toBeTruthy();
+  });
+
+  it("global switch is off (aria-checked=false) when no active pauses", () => {
+    renderTab();
+    const switches = screen.getAllByRole("switch");
+    expect(switches.length).toBe(5); // global + 4 buckets
+    for (const s of switches) {
+      expect(s.getAttribute("aria-checked")).toBe("false");
+    }
+  });
+});

--- a/tests/unit/email/pause.test.ts
+++ b/tests/unit/email/pause.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Unit tests for src/lib/email/pause.ts.
+ *
+ * The bucket resolver has zero dependencies and is pure — perfect candidate
+ * for unit coverage. Read/write paths are exercised in the integration test
+ * for the admin routes (which mocks the service layer).
+ */
+import { describe, it, expect } from "vitest";
+import { resolveEmailBucket } from "@/lib/email/pause";
+
+describe("resolveEmailBucket", () => {
+  it("routes auth kinds to gate", () => {
+    expect(resolveEmailBucket("password_reset")).toBe("gate");
+    expect(resolveEmailBucket("email_verification")).toBe("gate");
+    expect(resolveEmailBucket("email_change_confirmation")).toBe("gate");
+  });
+
+  it("routes newsletter kinds to field_notes", () => {
+    expect(resolveEmailBucket("blog_newsletter")).toBe("field_notes");
+    expect(resolveEmailBucket("field_notes_newsletter")).toBe("field_notes");
+  });
+
+  it("routes portal kinds to portal", () => {
+    expect(resolveEmailBucket("portal_magic_link")).toBe("portal");
+    expect(resolveEmailBucket("portal_invoice_ready")).toBe("portal");
+    expect(resolveEmailBucket("portal_estimate_ready")).toBe("portal");
+    expect(resolveEmailBucket("portal_questions_reminder")).toBe("portal");
+  });
+
+  it("defaults unknown / product / billing kinds to dispatch", () => {
+    expect(resolveEmailBucket("trial_expiry_warning")).toBe("dispatch");
+    expect(resolveEmailBucket("ads_briefing")).toBe("dispatch");
+    expect(resolveEmailBucket("unmapped_kind_xyz")).toBe("dispatch");
+    expect(resolveEmailBucket("")).toBe("dispatch");
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -130,6 +130,10 @@
     {
       "path": "/api/cron/email/worker",
       "schedule": "*/1 * * * *"
+    },
+    {
+      "path": "/api/cron/email/auto-resume",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Operator one-click email shutoff at three scopes — **global**, **sender bucket** (`dispatch` / `gate` / `field_notes` / `portal`), and **per-campaign**. Pause is the first check in `gatedSend`, *before* suppression — so an operator pause stops sends even when suppressions are intentionally bypassed. All actions audit-logged immutably; persistent rail notification fires to every admin on pause and auto-resolves on resume; a 5-minute cron clears any pause whose `paused_until` has elapsed and writes an `auto_resume` audit row.

## What's in here

- 3 migrations (renumbered 092-094 — 091 was taken by PR 3's email_jobs unique constraint)
  - \`email_pause_state\` (one row per scope; CHECK constraint on scope grammar)
  - \`email_pause_audit_log\` (append-only, UPDATE/DELETE revoked from non-service)
  - \`email_log.status\` comment documenting \`paused_skipped\`
- \`src/lib/email/pause.ts\` — service module. Reads NEVER throw; writes throw; \`getActivePauseScope\` resolves global → bucket → campaign in order, skipping past-due \`paused_until\` rows.
- \`gatedSend\` (\`src/lib/email/sendgrid.tsx\`) — pause check FIRST, then suppression. New \`paused_skipped\` variant on \`GatedSendResult\` and \`logEmail.status\`.
- Email worker (\`/api/cron/email/worker\`) — batch-fetches \`campaign:<uuid>\` pauses; paused jobs stay in \`pending\`. Worker also handles the \`paused_skipped\` race where a global/bucket pause flips on mid-batch.
- 3 admin API routes — \`POST /api/admin/email/pause\`, \`POST /api/admin/email/resume\`, \`GET /api/admin/email/pauses?audit=1\`. All \`withAdmin\` + \`requireAdmin\`. Reason is mandatory (≥ 3 chars), scope is regex-validated.
- Auto-resume cron at \`/api/cron/email/auto-resume\`, registered every 5 min in \`vercel.json\`.
- UI: 8th \`Killswitches\` tab on \`/admin/email\`, sticky \`ActivePauseBanner\` shown across SubTabs whenever any scope is paused. \`PauseConfirmationModal\` (z-3000) requires reason and offers Indefinite / 1h / 24h auto-resume. Olive \`#9DB582\` border + tan \`#C4A868\` eyebrow on the banner — never red.
- Persistent rail notification fires to every admin (looked up via \`admins.email\` → \`users.email\`) on pause; auto-resolves on resume / auto-resume.
- Motion variants in \`src/lib/utils/motion.ts\` — \`switchToggleVariants\`, \`activePauseBannerVariants\`, \`confirmationModalVariants\`. All consumers respect \`useReducedMotion()\`.
- Tests: 19 new tests across 3 files (4 unit pause, 12 integration routes, 3 UI snapshot). Full suite: 708 passed; the 2 baseline-failing suites (auth.test.tsx / projects.test.tsx) are env-only Firebase API key issues unrelated to this PR.
- Bible §14.8 documenting the full system.

## Test plan

- [ ] /admin/email → Killswitches tab loads; toggle Global on with reason "smoke"; sticky banner shows.
- [ ] Trigger a password reset; confirm \`email_log.status='paused_skipped'\`.
- [ ] Toggle Global off; banner disappears.
- [ ] Toggle bucket:gate on with paused_until = now + 1h; manually GET \`/api/cron/email/auto-resume\` after expiry; confirm \`auto_resume\` audit row + state cleared.
- [ ] Confirm persistent notification fires to admin email rail and resolves on resume.

## Notes

- Migrations have been applied to prod Supabase (\`ijeekuhbatykdomumfjx\`).
- 091 numbering was already taken by PR 3 — used 092/093/094 instead.
- Worker now handles 3 \`gatedSend\` outcomes (sent / suppression_skipped / paused_skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)