### PR TITLE
feat(email): PR 6 — Campaign Analytics (Sankey + domain bounce + version compare)

### DIFF
--- a/src/app/admin/email/_components/email-content.tsx
+++ b/src/app/admin/email/_components/email-content.tsx
@@ -10,6 +10,7 @@ import { ScheduleTab } from "./schedule-tab";
 import { ScheduledSendsTab } from "./scheduled-sends-tab";
 import { KillswitchesTab } from "./killswitches-tab";
 import { ActivePauseBanner } from "./active-pause-banner";
+import { CampaignAnalyticsTab } from "@/components/admin/email/campaign-analytics-tab";
 import type {
   EmailOverviewStats,
   EmailEngagementStats,
@@ -33,6 +34,7 @@ export function EmailContent({ overview, engagement, funnels, emailLog, newslett
       <SubTabs
         tabs={[
           "Overview",
+          "Campaign Analytics",
           "Scheduled Sends",
           "Funnels",
           "Email Log",
@@ -44,6 +46,7 @@ export function EmailContent({ overview, engagement, funnels, emailLog, newslett
       >
         {(tab) => {
           if (tab === "Overview") return <OverviewTab stats={overview} engagement={engagement} />;
+          if (tab === "Campaign Analytics") return <CampaignAnalyticsTab />;
           if (tab === "Scheduled Sends") return <ScheduledSendsTab />;
           if (tab === "Funnels") return <FunnelsTab data={funnels} />;
           if (tab === "Email Log") return <EmailLogTab entries={emailLog} />;

--- a/src/app/api/admin/email/campaigns/[id]/engagement/route.ts
+++ b/src/app/api/admin/email/campaigns/[id]/engagement/route.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /api/admin/email/campaigns/[id]/engagement
+ *   Returns aggregated engagement stats + funnel stages for a campaign.
+ *   60s Cache-Control — analytics doesn't need real-time accuracy.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin, withAdmin } from "@/lib/admin/api-auth";
+import {
+  getCampaignEngagementStats,
+  getCampaignFunnelStages,
+} from "@/lib/admin/email-campaign-queries";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET = withAdmin(async (req: NextRequest, ctx: RouteContext) => {
+  await requireAdmin(req);
+  const { id } = await ctx.params;
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json(
+      { ok: false, error: "invalid campaign id" },
+      { status: 400 }
+    );
+  }
+  const [stats, funnel] = await Promise.all([
+    getCampaignEngagementStats(id),
+    getCampaignFunnelStages(id),
+  ]);
+  if (!stats) {
+    return NextResponse.json(
+      { ok: false, error: "campaign not found" },
+      { status: 404 }
+    );
+  }
+  return NextResponse.json(
+    { ok: true, stats, funnel },
+    { headers: { "Cache-Control": "private, max-age=60" } }
+  );
+});

--- a/src/app/api/admin/email/campaigns/route.ts
+++ b/src/app/api/admin/email/campaigns/route.ts
@@ -47,7 +47,8 @@ export const GET = withAdmin(async (req: NextRequest) => {
   const status = parseStatus(sp.get("status"));
   const limit = Math.min(Math.max(Number(sp.get("limit") ?? 50), 1), 200);
   const offset = Math.max(Number(sp.get("offset") ?? 0), 0);
-  const result = await listCampaigns({ status, limit, offset });
+  const includeVersions = sp.get("include_versions") === "1";
+  const result = await listCampaigns({ status, limit, offset, includeVersions });
   return NextResponse.json(result);
 });
 

--- a/src/app/api/admin/email/templates/[type]/versions/compare/route.ts
+++ b/src/app/api/admin/email/templates/[type]/versions/compare/route.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /api/admin/email/templates/[type]/versions/compare?a=1.0.0&b=1.1.0&since=ISO
+ *   Returns side-by-side metrics for two template versions of the same email_type.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin, withAdmin } from "@/lib/admin/api-auth";
+import { getTemplateVersionCompare } from "@/lib/admin/email-campaign-queries";
+
+export const runtime = "nodejs";
+
+type RouteContext = { params: Promise<{ type: string }> };
+
+export const GET = withAdmin(async (req: NextRequest, ctx: RouteContext) => {
+  await requireAdmin(req);
+  const { type } = await ctx.params;
+  const url = new URL(req.url);
+  const a = url.searchParams.get("a");
+  const b = url.searchParams.get("b");
+  const since = url.searchParams.get("since") ?? undefined;
+  if (!a || !b) {
+    return NextResponse.json(
+      { ok: false, error: "a and b query params required" },
+      { status: 400 }
+    );
+  }
+  const result = await getTemplateVersionCompare(type, a, b, since);
+  return NextResponse.json(
+    { ok: true, result },
+    { headers: { "Cache-Control": "private, max-age=60" } }
+  );
+});

--- a/src/components/admin/email/campaign-analytics-tab.tsx
+++ b/src/components/admin/email/campaign-analytics-tab.tsx
@@ -8,15 +8,15 @@ import { CampaignDetailPanel } from "./campaign-detail-panel";
 interface CampaignRow {
   id: string;
   name: string;
-  email_type: string;
-  send_status: string;
-  sent_count: number;
-  delivered_count: number;
-  bounced_count: number;
-  recipient_count_actual: number;
-  template_versions_sent: string[];
-  completed_at: string | null;
-  created_at: string;
+  templateId: string;
+  sendStatus: string;
+  sentCount: number;
+  deliveredCount: number;
+  bouncedCount: number;
+  recipientCountActual: number | null;
+  templateVersionsSent: string[];
+  completedAt: string | null;
+  createdAt: string;
 }
 
 const STATUS_TOKEN: Record<string, string> = {
@@ -58,11 +58,11 @@ export function CampaignAnalyticsTab() {
   });
 
   const filtered = rows
-    .filter((r) => statusFilter === "all" || r.send_status === statusFilter)
+    .filter((r) => statusFilter === "all" || r.sendStatus === statusFilter)
     .sort((a, b) =>
       sortBy === "sent"
-        ? (b.sent_count ?? 0) - (a.sent_count ?? 0)
-        : new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        ? (b.sentCount ?? 0) - (a.sentCount ?? 0)
+        : new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
     );
 
   return (
@@ -102,12 +102,12 @@ export function CampaignAnalyticsTab() {
                     {row.name}
                   </div>
                   <div className="mt-1 font-mono text-[11px] uppercase tracking-[0.14em] text-text-3">
-                    [{row.email_type}]
+                    [{row.templateId}]
                     <span
                       className="ml-3"
-                      style={{ color: STATUS_TOKEN[row.send_status] ?? "var(--text-3)" }}
+                      style={{ color: STATUS_TOKEN[row.sendStatus] ?? "var(--text-3)" }}
                     >
-                      {row.send_status}
+                      {row.sendStatus}
                     </span>
                   </div>
                 </div>
@@ -115,7 +115,7 @@ export function CampaignAnalyticsTab() {
                   className="font-mono text-[14px] text-text-2"
                   style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
                 >
-                  {row.sent_count}/{row.recipient_count_actual}
+                  {row.sentCount}/{row.recipientCountActual ?? "—"}
                 </div>
               </button>
               <AnimatePresence initial={false}>
@@ -133,8 +133,8 @@ export function CampaignAnalyticsTab() {
                     <div className="px-5 py-5">
                       <CampaignDetailPanel
                         campaignId={row.id}
-                        emailType={row.email_type}
-                        templateVersionsSent={row.template_versions_sent}
+                        emailType={row.templateId}
+                        templateVersionsSent={row.templateVersionsSent}
                       />
                     </div>
                   </motion.div>

--- a/src/components/admin/email/campaign-analytics-tab.tsx
+++ b/src/components/admin/email/campaign-analytics-tab.tsx
@@ -145,7 +145,7 @@ export function CampaignAnalyticsTab() {
         })}
         {filtered.length === 0 && (
           <div className="px-5 py-12 text-center font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
-            // NO CAMPAIGNS MATCH FILTERS
+            {"// NO CAMPAIGNS MATCH FILTERS"}
           </div>
         )}
       </div>

--- a/src/components/admin/email/campaign-analytics-tab.tsx
+++ b/src/components/admin/email/campaign-analytics-tab.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { CampaignDetailPanel } from "./campaign-detail-panel";
+
+interface CampaignRow {
+  id: string;
+  name: string;
+  email_type: string;
+  send_status: string;
+  sent_count: number;
+  delivered_count: number;
+  bounced_count: number;
+  recipient_count_actual: number;
+  template_versions_sent: string[];
+  completed_at: string | null;
+  created_at: string;
+}
+
+const STATUS_TOKEN: Record<string, string> = {
+  draft: "var(--text-3)",
+  scheduled: "var(--text-2)",
+  in_flight: "var(--color-ops-accent)",
+  completed: "var(--color-olive)",
+  failed: "var(--color-brick)",
+  cancelled: "var(--text-mute)",
+  paused: "var(--color-tan)",
+};
+
+const ALL_STATUSES = Object.keys(STATUS_TOKEN);
+
+interface ListResponse {
+  rows: CampaignRow[];
+  total: number;
+}
+
+async function fetchCampaigns(): Promise<CampaignRow[]> {
+  const r = await fetch("/api/admin/email/campaigns?include_versions=1&limit=200");
+  if (!r.ok) return [];
+  const j = (await r.json()) as ListResponse;
+  return j.rows ?? [];
+}
+
+const EASE_SMOOTH = [0.22, 1, 0.36, 1] as const;
+
+export function CampaignAnalyticsTab() {
+  const reduced = useReducedMotion();
+  const [openId, setOpenId] = React.useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = React.useState<string>("all");
+  const [sortBy, setSortBy] = React.useState<"created" | "sent">("created");
+
+  const { data: rows = [] } = useQuery({
+    queryKey: ["campaign-analytics-list"],
+    queryFn: fetchCampaigns,
+    refetchInterval: 60_000,
+  });
+
+  const filtered = rows
+    .filter((r) => statusFilter === "all" || r.send_status === statusFilter)
+    .sort((a, b) =>
+      sortBy === "sent"
+        ? (b.sent_count ?? 0) - (a.sent_count ?? 0)
+        : new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="rounded-[5px] border border-glass-border bg-transparent px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-text-2"
+        >
+          <option value="all">all statuses</option>
+          {ALL_STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={() => setSortBy(sortBy === "created" ? "sent" : "created")}
+          className="rounded-[5px] border border-glass-border bg-transparent px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-text-2 hover:bg-surface-hover"
+        >
+          sort: {sortBy === "created" ? "newest" : "most sent"}
+        </button>
+      </div>
+
+      <div className="rounded-panel border border-glass-border">
+        {filtered.map((row) => {
+          const isOpen = openId === row.id;
+          return (
+            <div key={row.id}>
+              <button
+                onClick={() => setOpenId(isOpen ? null : row.id)}
+                className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left hover:bg-surface-hover"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-mohave text-[15px] text-text">
+                    {row.name}
+                  </div>
+                  <div className="mt-1 font-mono text-[11px] uppercase tracking-[0.14em] text-text-3">
+                    [{row.email_type}]
+                    <span
+                      className="ml-3"
+                      style={{ color: STATUS_TOKEN[row.send_status] ?? "var(--text-3)" }}
+                    >
+                      {row.send_status}
+                    </span>
+                  </div>
+                </div>
+                <div
+                  className="font-mono text-[14px] text-text-2"
+                  style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+                >
+                  {row.sent_count}/{row.recipient_count_actual}
+                </div>
+              </button>
+              <AnimatePresence initial={false}>
+                {isOpen && (
+                  <motion.div
+                    initial={reduced ? { opacity: 0 } : { opacity: 0, height: 0 }}
+                    animate={reduced ? { opacity: 1 } : { opacity: 1, height: "auto" }}
+                    exit={reduced ? { opacity: 0 } : { opacity: 0, height: 0 }}
+                    transition={{
+                      duration: reduced ? 0.15 : 0.32,
+                      ease: EASE_SMOOTH,
+                    }}
+                    className="overflow-hidden border-t border-white/[0.06]"
+                  >
+                    <div className="px-5 py-5">
+                      <CampaignDetailPanel
+                        campaignId={row.id}
+                        emailType={row.email_type}
+                        templateVersionsSent={row.template_versions_sent}
+                      />
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          );
+        })}
+        {filtered.length === 0 && (
+          <div className="px-5 py-12 text-center font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
+            // NO CAMPAIGNS MATCH FILTERS
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/email/campaign-detail-panel.tsx
+++ b/src/components/admin/email/campaign-detail-panel.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { motion, useReducedMotion } from "framer-motion";
+import {
+  campaignMetricGridVariants,
+  animatedCountVariants,
+} from "@/lib/utils/motion";
+import { CampaignSankeyChart } from "./campaign-sankey-chart";
+import { DomainBounceChart } from "./domain-bounce-chart";
+import { TemplateVersionCompareCard } from "./template-version-compare-card";
+import type {
+  CampaignEngagementStats,
+  CampaignFunnelStage,
+} from "@/lib/admin/email-campaign-types";
+
+interface Props {
+  campaignId: string;
+  emailType?: string;
+  templateVersionsSent?: string[];
+}
+
+interface EngagementResponse {
+  ok: boolean;
+  stats: CampaignEngagementStats;
+  funnel: CampaignFunnelStage[];
+}
+
+async function fetchEngagement(id: string): Promise<EngagementResponse | null> {
+  const r = await fetch(`/api/admin/email/campaigns/${id}/engagement`);
+  if (!r.ok) return null;
+  const j = (await r.json()) as EngagementResponse;
+  return j.ok ? j : null;
+}
+
+interface MetricCardProps {
+  label: string;
+  value: number;
+  suffix?: string;
+  secondary?: string;
+  index: number;
+}
+
+const MetricCard: React.FC<MetricCardProps> = ({
+  label,
+  value,
+  suffix,
+  secondary,
+  index,
+}) => {
+  const reduced = useReducedMotion();
+  return (
+    <motion.div
+      variants={reduced ? undefined : campaignMetricGridVariants}
+      initial={reduced ? undefined : "initial"}
+      animate={reduced ? undefined : "animate"}
+      custom={index}
+      className="rounded-panel border border-glass-border px-5 py-4"
+    >
+      <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
+        {label}
+      </div>
+      <div
+        className="mt-2 font-cakemono font-light text-[28px] uppercase tracking-[0.04em] text-text"
+        style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+      >
+        {value}
+        {suffix && (
+          <span className="ml-1 font-mono text-[14px] text-text-2">
+            {suffix}
+          </span>
+        )}
+      </div>
+      {secondary && (
+        <div
+          className="mt-1 font-mono text-[11px] text-text-3"
+          style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+        >
+          {secondary}
+        </div>
+      )}
+    </motion.div>
+  );
+};
+
+export function CampaignDetailPanel({
+  campaignId,
+  emailType,
+  templateVersionsSent,
+}: Props) {
+  const reduced = useReducedMotion();
+  const { data } = useQuery({
+    queryKey: ["campaign-engagement", campaignId],
+    queryFn: () => fetchEngagement(campaignId),
+    refetchInterval: 60_000,
+  });
+
+  if (!data) {
+    return (
+      <div className="py-12 text-center font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
+        // LOADING
+      </div>
+    );
+  }
+  const { stats, funnel } = data;
+  const showVersionCompare =
+    Boolean(emailType) &&
+    Array.isArray(templateVersionsSent) &&
+    templateVersionsSent.length >= 2;
+
+  return (
+    <motion.div
+      variants={reduced ? undefined : animatedCountVariants}
+      initial={reduced ? undefined : "initial"}
+      animate={reduced ? undefined : "animate"}
+      className="space-y-6"
+    >
+      <div className="grid grid-cols-4 gap-3">
+        <MetricCard label="Sent" value={stats.sent} index={0} />
+        <MetricCard
+          label="Delivered"
+          value={stats.delivered}
+          secondary={`${stats.bounce_rate}% bounce`}
+          index={1}
+        />
+        <MetricCard
+          label="Open rate"
+          value={stats.open_rate}
+          suffix="%"
+          secondary={`${stats.opened} unique`}
+          index={2}
+        />
+        <MetricCard
+          label="Click rate"
+          value={stats.click_rate}
+          suffix="%"
+          secondary={`${stats.clicked} unique`}
+          index={3}
+        />
+        <MetricCard label="CTOR" value={stats.ctor} suffix="%" index={4} />
+        <MetricCard label="Spam" value={stats.spam_reports} index={5} />
+        <MetricCard label="Unsub" value={stats.unsubscribes} index={6} />
+        <MetricCard
+          label="Suppressed"
+          value={stats.suppressed_skipped}
+          secondary={`${stats.in_flight} in-flight`}
+          index={7}
+        />
+      </div>
+
+      <CampaignSankeyChart stages={funnel} />
+
+      <DomainBounceChart data={stats.per_domain_bounce_summary} />
+
+      {showVersionCompare && (
+        <TemplateVersionCompareCard
+          emailType={emailType as string}
+          versions={templateVersionsSent as string[]}
+        />
+      )}
+    </motion.div>
+  );
+}

--- a/src/components/admin/email/campaign-detail-panel.tsx
+++ b/src/components/admin/email/campaign-detail-panel.tsx
@@ -99,7 +99,7 @@ export function CampaignDetailPanel({
   if (!data) {
     return (
       <div className="py-12 text-center font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
-        // LOADING
+        {"// LOADING"}
       </div>
     );
   }

--- a/src/components/admin/email/campaign-sankey-chart.tsx
+++ b/src/components/admin/email/campaign-sankey-chart.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import * as React from "react";
+import { Sankey, Tooltip, Rectangle } from "recharts";
+import { motion, useReducedMotion } from "framer-motion";
+import { sankeyLinkVariants, sankeyNodeVariants } from "@/lib/utils/motion";
+import type { CampaignFunnelStage } from "@/lib/admin/email-campaign-types";
+
+const STAGE_TOKEN: Record<CampaignFunnelStage["stage"], string> = {
+  enqueued: "var(--text-3)",
+  dispatched: "var(--text-2)",
+  delivered: "var(--color-olive)",
+  opened: "var(--color-ops-accent)",
+  clicked: "var(--color-tan)",
+};
+
+interface CampaignSankeyChartProps {
+  stages: CampaignFunnelStage[];
+}
+
+interface SankeyDatum {
+  nodes: Array<{ name: string; color: string }>;
+  links: Array<{ source: number; target: number; value: number }>;
+}
+
+function buildSankeyData(stages: CampaignFunnelStage[]): SankeyDatum {
+  const nodes = stages.map((s) => ({
+    name: s.stage.toUpperCase(),
+    color: STAGE_TOKEN[s.stage],
+  }));
+  const links = stages.slice(0, -1).map((_, i) => ({
+    source: i,
+    target: i + 1,
+    // Math.max(1, n) avoids Recharts collapsing zero-width links to nothing.
+    value: Math.max(1, stages[i + 1].value),
+  }));
+  return { nodes, links };
+}
+
+interface SankeyLinkProps {
+  sourceX: number;
+  sourceY: number;
+  sourceControlX: number;
+  targetControlX: number;
+  targetX: number;
+  targetY: number;
+  linkWidth: number;
+  index: number;
+}
+
+function AnimatedSankeyLink(props: unknown) {
+  const reduced = useReducedMotion();
+  const p = props as SankeyLinkProps;
+  const path =
+    `M${p.sourceX},${p.sourceY}` +
+    `C${p.sourceControlX},${p.sourceY} ${p.targetControlX},${p.targetY} ${p.targetX},${p.targetY}`;
+  return (
+    <motion.path
+      d={path}
+      fill="none"
+      stroke="var(--color-ops-accent)"
+      strokeOpacity={0.55}
+      strokeWidth={p.linkWidth}
+      variants={reduced ? undefined : sankeyLinkVariants}
+      initial={reduced ? undefined : "initial"}
+      animate={reduced ? undefined : "animate"}
+      custom={p.index}
+    />
+  );
+}
+
+interface SankeyNodeProps {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  payload: { name: string; color: string; value: number };
+}
+
+function SankeyNode(props: unknown) {
+  const reduced = useReducedMotion();
+  const p = props as SankeyNodeProps;
+  return (
+    <motion.g
+      variants={reduced ? undefined : sankeyNodeVariants}
+      initial={reduced ? undefined : "initial"}
+      animate={reduced ? undefined : "animate"}
+    >
+      <Rectangle
+        x={p.x}
+        y={p.y}
+        width={p.width}
+        height={p.height}
+        fill={p.payload.color}
+        fillOpacity={0.85}
+      />
+      <text
+        x={p.x + p.width + 8}
+        y={p.y + p.height / 2}
+        dy={4}
+        fontFamily="JetBrains Mono"
+        fontSize={11}
+        fill="var(--text-2)"
+        style={{ letterSpacing: "0.16em", textTransform: "uppercase", fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+      >
+        {p.payload.name} {p.payload.value}
+      </text>
+    </motion.g>
+  );
+}
+
+export function CampaignSankeyChart({ stages }: CampaignSankeyChartProps) {
+  if (stages.length < 2) {
+    return (
+      <div className="rounded-panel border border-glass-border px-6 py-8">
+        <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
+          // NO FUNNEL DATA YET
+        </div>
+        <p className="mt-2 font-mohave text-[14px] text-text-2">
+          Campaign hasn&apos;t accumulated enough events. Check back after the first dispatch tick.
+        </p>
+      </div>
+    );
+  }
+
+  const data = buildSankeyData(stages);
+
+  return (
+    <div className="rounded-panel border border-glass-border px-4 py-4" style={{ height: 320 }}>
+      <Sankey
+        width={760}
+        height={280}
+        data={data}
+        nodeWidth={14}
+        nodePadding={28}
+        margin={{ top: 8, right: 200, bottom: 8, left: 8 }}
+        link={<AnimatedSankeyLink />}
+        node={<SankeyNode />}
+      >
+        <Tooltip
+          contentStyle={{
+            background: "var(--surface-glass-dense)",
+            border: "1px solid rgba(255,255,255,0.18)",
+            borderRadius: 5,
+            fontFamily: "JetBrains Mono",
+            fontSize: 11,
+          }}
+        />
+      </Sankey>
+    </div>
+  );
+}

--- a/src/components/admin/email/campaign-sankey-chart.tsx
+++ b/src/components/admin/email/campaign-sankey-chart.tsx
@@ -114,7 +114,7 @@ export function CampaignSankeyChart({ stages }: CampaignSankeyChartProps) {
     return (
       <div className="rounded-panel border border-glass-border px-6 py-8">
         <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
-          // NO FUNNEL DATA YET
+          {"// NO FUNNEL DATA YET"}
         </div>
         <p className="mt-2 font-mohave text-[14px] text-text-2">
           Campaign hasn&apos;t accumulated enough events. Check back after the first dispatch tick.

--- a/src/components/admin/email/domain-bounce-chart.tsx
+++ b/src/components/admin/email/domain-bounce-chart.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import * as React from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import type { PerDomainBounce } from "@/lib/admin/email-campaign-types";
+
+interface DomainBounceChartProps {
+  data: PerDomainBounce[];
+}
+
+export function DomainBounceChart({ data }: DomainBounceChartProps) {
+  const sorted = [...data].sort((a, b) => b.bounces - a.bounces).slice(0, 10);
+
+  if (sorted.length === 0) {
+    return (
+      <div className="rounded-panel border border-glass-border px-6 py-8">
+        <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
+          // ZERO BOUNCES
+        </div>
+        <p className="mt-2 font-mohave text-[14px] text-text-2">
+          No bounce events recorded for this campaign.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="rounded-panel border border-glass-border px-4 py-4"
+      style={{ height: 320 }}
+    >
+      <div className="mb-3 font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
+        // BOUNCES BY DOMAIN — TOP {sorted.length}
+      </div>
+      <ResponsiveContainer width="100%" height={260}>
+        <BarChart
+          data={sorted}
+          layout="vertical"
+          margin={{ top: 4, right: 16, bottom: 4, left: 8 }}
+        >
+          <XAxis
+            type="number"
+            stroke="var(--text-mute)"
+            tick={{
+              fontFamily: "JetBrains Mono",
+              fontSize: 11,
+              fill: "var(--text-3)",
+            }}
+          />
+          <YAxis
+            dataKey="domain"
+            type="category"
+            stroke="var(--text-mute)"
+            width={120}
+            tick={{
+              fontFamily: "JetBrains Mono",
+              fontSize: 11,
+              fill: "var(--text-2)",
+            }}
+          />
+          <Tooltip
+            contentStyle={{
+              background: "var(--surface-glass-dense)",
+              border: "1px solid rgba(255,255,255,0.18)",
+              borderRadius: 5,
+              fontFamily: "JetBrains Mono",
+              fontSize: 11,
+            }}
+          />
+          <Bar dataKey="bounces" radius={[0, 2, 2, 0]}>
+            {sorted.map((_, i) => (
+              <Cell
+                key={i}
+                fill={i === 0 ? "var(--color-tan)" : "var(--color-ops-accent)"}
+                fillOpacity={0.85}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/admin/email/domain-bounce-chart.tsx
+++ b/src/components/admin/email/domain-bounce-chart.tsx
@@ -23,7 +23,7 @@ export function DomainBounceChart({ data }: DomainBounceChartProps) {
     return (
       <div className="rounded-panel border border-glass-border px-6 py-8">
         <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
-          // ZERO BOUNCES
+          {"// ZERO BOUNCES"}
         </div>
         <p className="mt-2 font-mohave text-[14px] text-text-2">
           No bounce events recorded for this campaign.
@@ -38,7 +38,7 @@ export function DomainBounceChart({ data }: DomainBounceChartProps) {
       style={{ height: 320 }}
     >
       <div className="mb-3 font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
-        // BOUNCES BY DOMAIN — TOP {sorted.length}
+        {`// BOUNCES BY DOMAIN — TOP ${sorted.length}`}
       </div>
       <ResponsiveContainer width="100%" height={260}>
         <BarChart

--- a/src/components/admin/email/template-version-compare-card.tsx
+++ b/src/components/admin/email/template-version-compare-card.tsx
@@ -83,7 +83,7 @@ export function TemplateVersionCompareCard({ emailType, versions }: Props) {
   return (
     <div className="rounded-panel border border-glass-border px-5 py-5">
       <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
-        // VERSION COMPARE
+        {"// VERSION COMPARE"}
       </div>
       <table className="w-full">
         <thead>

--- a/src/components/admin/email/template-version-compare-card.tsx
+++ b/src/components/admin/email/template-version-compare-card.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { VersionCompareResult } from "@/lib/admin/email-campaign-types";
+
+interface Props {
+  emailType: string;
+  versions: string[];
+}
+
+async function fetchCompare(
+  emailType: string,
+  a: string,
+  b: string
+): Promise<VersionCompareResult | null> {
+  const r = await fetch(
+    `/api/admin/email/templates/${encodeURIComponent(emailType)}/versions/compare` +
+      `?a=${encodeURIComponent(a)}&b=${encodeURIComponent(b)}`
+  );
+  if (!r.ok) return null;
+  const j = (await r.json()) as { result?: VersionCompareResult | null };
+  return j.result ?? null;
+}
+
+interface RowProps {
+  label: string;
+  valueA: number;
+  valueB: number;
+  isPct?: boolean;
+}
+
+const Row = ({ label, valueA, valueB, isPct }: RowProps) => {
+  const delta = valueA - valueB;
+  const winner = delta > 0 ? "a" : delta < 0 ? "b" : "tie";
+  return (
+    <tr>
+      <td className="py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-text-3">
+        {label}
+      </td>
+      <td
+        className={`py-2 text-right font-mono text-[14px] ${
+          winner === "a" ? "text-[var(--color-olive)]" : "text-text-2"
+        }`}
+        style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+      >
+        {valueA}
+        {isPct ? "%" : ""}
+      </td>
+      <td
+        className={`py-2 text-right font-mono text-[14px] ${
+          winner === "b" ? "text-[var(--color-olive)]" : "text-text-2"
+        }`}
+        style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+      >
+        {valueB}
+        {isPct ? "%" : ""}
+      </td>
+    </tr>
+  );
+};
+
+export function TemplateVersionCompareCard({ emailType, versions }: Props) {
+  const dedup = Array.from(new Set(versions)).slice(0, 2);
+  const a = dedup[0];
+  const b = dedup[1];
+  const enabled = Boolean(a && b);
+
+  const { data } = useQuery({
+    queryKey: ["template-version-compare", emailType, a, b],
+    queryFn: () => fetchCompare(emailType, a as string, b as string),
+    staleTime: 60_000,
+    enabled,
+  });
+
+  if (!enabled) return null;
+  if (!data) return null;
+
+  const versA = data.versions[a as string];
+  const versB = data.versions[b as string];
+  if (!versA || !versB) return null;
+
+  return (
+    <div className="rounded-panel border border-glass-border px-5 py-5">
+      <div className="mb-4 font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
+        // VERSION COMPARE
+      </div>
+      <table className="w-full">
+        <thead>
+          <tr>
+            <th className="text-left font-mono text-[11px] uppercase tracking-[0.14em] text-text-mute" />
+            <th className="text-right font-mono text-[11px] uppercase tracking-[0.14em] text-text-2">
+              v{a}
+            </th>
+            <th className="text-right font-mono text-[11px] uppercase tracking-[0.14em] text-text-2">
+              v{b}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <Row label="Sent" valueA={versA.sent} valueB={versB.sent} />
+          <Row label="Open rate" valueA={versA.open_rate} valueB={versB.open_rate} isPct />
+          <Row label="Click rate" valueA={versA.click_rate} valueB={versB.click_rate} isPct />
+          <Row label="Bounce rate" valueA={versA.bounce_rate} valueB={versB.bounce_rate} isPct />
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/lib/admin/email-campaign-queries.ts
+++ b/src/lib/admin/email-campaign-queries.ts
@@ -1,0 +1,58 @@
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import type {
+  CampaignEngagementStats,
+  CampaignFunnelStage,
+  VersionCompareResult,
+} from "./email-campaign-types";
+
+export async function getCampaignEngagementStats(
+  campaignId: string
+): Promise<CampaignEngagementStats | null> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase.rpc("campaign_engagement_stats", {
+    p_campaign_id: campaignId,
+  });
+  if (error) {
+    console.error("[getCampaignEngagementStats]", error);
+    return null;
+  }
+  return (data ?? null) as unknown as CampaignEngagementStats | null;
+}
+
+export async function getCampaignFunnelStages(
+  campaignId: string
+): Promise<CampaignFunnelStage[]> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase.rpc("campaign_funnel_stages", {
+    p_campaign_id: campaignId,
+  });
+  if (error) {
+    console.error("[getCampaignFunnelStages]", error);
+    return [];
+  }
+  return ((data ?? []) as Array<{ stage: string; value: number | string | null }>).map((r) => ({
+    stage: r.stage as CampaignFunnelStage["stage"],
+    value: Number(r.value ?? 0),
+  }));
+}
+
+export async function getTemplateVersionCompare(
+  emailType: string,
+  versionA: string,
+  versionB: string,
+  sinceIso?: string
+): Promise<VersionCompareResult | null> {
+  const supabase = getServiceRoleClient();
+  const { data, error } = await supabase.rpc("template_version_compare", {
+    p_email_type: emailType,
+    p_version_a: versionA,
+    p_version_b: versionB,
+    p_since:
+      sinceIso ?? new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+  });
+  if (error) {
+    console.error("[getTemplateVersionCompare]", error);
+    return null;
+  }
+  return data as unknown as VersionCompareResult;
+}

--- a/src/lib/admin/email-campaign-types.ts
+++ b/src/lib/admin/email-campaign-types.ts
@@ -1,0 +1,48 @@
+export interface CampaignFunnelStage {
+  stage: "enqueued" | "dispatched" | "delivered" | "opened" | "clicked";
+  value: number;
+}
+
+export interface PerDomainBounce {
+  domain: string;
+  bounces: number;
+  delivered: number;
+  dropped: number;
+}
+
+export interface CampaignEngagementStats {
+  campaign_id: string;
+  sent: number;
+  delivered: number;
+  bounced: number;
+  opened: number;
+  clicked: number;
+  spam_reports: number;
+  unsubscribes: number;
+  suppressed_skipped: number;
+  failed: number;
+  in_flight: number;
+  open_rate: number;
+  click_rate: number;
+  bounce_rate: number;
+  ctor: number;
+  per_domain_bounce_summary: PerDomainBounce[];
+  first_event_at: string | null;
+  last_event_at: string | null;
+}
+
+export interface VersionMetrics {
+  sent: number;
+  opens: number;
+  clicks: number;
+  bounces: number;
+  open_rate: number;
+  click_rate: number;
+  bounce_rate: number;
+}
+
+export interface VersionCompareResult {
+  email_type: string;
+  since: string;
+  versions: Record<string, VersionMetrics>;
+}

--- a/src/lib/email/campaigns.ts
+++ b/src/lib/email/campaigns.ts
@@ -237,8 +237,9 @@ export async function getCampaignStats(
 export async function listCampaigns(input: {
   status?: CampaignStatus | CampaignStatus[];
   limit?: number; offset?: number;
+  includeVersions?: boolean;
   client?: SupabaseClient;
-} = {}): Promise<{ rows: Campaign[]; total: number }> {
+} = {}): Promise<{ rows: (Campaign & { templateVersionsSent?: string[] })[]; total: number }> {
   const db = input.client ?? getServiceRoleClient();
   let q = db.from("email_campaigns").select("*", { count: "exact" })
     .order("created_at", { ascending: false })
@@ -248,5 +249,32 @@ export async function listCampaigns(input: {
   }
   const { data, count, error } = await q;
   if (error) throw new Error(`listCampaigns: ${error.message}`);
-  return { rows: (data ?? []).map((r) => rowToCampaign(r as Row)), total: count ?? 0 };
+  const rows = (data ?? []).map((r) => rowToCampaign(r as Row));
+
+  if (!input.includeVersions || rows.length === 0) {
+    return { rows, total: count ?? 0 };
+  }
+
+  const ids = rows.map((r) => r.id);
+  const { data: jobRows, error: jobErr } = await db
+    .from("email_jobs")
+    .select("campaign_id, template_version")
+    .in("campaign_id", ids)
+    .not("template_version", "is", null);
+  if (jobErr) throw new Error(`listCampaigns versions: ${jobErr.message}`);
+
+  const versionsByCampaign = new Map<string, string[]>();
+  for (const j of (jobRows ?? []) as Array<{ campaign_id: string; template_version: string }>) {
+    const arr = versionsByCampaign.get(j.campaign_id) ?? [];
+    if (!arr.includes(j.template_version)) arr.push(j.template_version);
+    versionsByCampaign.set(j.campaign_id, arr);
+  }
+
+  return {
+    rows: rows.map((r) => ({
+      ...r,
+      templateVersionsSent: versionsByCampaign.get(r.id) ?? [],
+    })),
+    total: count ?? 0,
+  };
 }

--- a/src/lib/utils/motion.ts
+++ b/src/lib/utils/motion.ts
@@ -527,3 +527,43 @@ export const confirmationModalVariants: Variants = {
   animate: { opacity: 1, scale: 1, transition: { duration: 0.24, ease: EASE_SMOOTH } },
   exit: { opacity: 0, scale: 0.96, transition: { duration: 0.16, ease: EASE_SMOOTH } },
 };
+
+// ---------------------------------------------------------------------------
+// Campaign analytics (PR 6) — metric grid, Sankey funnel, bounce chart
+// ---------------------------------------------------------------------------
+
+/** 8-card metric grid — 60ms stagger lifts each card in sequence. */
+export const campaignMetricGridVariants: Variants = {
+  initial: { opacity: 0, y: 6 },
+  animate: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.32, ease: EASE_SMOOTH, delay: i * 0.06 },
+  }),
+};
+
+/** Sankey link draw — `pathLength` 0→1 with 80ms stagger per link. */
+export const sankeyLinkVariants: Variants = {
+  initial: { pathLength: 0, opacity: 0.2 },
+  animate: (i: number) => ({
+    pathLength: 1,
+    opacity: 0.85,
+    transition: { duration: 0.42, ease: EASE_SMOOTH, delay: i * 0.08 },
+  }),
+};
+
+/** Sankey node entrance — quiet pop after links anchor. */
+export const sankeyNodeVariants: Variants = {
+  initial: { opacity: 0, scale: 0.94 },
+  animate: {
+    opacity: 1,
+    scale: 1,
+    transition: { duration: 0.28, ease: EASE_SMOOTH },
+  },
+};
+
+/** Single-value count entrance — used for animated number cells. */
+export const animatedCountVariants: Variants = {
+  initial: { opacity: 0, y: 4 },
+  animate: { opacity: 1, y: 0, transition: { duration: 0.32, ease: EASE_SMOOTH } },
+};

--- a/supabase/migrations/098_email_log_template_version.sql
+++ b/supabase/migrations/098_email_log_template_version.sql
@@ -1,0 +1,14 @@
+-- 098_email_log_template_version.sql
+-- Captures which template version was rendered for each send.
+-- Format: semver "1.0.0" — must match the @template-version comment header
+-- in src/lib/email/react/templates/*.tsx.
+
+ALTER TABLE public.email_log
+  ADD COLUMN IF NOT EXISTS template_version text;
+
+CREATE INDEX IF NOT EXISTS idx_email_log_template_version
+  ON public.email_log (email_type, template_version)
+  WHERE template_version IS NOT NULL;
+
+COMMENT ON COLUMN public.email_log.template_version IS
+  'Semver template version at send time. Set by gatedSend from the resolved template registry. NULL for sends predating PR 6.';

--- a/supabase/migrations/099_email_jobs_template_version.sql
+++ b/supabase/migrations/099_email_jobs_template_version.sql
@@ -1,0 +1,12 @@
+-- 099_email_jobs_template_version.sql
+-- Captures the template version each campaign job was rendered with.
+
+ALTER TABLE public.email_jobs
+  ADD COLUMN IF NOT EXISTS template_version text;
+
+CREATE INDEX IF NOT EXISTS idx_email_jobs_campaign_version
+  ON public.email_jobs (campaign_id, template_version)
+  WHERE template_version IS NOT NULL;
+
+COMMENT ON COLUMN public.email_jobs.template_version IS
+  'Semver template version at job dispatch time. Used by version-compare analytics.';

--- a/supabase/migrations/100_campaign_engagement_rpcs.sql
+++ b/supabase/migrations/100_campaign_engagement_rpcs.sql
@@ -1,0 +1,174 @@
+-- 100_campaign_engagement_rpcs.sql
+-- Engagement aggregation. campaign_engagement_stats returns a denormalized
+-- JSONB blob; campaign_funnel_stages returns one row per Sankey stage.
+
+CREATE INDEX IF NOT EXISTS idx_email_events_sg_event
+  ON public.email_events (sg_message_id, event)
+  WHERE sg_message_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_email_jobs_campaign_status
+  ON public.email_jobs (campaign_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_email_log_campaign_id
+  ON public.email_log (campaign_id)
+  WHERE campaign_id IS NOT NULL;
+
+-- ============================================================================
+-- campaign_engagement_stats(campaign_id uuid) RETURNS jsonb
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.campaign_engagement_stats(p_campaign_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_camp record;
+  v_unique_opens int;
+  v_unique_clicks int;
+  v_per_domain jsonb;
+  v_first_event timestamptz;
+  v_last_event timestamptz;
+  v_in_flight int;
+  v_failed int;
+  v_open_rate numeric;
+  v_click_rate numeric;
+  v_bounce_rate numeric;
+  v_ctor numeric;
+  v_spam_count int;
+  v_unsubscribe_count int;
+BEGIN
+  SELECT * INTO v_camp FROM public.email_campaigns WHERE id = p_campaign_id;
+  IF v_camp IS NULL THEN RETURN NULL; END IF;
+
+  -- Unique opens / clicks via JOIN of jobs↔events
+  SELECT count(DISTINCT j.recipient_email)
+    INTO v_unique_opens
+    FROM public.email_jobs j
+    JOIN public.email_events e ON e.sg_message_id = j.sg_message_id
+   WHERE j.campaign_id = p_campaign_id AND e.event = 'open';
+
+  SELECT count(DISTINCT j.recipient_email)
+    INTO v_unique_clicks
+    FROM public.email_jobs j
+    JOIN public.email_events e ON e.sg_message_id = j.sg_message_id
+   WHERE j.campaign_id = p_campaign_id AND e.event = 'click';
+
+  SELECT count(*) INTO v_in_flight
+    FROM public.email_jobs WHERE campaign_id = p_campaign_id AND status = 'pending';
+  SELECT count(*) INTO v_failed
+    FROM public.email_jobs WHERE campaign_id = p_campaign_id AND status = 'failed';
+
+  SELECT min(e."timestamp"), max(e."timestamp")
+    INTO v_first_event, v_last_event
+    FROM public.email_jobs j
+    JOIN public.email_events e ON e.sg_message_id = j.sg_message_id
+   WHERE j.campaign_id = p_campaign_id;
+
+  -- Per-domain bounce summary, top 10
+  SELECT coalesce(jsonb_agg(d ORDER BY d.bounces DESC), '[]'::jsonb)
+    INTO v_per_domain
+    FROM (
+      SELECT
+        lower(split_part(j.recipient_email, '@', 2)) AS domain,
+        count(*) FILTER (WHERE e.event = 'bounce') AS bounces,
+        count(*) FILTER (WHERE e.event = 'delivered') AS delivered,
+        count(*) FILTER (WHERE e.event = 'dropped') AS dropped
+      FROM public.email_jobs j
+      LEFT JOIN public.email_events e ON e.sg_message_id = j.sg_message_id
+      WHERE j.campaign_id = p_campaign_id
+      GROUP BY 1
+      ORDER BY 2 DESC NULLS LAST
+      LIMIT 10
+    ) d;
+
+  -- Spam / unsubscribe events (table has no campaign counter columns for these)
+  SELECT count(*) INTO v_spam_count
+    FROM public.email_jobs j
+    JOIN public.email_events e ON e.sg_message_id = j.sg_message_id
+   WHERE j.campaign_id = p_campaign_id AND e.event = 'spamreport';
+
+  SELECT count(*) INTO v_unsubscribe_count
+    FROM public.email_jobs j
+    JOIN public.email_events e ON e.sg_message_id = j.sg_message_id
+   WHERE j.campaign_id = p_campaign_id AND e.event = 'unsubscribe';
+
+  v_open_rate := CASE WHEN v_camp.delivered_count > 0
+                      THEN round(v_unique_opens::numeric / v_camp.delivered_count * 100, 1)
+                      ELSE 0 END;
+  v_click_rate := CASE WHEN v_camp.delivered_count > 0
+                       THEN round(v_unique_clicks::numeric / v_camp.delivered_count * 100, 1)
+                       ELSE 0 END;
+  v_bounce_rate := CASE WHEN (v_camp.sent_count + v_camp.bounced_count) > 0
+                        THEN round(v_camp.bounced_count::numeric / (v_camp.sent_count + v_camp.bounced_count) * 100, 1)
+                        ELSE 0 END;
+  v_ctor := CASE WHEN v_unique_opens > 0
+                 THEN round(v_unique_clicks::numeric / v_unique_opens * 100, 1)
+                 ELSE 0 END;
+
+  RETURN jsonb_build_object(
+    'campaign_id', p_campaign_id,
+    'sent', v_camp.sent_count,
+    'delivered', v_camp.delivered_count,
+    'bounced', v_camp.bounced_count,
+    'opened', v_unique_opens,
+    'clicked', v_unique_clicks,
+    'spam_reports', v_spam_count,
+    'unsubscribes', v_unsubscribe_count,
+    'suppressed_skipped', v_camp.suppressed_skipped_count,
+    'failed', v_failed,
+    'in_flight', v_in_flight,
+    'open_rate', v_open_rate,
+    'click_rate', v_click_rate,
+    'bounce_rate', v_bounce_rate,
+    'ctor', v_ctor,
+    'per_domain_bounce_summary', v_per_domain,
+    'first_event_at', v_first_event,
+    'last_event_at', v_last_event
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.campaign_engagement_stats(uuid) FROM anon, authenticated;
+
+-- ============================================================================
+-- campaign_funnel_stages(campaign_id uuid) RETURNS TABLE
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.campaign_funnel_stages(p_campaign_id uuid)
+RETURNS TABLE(stage text, value bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_camp record;
+  v_dispatched bigint;
+  v_unique_opens bigint;
+  v_unique_clicks bigint;
+BEGIN
+  SELECT * INTO v_camp FROM public.email_campaigns WHERE id = p_campaign_id;
+  IF v_camp IS NULL THEN RETURN; END IF;
+
+  SELECT count(*) INTO v_dispatched
+    FROM public.email_jobs WHERE campaign_id = p_campaign_id AND status IN ('sent', 'bounced');
+
+  SELECT count(DISTINCT j.recipient_email)
+    INTO v_unique_opens
+    FROM public.email_jobs j
+    JOIN public.email_events e ON e.sg_message_id = j.sg_message_id
+   WHERE j.campaign_id = p_campaign_id AND e.event = 'open';
+
+  SELECT count(DISTINCT j.recipient_email)
+    INTO v_unique_clicks
+    FROM public.email_jobs j
+    JOIN public.email_events e ON e.sg_message_id = j.sg_message_id
+   WHERE j.campaign_id = p_campaign_id AND e.event = 'click';
+
+  stage := 'enqueued'; value := v_camp.recipient_count_actual; RETURN NEXT;
+  stage := 'dispatched'; value := v_dispatched; RETURN NEXT;
+  stage := 'delivered'; value := v_camp.delivered_count; RETURN NEXT;
+  stage := 'opened'; value := v_unique_opens; RETURN NEXT;
+  stage := 'clicked'; value := v_unique_clicks; RETURN NEXT;
+  RETURN;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.campaign_funnel_stages(uuid) FROM anon, authenticated;

--- a/supabase/migrations/101_template_version_compare_rpc.sql
+++ b/supabase/migrations/101_template_version_compare_rpc.sql
@@ -1,0 +1,63 @@
+-- 101_template_version_compare_rpc.sql
+-- Side-by-side metrics for two template versions of the same email_type.
+-- Source of truth: email_jobs (carries template_version, sg_message_id, status,
+-- created_at). email_campaigns.template_id maps to the template registry key
+-- (which equals email_type semantically). email_events joined via sg_message_id.
+
+CREATE OR REPLACE FUNCTION public.template_version_compare(
+  p_email_type text,
+  p_version_a text,
+  p_version_b text,
+  p_since timestamptz DEFAULT now() - interval '30 days'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_versions jsonb;
+BEGIN
+  WITH scoped_jobs AS (
+    SELECT j.id,
+           j.sg_message_id,
+           j.recipient_email,
+           j.template_version,
+           j.status
+    FROM public.email_jobs j
+    JOIN public.email_campaigns c ON c.id = j.campaign_id
+    WHERE c.template_id = p_email_type
+      AND j.template_version IN (p_version_a, p_version_b)
+      AND j.created_at >= p_since
+  ),
+  per_version AS (
+    SELECT
+      sj.template_version AS version,
+      count(*) FILTER (WHERE sj.status IN ('sent', 'bounced')) AS sent,
+      count(DISTINCT sj.recipient_email) FILTER (WHERE e.event = 'open') AS opens,
+      count(DISTINCT sj.recipient_email) FILTER (WHERE e.event = 'click') AS clicks,
+      count(*) FILTER (WHERE e.event = 'bounce') AS bounces
+    FROM scoped_jobs sj
+    LEFT JOIN public.email_events e ON e.sg_message_id = sj.sg_message_id
+    GROUP BY 1
+  )
+  SELECT jsonb_object_agg(version, jsonb_build_object(
+    'sent', sent,
+    'opens', opens,
+    'clicks', clicks,
+    'bounces', bounces,
+    'open_rate', CASE WHEN sent > 0 THEN round(opens::numeric / sent * 100, 1) ELSE 0 END,
+    'click_rate', CASE WHEN sent > 0 THEN round(clicks::numeric / sent * 100, 1) ELSE 0 END,
+    'bounce_rate', CASE WHEN sent > 0 THEN round(bounces::numeric / sent * 100, 1) ELSE 0 END
+  ))
+  INTO v_versions
+  FROM per_version;
+
+  RETURN jsonb_build_object(
+    'email_type', p_email_type,
+    'since', p_since,
+    'versions', coalesce(v_versions, '{}'::jsonb)
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.template_version_compare(text, text, text, timestamptz) FROM anon, authenticated;

--- a/tests/integration/campaign-engagement-route.test.ts
+++ b/tests/integration/campaign-engagement-route.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/admin/api-auth", () => ({
+  withAdmin: <H extends (...args: unknown[]) => unknown>(h: H) => h,
+  requireAdmin: vi.fn(async () => ({ uid: "admin", email: "a@x.com" })),
+}));
+
+const statsMock = vi.fn();
+const funnelMock = vi.fn();
+vi.mock("@/lib/admin/email-campaign-queries", () => ({
+  getCampaignEngagementStats: (...a: unknown[]) => statsMock(...a),
+  getCampaignFunnelStages: (...a: unknown[]) => funnelMock(...a),
+}));
+
+import { GET } from "@/app/api/admin/email/campaigns/[id]/engagement/route";
+
+const mkReq = () => new Request("https://x") as never;
+const mkCtx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("GET /api/admin/email/campaigns/[id]/engagement", () => {
+  it("rejects malformed UUID with 400", async () => {
+    const r = await GET(mkReq(), mkCtx("not-a-uuid"));
+    expect(r.status).toBe(400);
+  });
+
+  it("returns 404 when campaign not found", async () => {
+    statsMock.mockResolvedValueOnce(null);
+    funnelMock.mockResolvedValueOnce([]);
+    const r = await GET(
+      mkReq(),
+      mkCtx("11111111-1111-1111-1111-111111111111")
+    );
+    expect(r.status).toBe(404);
+  });
+
+  it("returns 200 with stats + funnel + 60s Cache-Control", async () => {
+    statsMock.mockResolvedValueOnce({
+      campaign_id: "11111111-1111-1111-1111-111111111111",
+      sent: 10,
+    });
+    funnelMock.mockResolvedValueOnce([
+      { stage: "enqueued", value: 10 },
+      { stage: "delivered", value: 9 },
+    ]);
+    const r = await GET(
+      mkReq(),
+      mkCtx("11111111-1111-1111-1111-111111111111")
+    );
+    expect(r.status).toBe(200);
+    expect(r.headers.get("Cache-Control")).toContain("max-age=60");
+    const body = await r.json();
+    expect(body.ok).toBe(true);
+    expect(body.stats.sent).toBe(10);
+    expect(body.funnel).toHaveLength(2);
+  });
+});

--- a/tests/unit/email/campaign-detail-panel.test.tsx
+++ b/tests/unit/email/campaign-detail-panel.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { CampaignSankeyChart } from "@/components/admin/email/campaign-sankey-chart";
+
+describe("CampaignSankeyChart", () => {
+  it("renders empty state when fewer than 2 stages", () => {
+    const { getByText } = render(<CampaignSankeyChart stages={[]} />);
+    expect(getByText(/NO FUNNEL DATA YET/)).toBeTruthy();
+  });
+
+  it("renders empty state with one stage", () => {
+    const { getByText } = render(
+      <CampaignSankeyChart stages={[{ stage: "enqueued", value: 5 }]} />
+    );
+    expect(getByText(/NO FUNNEL DATA YET/)).toBeTruthy();
+  });
+});

--- a/tests/unit/email/campaign-query-mappers.test.ts
+++ b/tests/unit/email/campaign-query-mappers.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+
+const rpcMock = vi.fn();
+vi.mock("@/lib/supabase/server-client", () => ({
+  getServiceRoleClient: () => ({ rpc: (...a: unknown[]) => rpcMock(...a) }),
+}));
+
+import {
+  getCampaignFunnelStages,
+  getCampaignEngagementStats,
+} from "@/lib/admin/email-campaign-queries";
+
+describe("query mappers", () => {
+  it("getCampaignFunnelStages coerces value to number", async () => {
+    rpcMock.mockResolvedValueOnce({
+      data: [
+        { stage: "delivered", value: "42" },
+        { stage: "opened", value: 7 },
+      ],
+      error: null,
+    });
+    const result = await getCampaignFunnelStages("c1");
+    expect(result).toEqual([
+      { stage: "delivered", value: 42 },
+      { stage: "opened", value: 7 },
+    ]);
+  });
+
+  it("getCampaignEngagementStats returns null on error", async () => {
+    rpcMock.mockResolvedValueOnce({ data: null, error: { message: "boom" } });
+    expect(await getCampaignEngagementStats("c1")).toBeNull();
+  });
+
+  it("getCampaignEngagementStats returns null when RPC returns null", async () => {
+    rpcMock.mockResolvedValueOnce({ data: null, error: null });
+    expect(await getCampaignEngagementStats("c1")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Campaign Analytics tab (`/admin/email` 2nd tab) with inline expand-to-detail rows
- 8 metric cards (Cake Mono Light), animated Sankey funnel (5 stages, pathLength 80ms stagger), top-10 bouncing domains, template-version compare card (hidden when fewer than 2 versions sent)
- 4 migrations (098–101): `template_version` columns on `email_log` + `email_jobs`, plus 3 SECURITY DEFINER RPCs (`campaign_engagement_stats`, `campaign_funnel_stages`, `template_version_compare`) — all admin-only
- 2 admin API routes with 60s `Cache-Control` (Next.js 15 `params: Promise<{...}>` signature)
- Extends PR 3's `GET /api/admin/email/campaigns` with optional `?include_versions=1` for inline version aggregation
- Bible §14.10 documents the system

## Architecture notes

- `email_log` has no `sg_message_id` column — version compare RPC therefore sources from `email_jobs` and joins `email_campaigns` to filter by `template_id = email_type`
- Spam/unsubscribe counts derived from event aggregation since `email_campaigns` has no counter columns for those events
- All chart colors via CSS vars (`var(--color-olive)`, `var(--color-ops-accent)`, `var(--text-2)`, etc.) — zero hardcoded hex
- All animations honor `useReducedMotion()` (instant fallback)

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run build` — clean (production)
- [x] `npx vitest run` — 697 tests pass; 2 baseline suite failures unchanged (Firebase auth env init in `tests/integration/auth.test.tsx` + `projects.test.tsx` — unrelated to PR6)
- [x] 8 new tests passing (mapper coercion, route validation, Sankey empty state)
- [ ] Manual: open `/admin/email` → Campaign Analytics tab → expand a row → Sankey draws, bounce chart renders, version compare conditionally hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)