### PR TITLE
PR 8: Email Event Monitor + Anomaly Alerts

### DIFF
--- a/src/app/admin/email/_components/anomaly-history.tsx
+++ b/src/app/admin/email/_components/anomaly-history.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * Paginated audit log of detected anomalies. Each row expands to reveal
+ * the full context JSON and the action_taken text written by the cron.
+ */
+import * as React from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { useQuery } from "@tanstack/react-query";
+import type { AnomalyLogRow, AnomalyKind } from "@/lib/admin/types";
+
+const KIND_LABEL: Record<AnomalyKind, string> = {
+  bounce_spike: "BOUNCE SPIKE",
+  spam_spike: "SPAM SPIKE",
+  delivery_drop: "DELIVERY DROP",
+  volume_drop: "VOLUME DROP",
+};
+
+const PAGE_SIZE = 25;
+
+function isVisible(): boolean {
+  return typeof document !== "undefined"
+    ? document.visibilityState === "visible"
+    : true;
+}
+
+export function AnomalyHistory() {
+  const reduce = useReducedMotion();
+  const [page, setPage] = React.useState(0);
+  const [expanded, setExpanded] = React.useState<Set<string>>(new Set());
+
+  const q = useQuery({
+    queryKey: ["anomalies", page],
+    queryFn: async (): Promise<{ rows: AnomalyLogRow[]; total: number }> => {
+      const r = await fetch(
+        `/api/admin/email/monitor/anomalies?limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`
+      );
+      if (!r.ok) throw new Error("anomalies_failed");
+      return (await r.json()) as { rows: AnomalyLogRow[]; total: number };
+    },
+    refetchInterval: () => (isVisible() ? 15000 : false),
+    refetchIntervalInBackground: false,
+  });
+
+  function toggle(id: string) {
+    const next = new Set(expanded);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setExpanded(next);
+  }
+
+  return (
+    <div
+      className="rounded-panel overflow-hidden"
+      style={{ border: "1px solid rgba(255,255,255,0.06)" }}
+    >
+      <p
+        className="px-3 py-2 font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3"
+        style={{ background: "rgba(255,255,255,0.02)" }}
+      >
+        // ANOMALY LOG [{q.data?.total ?? 0}]
+      </p>
+      {(q.data?.rows.length ?? 0) === 0 && !q.isLoading && (
+        <p className="font-mono text-[11px] text-text-mute py-6 px-3">
+          [no anomalies recorded]
+        </p>
+      )}
+      {q.data?.rows.map((r) => {
+        const isOpen = expanded.has(r.id);
+        return (
+          <div key={r.id} className="border-t border-white/[0.04]">
+            <button
+              type="button"
+              onClick={() => toggle(r.id)}
+              className="w-full grid grid-cols-[120px_140px_1fr_160px] gap-3 px-3 py-2 items-center text-left hover:bg-white/[0.03] transition-colors"
+            >
+              <span
+                className="font-cakemono font-light text-[10px] tracking-[0.06em]"
+                style={{
+                  color: r.severity === "critical" ? "#93321A" : "#C4A868",
+                }}
+              >
+                {r.severity === "critical" ? "CRITICAL" : "WARN"}
+              </span>
+              <span className="font-cakemono font-light text-[10px] tracking-[0.06em] text-text-2">
+                {KIND_LABEL[r.kind] ?? r.kind}
+              </span>
+              <span
+                className="font-mono text-[11px] text-text"
+                style={{ fontFeatureSettings: '"tnum" 1' }}
+              >
+                {Number(r.metric_value).toFixed(2)} / {r.threshold} ({r.window_minutes}m)
+              </span>
+              <span className="font-mono text-[11px] text-text-3 text-right">
+                {new Date(r.detected_at).toLocaleString()}
+              </span>
+            </button>
+            <AnimatePresence initial={false}>
+              {isOpen && (
+                <motion.div
+                  initial={reduce ? false : { opacity: 0, height: 0 }}
+                  animate={
+                    reduce
+                      ? { opacity: 1, height: "auto" }
+                      : { opacity: 1, height: "auto" }
+                  }
+                  exit={reduce ? { opacity: 0 } : { opacity: 0, height: 0 }}
+                  transition={
+                    reduce
+                      ? { duration: 0 }
+                      : { duration: 0.25, ease: [0.22, 1, 0.36, 1] }
+                  }
+                  className="px-3 pb-3 overflow-hidden"
+                >
+                  {r.action_taken && (
+                    <p className="font-mono text-[11px] text-[#9DB582] mb-2">
+                      [action] {r.action_taken}
+                    </p>
+                  )}
+                  <pre
+                    className="font-mono text-[10px] text-text-2 whitespace-pre-wrap p-2 rounded-chip"
+                    style={{
+                      background: "rgba(255,255,255,0.03)",
+                      border: "1px solid rgba(255,255,255,0.06)",
+                    }}
+                  >
+                    {JSON.stringify(r.context, null, 2)}
+                  </pre>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        );
+      })}
+      {q.data && q.data.total > PAGE_SIZE && (
+        <div
+          className="flex items-center justify-between p-2 font-mono text-[11px] text-text-3"
+          style={{ fontFeatureSettings: '"tnum" 1' }}
+        >
+          <span>
+            [page {page + 1} of {Math.ceil(q.data.total / PAGE_SIZE)}]
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={page === 0}
+              onClick={() => setPage((p) => Math.max(p - 1, 0))}
+              className="px-2 py-0.5 border border-white/10 rounded-chip disabled:opacity-30"
+            >
+              PREV
+            </button>
+            <button
+              type="button"
+              disabled={(page + 1) * PAGE_SIZE >= q.data.total}
+              onClick={() => setPage((p) => p + 1)}
+              className="px-2 py-0.5 border border-white/10 rounded-chip disabled:opacity-30"
+            >
+              NEXT
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/email/_components/anomaly-history.tsx
+++ b/src/app/admin/email/_components/anomaly-history.tsx
@@ -58,7 +58,7 @@ export function AnomalyHistory() {
         className="px-3 py-2 font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3"
         style={{ background: "rgba(255,255,255,0.02)" }}
       >
-        // ANOMALY LOG [{q.data?.total ?? 0}]
+        {`// ANOMALY LOG [${q.data?.total ?? 0}]`}
       </p>
       {(q.data?.rows.length ?? 0) === 0 && !q.isLoading && (
         <p className="font-mono text-[11px] text-text-mute py-6 px-3">

--- a/src/app/admin/email/_components/bounce-gauge.tsx
+++ b/src/app/admin/email/_components/bounce-gauge.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+/**
+ * Bounce-rate semicircular gauge. 0..15% range with green/yellow/red zones.
+ * Operator should be able to read deliverability state in <1s.
+ */
+import { motion, useReducedMotion } from "framer-motion";
+import { bounceGaugeNeedleVariants } from "@/lib/utils/motion";
+
+interface Props {
+  bouncePct: number;
+}
+
+const MAX_PCT = 15;
+
+export function BounceGauge({ bouncePct }: Props) {
+  const reduce = useReducedMotion();
+  const clamped = Math.max(0, Math.min(bouncePct, MAX_PCT));
+  const angleDeg = -90 + (clamped / MAX_PCT) * 180;
+  const zone = bouncePct >= 10 ? "critical" : bouncePct >= 5 ? "warn" : "ok";
+  const needleColor =
+    zone === "critical" ? "#93321A" : zone === "warn" ? "#C4A868" : "#9DB582";
+  const readoutColor =
+    zone === "critical" ? "#B58289" : zone === "warn" ? "#C4A868" : "#9DB582";
+
+  return (
+    <div
+      className="rounded-panel p-4"
+      style={{ border: "1px solid rgba(255,255,255,0.06)" }}
+    >
+      <span className="font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3 block mb-2">
+        // BOUNCE RATE [15-MIN]
+      </span>
+      <svg
+        viewBox="0 0 200 110"
+        className="w-full max-w-[280px] block"
+        role="img"
+        aria-label={`Bounce rate ${bouncePct.toFixed(2)} percent`}
+      >
+        <path
+          d="M 20 90 A 80 80 0 0 1 80 18.6"
+          stroke="#9DB582"
+          strokeWidth="3"
+          fill="none"
+        />
+        <path
+          d="M 80 18.6 A 80 80 0 0 1 140 30.7"
+          stroke="#C4A868"
+          strokeWidth="3"
+          fill="none"
+        />
+        <path
+          d="M 140 30.7 A 80 80 0 0 1 180 90"
+          stroke="#93321A"
+          strokeWidth="3"
+          fill="none"
+        />
+        <text x="20" y="105" fill="#8A8A8A" fontSize="8" fontFamily="JetBrains Mono">
+          0%
+        </text>
+        <text x="95" y="14" fill="#8A8A8A" fontSize="8" fontFamily="JetBrains Mono">
+          5
+        </text>
+        <text x="135" y="22" fill="#8A8A8A" fontSize="8" fontFamily="JetBrains Mono">
+          10
+        </text>
+        <text x="170" y="105" fill="#8A8A8A" fontSize="8" fontFamily="JetBrains Mono">
+          15%
+        </text>
+        <motion.line
+          x1="100"
+          y1="90"
+          x2="100"
+          y2="20"
+          stroke={needleColor}
+          strokeWidth="2"
+          strokeLinecap="round"
+          custom={angleDeg}
+          variants={bounceGaugeNeedleVariants}
+          initial={reduce ? false : "hidden"}
+          animate={reduce ? { rotate: angleDeg, transition: { duration: 0 } } : "visible"}
+          style={{ transformOrigin: "100px 90px" }}
+        />
+        <circle cx="100" cy="90" r="3" fill="#EDEDED" />
+      </svg>
+      <p
+        className="mt-2 font-mono text-[20px] tracking-tight"
+        style={{
+          color: readoutColor,
+          fontFeatureSettings: '"tnum" 1, "zero" 1',
+        }}
+      >
+        {bouncePct.toFixed(2)}%
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/email/_components/bounce-gauge.tsx
+++ b/src/app/admin/email/_components/bounce-gauge.tsx
@@ -29,7 +29,7 @@ export function BounceGauge({ bouncePct }: Props) {
       style={{ border: "1px solid rgba(255,255,255,0.06)" }}
     >
       <span className="font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3 block mb-2">
-        // BOUNCE RATE [15-MIN]
+        {"// BOUNCE RATE [15-MIN]"}
       </span>
       <svg
         viewBox="0 0 200 110"

--- a/src/app/admin/email/_components/email-content.tsx
+++ b/src/app/admin/email/_components/email-content.tsx
@@ -14,6 +14,7 @@ import { TemplatesTab } from "./templates-tab";
 import { AudienceBuilderTab } from "./audience-builder-tab";
 import { SuppressionsTab } from "./suppressions-tab";
 import { CampaignAnalyticsTab } from "@/components/admin/email/campaign-analytics-tab";
+import { EventMonitorTab } from "./event-monitor-tab";
 import type {
   EmailOverviewStats,
   EmailEngagementStats,
@@ -37,6 +38,7 @@ export function EmailContent({ overview, engagement, funnels, emailLog, newslett
       <SubTabs
         tabs={[
           "Overview",
+          "Event Monitor",
           "Campaign Analytics",
           "Scheduled Sends",
           "Audience",
@@ -52,6 +54,7 @@ export function EmailContent({ overview, engagement, funnels, emailLog, newslett
       >
         {(tab) => {
           if (tab === "Overview") return <OverviewTab stats={overview} engagement={engagement} />;
+          if (tab === "Event Monitor") return <EventMonitorTab />;
           if (tab === "Campaign Analytics") return <CampaignAnalyticsTab />;
           if (tab === "Scheduled Sends") return <ScheduledSendsTab />;
           if (tab === "Audience") return <AudienceBuilderTab />;

--- a/src/app/admin/email/_components/event-monitor-tab.tsx
+++ b/src/app/admin/email/_components/event-monitor-tab.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+/**
+ * Event Monitor — top-level orchestration of the live deliverability tab.
+ *
+ * Layout (desktop):
+ *   header :: title + filter chips
+ *   row 1  :: bounce gauge | 6 metric cards (sent/delivered/bounced/spam/open/click)
+ *   row 2  :: live event stream | top-10 bounce domains
+ *   row 3  :: full anomaly history
+ *
+ * Polling cadence: 5s for metrics + stream while tab visible, 10s for
+ * top-bounce-domains, 15s for anomaly history. All paused on hidden.
+ */
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { BounceGauge } from "./bounce-gauge";
+import { EventStream } from "./event-stream";
+import { MonitorMetricBar } from "./monitor-metric-bar";
+import { TopBounceDomains } from "./top-bounce-domains";
+import { AnomalyHistory } from "./anomaly-history";
+import { MonitorFilters } from "./monitor-filters";
+import type { EventMetrics } from "@/lib/admin/types";
+
+function isVisible(): boolean {
+  return typeof document !== "undefined"
+    ? document.visibilityState === "visible"
+    : true;
+}
+
+export function EventMonitorTab() {
+  const [windowMinutes, setWindowMinutes] = React.useState(60);
+  const [bucket, setBucket] = React.useState<"1m" | "5m" | "15m">("5m");
+  const [eventTypes, setEventTypes] = React.useState<string[]>([]);
+
+  const metrics = useQuery({
+    queryKey: ["eventMetrics", windowMinutes, bucket],
+    queryFn: async (): Promise<EventMetrics | null> => {
+      const r = await fetch(
+        `/api/admin/email/monitor/metrics?minutesBack=${windowMinutes}&bucket=${bucket}`
+      );
+      if (!r.ok) throw new Error("metrics_failed");
+      const json = (await r.json()) as { metrics?: EventMetrics | null };
+      return json.metrics ?? null;
+    },
+    refetchInterval: () => (isVisible() ? 5000 : false),
+    refetchIntervalInBackground: false,
+  });
+
+  // Always keep a 15-min snapshot for the gauge — independent of UI window.
+  const gauge = useQuery({
+    queryKey: ["gaugeMetrics"],
+    queryFn: async (): Promise<EventMetrics | null> => {
+      const r = await fetch(
+        "/api/admin/email/monitor/metrics?minutesBack=15"
+      );
+      if (!r.ok) throw new Error("gauge_failed");
+      const json = (await r.json()) as { metrics?: EventMetrics | null };
+      return json.metrics ?? null;
+    },
+    refetchInterval: () => (isVisible() ? 5000 : false),
+    refetchIntervalInBackground: false,
+  });
+
+  return (
+    <section className="space-y-5">
+      <header className="flex items-start justify-between flex-wrap gap-3">
+        <div>
+          <h3 className="font-cakemono font-light text-[14px] tracking-[0.06em] text-text">
+            // EVENT MONITOR
+          </h3>
+          <p className="font-mono text-[11px] text-text-3">
+            [live deliverability — refreshes every 5s while visible]
+          </p>
+        </div>
+        <MonitorFilters
+          windowMinutes={windowMinutes}
+          setWindowMinutes={setWindowMinutes}
+          bucket={bucket}
+          setBucket={setBucket}
+          eventTypes={eventTypes}
+          setEventTypes={setEventTypes}
+        />
+      </header>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-4">
+        <BounceGauge bouncePct={Number(gauge.data?.bounce_pct ?? 0)} />
+        <MonitorMetricBar metrics={metrics.data ?? null} />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <EventStream eventTypes={eventTypes.length > 0 ? eventTypes : undefined} />
+        <TopBounceDomains minutesBack={windowMinutes} />
+      </div>
+
+      <AnomalyHistory />
+    </section>
+  );
+}

--- a/src/app/admin/email/_components/event-monitor-tab.tsx
+++ b/src/app/admin/email/_components/event-monitor-tab.tsx
@@ -67,7 +67,7 @@ export function EventMonitorTab() {
       <header className="flex items-start justify-between flex-wrap gap-3">
         <div>
           <h3 className="font-cakemono font-light text-[14px] tracking-[0.06em] text-text">
-            // EVENT MONITOR
+            {"// EVENT MONITOR"}
           </h3>
           <p className="font-mono text-[11px] text-text-3">
             [live deliverability — refreshes every 5s while visible]

--- a/src/app/admin/email/_components/event-stream.tsx
+++ b/src/app/admin/email/_components/event-stream.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * Live tail of the most recent email events. Refreshes every 5 seconds while
+ * the tab is visible — pauses on hidden tab to avoid wasted polling.
+ */
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { useQuery } from "@tanstack/react-query";
+import { eventStreamRowVariants } from "@/lib/utils/motion";
+import type { EventStreamRow } from "@/lib/admin/types";
+
+interface Props {
+  eventTypes?: string[];
+}
+
+const EVENT_COLORS: Record<string, string> = {
+  delivered: "#9DB582",
+  processed: "#B5B5B5",
+  open: "#C4A868",
+  click: "#6F94B0",
+  bounce: "#B58289",
+  spamreport: "#93321A",
+  dropped: "#C4A868",
+  deferred: "#8A8A8A",
+  unsubscribe: "#B58289",
+  group_unsubscribe: "#B58289",
+};
+
+function isVisible(): boolean {
+  return typeof document !== "undefined"
+    ? document.visibilityState === "visible"
+    : true;
+}
+
+export function EventStream({ eventTypes }: Props) {
+  const reduce = useReducedMotion();
+  const stream = useQuery({
+    queryKey: ["eventStream", eventTypes?.join(",") ?? ""],
+    queryFn: async (): Promise<EventStreamRow[]> => {
+      const sp = new URLSearchParams({ limit: "50" });
+      if (eventTypes && eventTypes.length > 0) {
+        sp.set("events", eventTypes.join(","));
+      }
+      const r = await fetch(`/api/admin/email/monitor/stream?${sp.toString()}`);
+      if (!r.ok) throw new Error("stream_failed");
+      const json = (await r.json()) as { events?: EventStreamRow[] };
+      return json.events ?? [];
+    },
+    refetchInterval: () => (isVisible() ? 5000 : false),
+    refetchIntervalInBackground: false,
+  });
+
+  return (
+    <div
+      className="rounded-panel overflow-hidden"
+      style={{ border: "1px solid rgba(255,255,255,0.06)" }}
+    >
+      <p
+        className="px-3 py-2 font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3"
+        style={{ background: "rgba(255,255,255,0.02)" }}
+      >
+        // EVENT STREAM [last 50]
+      </p>
+      <div className="max-h-[420px] overflow-y-auto scrollbar-hide">
+        <AnimatePresence initial={false}>
+          {stream.data?.map((e) => (
+            <motion.div
+              key={e.id}
+              variants={reduce ? undefined : eventStreamRowVariants}
+              initial={reduce ? false : "hidden"}
+              animate={reduce ? undefined : "visible"}
+              exit={reduce ? undefined : "exit"}
+              className="grid grid-cols-[80px_1fr_120px] gap-3 px-3 py-1.5 border-t border-white/[0.04] items-center font-mono text-[11px]"
+              style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+            >
+              <span
+                className="font-cakemono font-light text-[10px] tracking-[0.06em]"
+                style={{ color: EVENT_COLORS[e.event] ?? "#B5B5B5" }}
+              >
+                {e.event.toUpperCase()}
+              </span>
+              <span className="text-text truncate">{e.email}</span>
+              <span className="text-text-3 text-right">
+                {new Date(e.timestamp).toLocaleTimeString()}
+              </span>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+        {(stream.data?.length ?? 0) === 0 && !stream.isLoading && (
+          <p className="font-mono text-[11px] text-text-mute py-6">
+            [no events in window]
+          </p>
+        )}
+        {stream.isLoading && (stream.data?.length ?? 0) === 0 && (
+          <p className="font-mono text-[11px] text-text-mute py-6">
+            [loading...]
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/email/_components/event-stream.tsx
+++ b/src/app/admin/email/_components/event-stream.tsx
@@ -59,7 +59,7 @@ export function EventStream({ eventTypes }: Props) {
         className="px-3 py-2 font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3"
         style={{ background: "rgba(255,255,255,0.02)" }}
       >
-        // EVENT STREAM [last 50]
+        {"// EVENT STREAM [last 50]"}
       </p>
       <div className="max-h-[420px] overflow-y-auto scrollbar-hide">
         <AnimatePresence initial={false}>

--- a/src/app/admin/email/_components/event-stream.tsx
+++ b/src/app/admin/email/_components/event-stream.tsx
@@ -34,7 +34,7 @@ function isVisible(): boolean {
 
 export function EventStream({ eventTypes }: Props) {
   const reduce = useReducedMotion();
-  const stream = useQuery({
+  const stream = useQuery<EventStreamRow[]>({
     queryKey: ["eventStream", eventTypes?.join(",") ?? ""],
     queryFn: async (): Promise<EventStreamRow[]> => {
       const sp = new URLSearchParams({ limit: "50" });
@@ -86,12 +86,12 @@ export function EventStream({ eventTypes }: Props) {
             </motion.div>
           ))}
         </AnimatePresence>
-        {(stream.data?.length ?? 0) === 0 && !stream.isLoading && (
+        {!stream.isLoading && !stream.data?.length && (
           <p className="font-mono text-[11px] text-text-mute py-6">
             [no events in window]
           </p>
         )}
-        {stream.isLoading && (stream.data?.length ?? 0) === 0 && (
+        {stream.isLoading && (
           <p className="font-mono text-[11px] text-text-mute py-6">
             [loading...]
           </p>

--- a/src/app/admin/email/_components/monitor-filters.tsx
+++ b/src/app/admin/email/_components/monitor-filters.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+/**
+ * Filter chips for the Event Monitor — window length, bucket size, event
+ * type filter for the live stream.
+ */
+import * as React from "react";
+
+interface Props {
+  windowMinutes: number;
+  setWindowMinutes: (n: number) => void;
+  bucket: "1m" | "5m" | "15m";
+  setBucket: (b: "1m" | "5m" | "15m") => void;
+  eventTypes: string[];
+  setEventTypes: (t: string[]) => void;
+}
+
+const WINDOWS: Array<{ id: number; label: string }> = [
+  { id: 15, label: "15M" },
+  { id: 60, label: "1H" },
+  { id: 360, label: "6H" },
+  { id: 1440, label: "24H" },
+];
+
+const BUCKETS: ReadonlyArray<{ id: "1m" | "5m" | "15m"; label: string }> = [
+  { id: "1m", label: "1M" },
+  { id: "5m", label: "5M" },
+  { id: "15m", label: "15M" },
+];
+
+const EVENTS = ["processed", "delivered", "bounce", "spamreport", "open", "click"];
+
+export function MonitorFilters({
+  windowMinutes,
+  setWindowMinutes,
+  bucket,
+  setBucket,
+  eventTypes,
+  setEventTypes,
+}: Props) {
+  function toggleEvent(e: string) {
+    if (eventTypes.includes(e)) {
+      setEventTypes(eventTypes.filter((x) => x !== e));
+    } else {
+      setEventTypes([...eventTypes, e]);
+    }
+  }
+
+  return (
+    <div className="flex gap-3 flex-wrap items-end">
+      <ChipGroup
+        label="WINDOW"
+        options={WINDOWS.map((w) => ({ id: String(w.id), label: w.label }))}
+        active={String(windowMinutes)}
+        onChange={(v) => setWindowMinutes(Number(v))}
+      />
+      <ChipGroup
+        label="BUCKET"
+        options={BUCKETS.map((b) => ({ id: b.id, label: b.label }))}
+        active={bucket}
+        onChange={(v) => setBucket(v as "1m" | "5m" | "15m")}
+      />
+      <div>
+        <span className="font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3 block mb-1">
+          EVENTS
+        </span>
+        <div className="flex gap-1 flex-wrap">
+          {EVENTS.map((e) => {
+            const on = eventTypes.includes(e);
+            return (
+              <button
+                key={e}
+                type="button"
+                onClick={() => toggleEvent(e)}
+                className="font-mono text-[10px] px-2 py-0.5 rounded-chip"
+                style={{
+                  border: `1px solid ${on ? "#6F94B0" : "rgba(255,255,255,0.12)"}`,
+                  color: on ? "#6F94B0" : "#B5B5B5",
+                }}
+              >
+                {e}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChipGroup({
+  label,
+  options,
+  active,
+  onChange,
+}: {
+  label: string;
+  options: ReadonlyArray<{ id: string; label: string }>;
+  active: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <span className="font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3 block mb-1">
+        {label}
+      </span>
+      <div className="flex gap-1">
+        {options.map((o) => (
+          <button
+            key={o.id}
+            type="button"
+            onClick={() => onChange(o.id)}
+            className="font-cakemono font-light text-[10px] tracking-[0.06em] px-2 py-0.5 rounded-chip"
+            style={{
+              border: `1px solid ${active === o.id ? "#6F94B0" : "rgba(255,255,255,0.12)"}`,
+              color: active === o.id ? "#6F94B0" : "#B5B5B5",
+            }}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/email/_components/monitor-metric-bar.tsx
+++ b/src/app/admin/email/_components/monitor-metric-bar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+ * 6 metric cards (sent, delivered, bounced, spam, opened, clicked) — each
+ * displays the period total in JetBrains Mono and a sparkline drawn from
+ * the by_minute buckets returned by email_event_metrics.
+ */
+import { motion, useReducedMotion } from "framer-motion";
+import { sparklineVariants } from "@/lib/utils/motion";
+import type { EventMetrics, EventMetricsBucket } from "@/lib/admin/types";
+
+interface Props {
+  metrics: EventMetrics | null;
+}
+
+type BucketKey = "sent" | "delivered" | "bounced" | "spam" | "open" | "click";
+
+interface CardSpec {
+  key: BucketKey;
+  label: string;
+  total: number;
+  color: string;
+}
+
+export function MonitorMetricBar({ metrics }: Props) {
+  if (!metrics) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="rounded-panel p-3 h-[64px]"
+            style={{
+              border: "1px solid rgba(255,255,255,0.06)",
+              background: "rgba(255,255,255,0.02)",
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const cards: CardSpec[] = [
+    { key: "sent", label: "SENT", total: metrics.total_sent, color: "#B5B5B5" },
+    { key: "delivered", label: "DELIVERED", total: metrics.total_delivered, color: "#9DB582" },
+    { key: "bounced", label: "BOUNCED", total: metrics.total_bounced, color: "#B58289" },
+    { key: "spam", label: "SPAM", total: metrics.total_spam, color: "#93321A" },
+    { key: "open", label: "OPENED", total: metrics.total_open, color: "#C4A868" },
+    { key: "click", label: "CLICKED", total: metrics.total_click, color: "#6F94B0" },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {cards.map((c) => (
+        <Card key={c.key} spec={c} buckets={metrics.by_minute} />
+      ))}
+    </div>
+  );
+}
+
+function Card({ spec, buckets }: { spec: CardSpec; buckets: EventMetricsBucket[] }) {
+  const reduce = useReducedMotion();
+  const points = buckets.map((b) => Number(b[spec.key]) || 0);
+  const max = Math.max(...points, 1);
+  const path =
+    points.length > 1
+      ? "M " +
+        points
+          .map((v, i) => `${(i / (points.length - 1)) * 100} ${30 - (v / max) * 28}`)
+          .join(" L ")
+      : "M 0 28 L 100 28";
+
+  return (
+    <div
+      className="rounded-panel p-3"
+      style={{ border: "1px solid rgba(255,255,255,0.06)" }}
+    >
+      <div className="flex items-baseline justify-between mb-1">
+        <span className="font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3">
+          {spec.label}
+        </span>
+        <span
+          className="font-mono text-[18px]"
+          style={{ color: spec.color, fontFeatureSettings: '"tnum" 1, "zero" 1' }}
+        >
+          {spec.total.toLocaleString()}
+        </span>
+      </div>
+      <svg viewBox="0 0 100 30" className="w-full h-8" preserveAspectRatio="none">
+        <motion.path
+          d={path}
+          fill="none"
+          stroke={spec.color}
+          strokeWidth="1.2"
+          strokeLinecap="round"
+          variants={reduce ? undefined : sparklineVariants}
+          initial={reduce ? false : "hidden"}
+          animate={reduce ? undefined : "visible"}
+        />
+      </svg>
+    </div>
+  );
+}

--- a/src/app/admin/email/_components/top-bounce-domains.tsx
+++ b/src/app/admin/email/_components/top-bounce-domains.tsx
@@ -42,7 +42,7 @@ export function TopBounceDomains({ minutesBack }: Props) {
       style={{ border: "1px solid rgba(255,255,255,0.06)" }}
     >
       <span className="font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3 block mb-3">
-        // TOP BOUNCE DOMAINS
+        {"// TOP BOUNCE DOMAINS"}
       </span>
       <div className="space-y-2">
         {q.data?.map((d, i) => (

--- a/src/app/admin/email/_components/top-bounce-domains.tsx
+++ b/src/app/admin/email/_components/top-bounce-domains.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+/**
+ * Horizontal-bar list of the top 10 bounce-receiver domains in the window.
+ * Refreshes every 10 seconds while visible.
+ */
+import { motion, useReducedMotion } from "framer-motion";
+import { useQuery } from "@tanstack/react-query";
+import type { TopBounceDomain } from "@/lib/admin/types";
+
+interface Props {
+  minutesBack: number;
+}
+
+function isVisible(): boolean {
+  return typeof document !== "undefined"
+    ? document.visibilityState === "visible"
+    : true;
+}
+
+export function TopBounceDomains({ minutesBack }: Props) {
+  const reduce = useReducedMotion();
+  const q = useQuery({
+    queryKey: ["topBounceDomains", minutesBack],
+    queryFn: async (): Promise<TopBounceDomain[]> => {
+      const r = await fetch(
+        `/api/admin/email/monitor/domains?minutesBack=${minutesBack}&limit=10`
+      );
+      if (!r.ok) throw new Error("domains_failed");
+      const json = (await r.json()) as { domains?: TopBounceDomain[] };
+      return json.domains ?? [];
+    },
+    refetchInterval: () => (isVisible() ? 10000 : false),
+    refetchIntervalInBackground: false,
+  });
+
+  const max = Math.max(...(q.data?.map((d) => d.bounce_count) ?? [1]), 1);
+
+  return (
+    <div
+      className="rounded-panel p-3"
+      style={{ border: "1px solid rgba(255,255,255,0.06)" }}
+    >
+      <span className="font-cakemono font-light text-[10px] tracking-[0.06em] text-text-3 block mb-3">
+        // TOP BOUNCE DOMAINS
+      </span>
+      <div className="space-y-2">
+        {q.data?.map((d, i) => (
+          <div
+            key={d.domain}
+            className="grid grid-cols-[140px_1fr_60px] gap-2 items-center"
+          >
+            <span className="font-mono text-[11px] text-text truncate">
+              {d.domain}
+            </span>
+            <div
+              className="h-[4px] rounded-bar overflow-hidden"
+              style={{ background: "rgba(255,255,255,0.04)" }}
+            >
+              <motion.div
+                className="h-full"
+                style={{ background: "#B58289" }}
+                initial={reduce ? false : { width: 0 }}
+                animate={{ width: `${(d.bounce_count / max) * 100}%` }}
+                transition={
+                  reduce
+                    ? { duration: 0 }
+                    : { duration: 0.5, ease: [0.22, 1, 0.36, 1], delay: i * 0.04 }
+                }
+              />
+            </div>
+            <span
+              className="font-mono text-[11px] text-text-2 text-right"
+              style={{ fontFeatureSettings: '"tnum" 1' }}
+            >
+              {d.bounce_count}
+            </span>
+          </div>
+        ))}
+        {(q.data?.length ?? 0) === 0 && !q.isLoading && (
+          <p className="font-mono text-[11px] text-text-mute py-2">
+            [no bounces in window]
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/email/monitor/anomalies/route.ts
+++ b/src/app/api/admin/email/monitor/anomalies/route.ts
@@ -1,0 +1,55 @@
+/**
+ * GET /api/admin/email/monitor/anomalies
+ *
+ * Paginated read of `email_anomaly_log`. Used by the Anomaly History
+ * panel and supports drill-down by kind.
+ *
+ * Query params:
+ *   - limit: 1..200 (default 50)
+ *   - offset: >= 0 (default 0)
+ *   - kind: optional bounce_spike | spam_spike | delivery_drop | volume_drop
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const VALID_KINDS = new Set([
+  "bounce_spike",
+  "spam_spike",
+  "delivery_drop",
+  "volume_drop",
+]);
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+
+  const sp = req.nextUrl.searchParams;
+  const limitRaw = Number(sp.get("limit") ?? 50);
+  const limit = Number.isFinite(limitRaw)
+    ? Math.min(Math.max(Math.trunc(limitRaw), 1), 200)
+    : 50;
+  const offsetRaw = Number(sp.get("offset") ?? 0);
+  const offset = Number.isFinite(offsetRaw)
+    ? Math.max(Math.trunc(offsetRaw), 0)
+    : 0;
+  const kindParam = sp.get("kind");
+  const kind = kindParam && VALID_KINDS.has(kindParam) ? kindParam : null;
+
+  const db = getServiceRoleClient();
+  let q = db
+    .from("email_anomaly_log")
+    .select("*", { count: "exact" })
+    .order("detected_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+  if (kind) q = q.eq("kind", kind);
+
+  const { data, count, error } = await q;
+  if (error) {
+    console.error("[monitor/anomalies] error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ rows: data ?? [], total: count ?? 0 });
+});

--- a/src/app/api/admin/email/monitor/domains/route.ts
+++ b/src/app/api/admin/email/monitor/domains/route.ts
@@ -1,0 +1,41 @@
+/**
+ * GET /api/admin/email/monitor/domains
+ *
+ * Returns the top N bounce-receiver domains in the window. Used by the
+ * "Top bounce domains" horizontal-bar widget.
+ *
+ * Query params:
+ *   - minutesBack: 5..1440 (default 60)
+ *   - limit: 1..50 (default 10)
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+
+  const sp = req.nextUrl.searchParams;
+  const minutesBackRaw = Number(sp.get("minutesBack") ?? 60);
+  const minutesBack = Number.isFinite(minutesBackRaw)
+    ? Math.min(Math.max(Math.trunc(minutesBackRaw), 5), 1440)
+    : 60;
+  const limitRaw = Number(sp.get("limit") ?? 10);
+  const limit = Number.isFinite(limitRaw)
+    ? Math.min(Math.max(Math.trunc(limitRaw), 1), 50)
+    : 10;
+
+  const db = getServiceRoleClient();
+  const { data, error } = await db.rpc("email_top_bounce_domains", {
+    p_minutes_back: minutesBack,
+    p_limit: limit,
+  });
+  if (error) {
+    console.error("[monitor/domains] RPC error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ domains: data ?? [] });
+});

--- a/src/app/api/admin/email/monitor/metrics/route.ts
+++ b/src/app/api/admin/email/monitor/metrics/route.ts
@@ -1,0 +1,43 @@
+/**
+ * GET /api/admin/email/monitor/metrics
+ *
+ * Admin-gated read of `email_event_metrics(p_minutes_back, p_bucket)`.
+ * Used by the Event Monitor dashboard at /admin/email?tab=event-monitor.
+ *
+ * Query params:
+ *   - minutesBack: 5..1440 (default 60)
+ *   - bucket: 1m | 5m | 15m | (omit for no bucketing)
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+
+  const sp = req.nextUrl.searchParams;
+  const minutesBackRaw = Number(sp.get("minutesBack") ?? 60);
+  const minutesBack = Number.isFinite(minutesBackRaw)
+    ? Math.min(Math.max(Math.trunc(minutesBackRaw), 5), 1440)
+    : 60;
+
+  const bucketParam = sp.get("bucket");
+  const bucket =
+    bucketParam === "1m" || bucketParam === "5m" || bucketParam === "15m"
+      ? bucketParam
+      : null;
+
+  const db = getServiceRoleClient();
+  const { data, error } = await db.rpc("email_event_metrics", {
+    p_minutes_back: minutesBack,
+    p_bucket: bucket,
+  });
+  if (error) {
+    console.error("[monitor/metrics] RPC error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ metrics: data });
+});

--- a/src/app/api/admin/email/monitor/stream/route.ts
+++ b/src/app/api/admin/email/monitor/stream/route.ts
@@ -1,0 +1,47 @@
+/**
+ * GET /api/admin/email/monitor/stream
+ *
+ * Returns the most recent N rows from `email_events`, optionally filtered
+ * by event types. Used by the live event stream panel in the Event Monitor.
+ *
+ * Query params:
+ *   - limit: 1..200 (default 50)
+ *   - events: comma-separated list of event types (e.g. "bounce,spamreport")
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+
+  const sp = req.nextUrl.searchParams;
+  const limitRaw = Number(sp.get("limit") ?? 50);
+  const limit = Number.isFinite(limitRaw)
+    ? Math.min(Math.max(Math.trunc(limitRaw), 1), 200)
+    : 50;
+
+  const eventTypes = sp
+    .get("events")
+    ?.split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const db = getServiceRoleClient();
+  let q = db
+    .from("email_events")
+    .select("id, email, event, timestamp, sg_message_id, reason")
+    .order("timestamp", { ascending: false })
+    .limit(limit);
+  if (eventTypes && eventTypes.length > 0) q = q.in("event", eventTypes);
+
+  const { data, error } = await q;
+  if (error) {
+    console.error("[monitor/stream] error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ events: data ?? [] });
+});

--- a/src/app/api/admin/email/pause/route.ts
+++ b/src/app/api/admin/email/pause/route.ts
@@ -69,7 +69,7 @@ export const POST = withAdmin(async (req: NextRequest) => {
       actorUserId: admin.uid,
       actorEmail: admin.email,
     });
-    return NextResponse.json({ ok: true, paused: result });
+    return NextResponse.json({ ok: true, paused: result.state });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json({ ok: false, error: message }, { status: 500 });

--- a/src/app/api/cron/email/anomaly-check/route.ts
+++ b/src/app/api/cron/email/anomaly-check/route.ts
@@ -1,0 +1,212 @@
+/**
+ * /api/cron/email/anomaly-check
+ *
+ * Runs every 5 minutes. Pulls deliverability metrics from the
+ * `email_event_metrics` RPC for the live 15-min window plus a 60-min
+ * baseline (used for volume drop detection), evaluates them against the
+ * pure evaluator in src/lib/email/anomaly-thresholds.ts, dedups against
+ * recent log rows, persists new breaches into `email_anomaly_log`,
+ * fires a notification rail entry for the operator, and — for critical
+ * bounce/spam spikes only — calls pause('global', ...) and writes the
+ * resulting audit id back onto the anomaly row.
+ *
+ * Auth: Bearer ${CRON_SECRET}.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import {
+  evaluateThresholds,
+  severityRank,
+  type AnomalyEval,
+  type MetricSnapshot,
+} from "@/lib/email/anomaly-thresholds";
+import { pause } from "@/lib/email/pause";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const DEDUP_WINDOW_MINUTES = 60;
+
+interface MetricsResp {
+  window_minutes: number;
+  total_sent: number;
+  total_delivered: number;
+  total_bounced: number;
+  bounce_pct: number;
+  total_spam: number;
+  spam_pct: number;
+  total_open: number;
+  open_pct: number;
+  total_click: number;
+  click_pct: number;
+  error_events: number;
+}
+
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json(
+      { ok: false, error: "CRON_SECRET not configured" },
+      { status: 500 }
+    );
+  }
+  if (request.headers.get("authorization") !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const db = getServiceRoleClient();
+
+  const [{ data: nowRaw, error: nowErr }, { data: baseRaw }] = await Promise.all([
+    db.rpc("email_event_metrics", { p_minutes_back: 15 }),
+    db.rpc("email_event_metrics", { p_minutes_back: 60 }),
+  ]);
+  if (nowErr || !nowRaw) {
+    console.error("[anomaly-check] metrics fetch failed:", nowErr);
+    return NextResponse.json({ ok: false, error: "metrics_failed" }, { status: 500 });
+  }
+  const m = nowRaw as MetricsResp;
+  const base = baseRaw as MetricsResp | null;
+
+  const snapshot: MetricSnapshot = {
+    windowMinutes: m.window_minutes,
+    totalSent: m.total_sent,
+    totalDelivered: m.total_delivered,
+    totalBounced: m.total_bounced,
+    bouncePct: Number(m.bounce_pct),
+    totalSpam: m.total_spam,
+    spamPct: Number(m.spam_pct),
+    totalOpen: m.total_open,
+    openPct: Number(m.open_pct),
+    totalClick: m.total_click,
+    clickPct: Number(m.click_pct),
+    errorEvents: m.error_events,
+    baselineSent: base?.total_sent,
+    baselineWindowMinutes: base?.window_minutes,
+  };
+
+  const evals = evaluateThresholds(snapshot);
+  if (evals.length === 0) {
+    return NextResponse.json({ ok: true, evals: 0, written: 0 });
+  }
+
+  const sinceIso = new Date(Date.now() - DEDUP_WINDOW_MINUTES * 60 * 1000).toISOString();
+  const { data: recent } = await db
+    .from("email_anomaly_log")
+    .select("kind, severity, detected_at")
+    .gte("detected_at", sinceIso);
+
+  const recentByKind = new Map<string, "warn" | "critical">();
+  for (const r of (recent ?? []) as Array<{ kind: string; severity: "warn" | "critical" }>) {
+    const prev = recentByKind.get(r.kind);
+    if (!prev || severityRank(r.severity) >= severityRank(prev)) {
+      recentByKind.set(r.kind, r.severity);
+    }
+  }
+
+  let written = 0;
+  for (const ev of evals) {
+    const recentSev = recentByKind.get(ev.kind);
+    if (recentSev && severityRank(recentSev) >= severityRank(ev.severity)) {
+      continue;
+    }
+
+    const { data: logRow, error: logErr } = await db
+      .from("email_anomaly_log")
+      .insert({
+        kind: ev.kind,
+        severity: ev.severity,
+        window_minutes: ev.windowMinutes,
+        metric_value: ev.metricValue,
+        threshold: ev.threshold,
+        context: ev.context,
+        action_taken: null,
+      })
+      .select("id")
+      .single();
+    if (logErr || !logRow) {
+      console.error("[anomaly-check] log insert failed:", logErr);
+      continue;
+    }
+    const anomalyId = logRow.id as string;
+
+    let pauseAuditId: string | null = null;
+    let actionTaken: string | null = null;
+    if (
+      ev.severity === "critical" &&
+      (ev.kind === "bounce_spike" || ev.kind === "spam_spike")
+    ) {
+      const operatorUserId = process.env.PMF_OPERATOR_USER_ID;
+      const operatorEmail = process.env.PMF_NOTIFICATION_EMAIL;
+      if (!operatorUserId || !operatorEmail) {
+        actionTaken =
+          "pause skipped: PMF_OPERATOR_USER_ID or PMF_NOTIFICATION_EMAIL unset (cannot record actor)";
+        console.error("[anomaly-check] pause skipped — missing actor env vars");
+      } else {
+        try {
+          const result = await pause({
+            scope: "global",
+            reason: `auto: ${ev.kind} ${ev.metricValue}% over ${ev.threshold}%`,
+            actorUserId: operatorUserId,
+            actorEmail: operatorEmail,
+            severity: "critical",
+            anomalyLogId: anomalyId,
+          });
+          pauseAuditId = result.pauseAuditId;
+          actionTaken = `pause(global) by anomaly ${ev.kind}@${ev.metricValue}% [audit ${pauseAuditId ?? "unknown"}]`;
+        } catch (err) {
+          actionTaken = `pause attempt failed: ${err instanceof Error ? err.message : String(err)}`;
+          console.error("[anomaly-check] pause failed:", err);
+        }
+      }
+    }
+
+    const operatorUserId = process.env.PMF_OPERATOR_USER_ID;
+    const operatorCompanyId = process.env.PMF_OPERATOR_COMPANY_ID;
+    let notifId: string | null = null;
+    if (operatorUserId && operatorCompanyId) {
+      const { data: notifRow } = await db
+        .from("notifications")
+        .insert({
+          user_id: operatorUserId,
+          company_id: operatorCompanyId,
+          type: "email_anomaly",
+          title: `${ev.severity === "critical" ? "CRITICAL" : "WARN"} :: ${labelForKind(ev.kind)}`,
+          body: `${ev.metricValue.toFixed(2)} (threshold ${ev.threshold}) over ${ev.windowMinutes}m`,
+          is_read: false,
+          persistent: ev.severity === "critical",
+          action_url: "/admin/email?tab=event-monitor",
+          action_label: "VIEW MONITOR",
+        })
+        .select("id")
+        .single();
+      notifId = (notifRow?.id as string | undefined) ?? null;
+    }
+
+    await db
+      .from("email_anomaly_log")
+      .update({
+        action_taken: actionTaken,
+        notification_id: notifId,
+        pause_audit_id: pauseAuditId,
+      })
+      .eq("id", anomalyId);
+
+    written++;
+  }
+
+  return NextResponse.json({ ok: true, evals: evals.length, written });
+}
+
+function labelForKind(k: AnomalyEval["kind"]): string {
+  switch (k) {
+    case "bounce_spike":
+      return "BOUNCE SPIKE";
+    case "spam_spike":
+      return "SPAM SPIKE";
+    case "delivery_drop":
+      return "DELIVERY DROP";
+    case "volume_drop":
+      return "VOLUME DROP";
+  }
+}

--- a/src/lib/admin/types.ts
+++ b/src/lib/admin/types.ts
@@ -690,3 +690,69 @@ export interface AudiencePreviewResponse {
   count: number;
   sample: Array<{ user_id: string; email: string }>;
 }
+
+// ─── Email — Event Monitor (PR 8) ─────────────────────────────────────────
+
+export interface EventMetricsBucket {
+  bucket_at: string;
+  sent: number;
+  delivered: number;
+  bounced: number;
+  spam: number;
+  open: number;
+  click: number;
+}
+
+export interface EventMetrics {
+  window_minutes: number;
+  total_sent: number;
+  total_delivered: number;
+  total_bounced: number;
+  bounce_pct: number;
+  total_spam: number;
+  spam_pct: number;
+  total_open: number;
+  open_pct: number;
+  total_click: number;
+  click_pct: number;
+  error_events: number;
+  by_minute: EventMetricsBucket[];
+}
+
+export interface EventStreamRow {
+  id: string;
+  email: string;
+  event: string;
+  timestamp: string;
+  sg_message_id: string | null;
+  reason: string | null;
+}
+
+export interface TopBounceDomain {
+  domain: string;
+  bounce_count: number;
+  bounce_pct: number;
+}
+
+export type AnomalyKind =
+  | "bounce_spike"
+  | "spam_spike"
+  | "delivery_drop"
+  | "volume_drop";
+
+export type AnomalySeverity = "warn" | "critical";
+
+export interface AnomalyLogRow {
+  id: string;
+  detected_at: string;
+  kind: AnomalyKind;
+  severity: AnomalySeverity;
+  window_minutes: number;
+  metric_value: number;
+  threshold: number;
+  context: Record<string, unknown>;
+  action_taken: string | null;
+  notification_id: string | null;
+  pause_audit_id: string | null;
+  resolved_at: string | null;
+}

--- a/src/lib/email/anomaly-thresholds.ts
+++ b/src/lib/email/anomaly-thresholds.ts
@@ -1,0 +1,129 @@
+/**
+ * OPS Email — anomaly thresholds.
+ *
+ * Pure functions only. No I/O. evaluateThresholds(snapshot) returns the
+ * full list of breaches the cron should consider; the cron applies dedup
+ * logic and decides which to actually persist.
+ */
+
+export const BOUNCE_WARN_PCT = 5;
+export const BOUNCE_CRIT_PCT = 10;
+export const SPAM_WARN_PCT = 0.1;
+export const SPAM_CRIT_PCT = 0.5;
+/** Delivered/sent below this percentage in window → delivery_drop. */
+export const DELIVERY_WARN_PCT = 80;
+/** Delivery rate below this percentage → critical instead of warn. */
+export const DELIVERY_CRIT_PCT = 60;
+/** Volume <X% of trailing baseline → volume_drop. */
+export const VOLUME_DROP_PCT = 10;
+/** Volume_drop ratio below this percentage → critical. */
+export const VOLUME_CRIT_PCT = 1;
+/** Require at least N sends before computing percentage anomalies (suppresses noise). */
+export const MIN_SENDS_FOR_PCT = 5;
+
+export type AnomalyKind =
+  | "bounce_spike" | "spam_spike" | "delivery_drop" | "volume_drop";
+export type AnomalySeverity = "warn" | "critical";
+
+export interface MetricSnapshot {
+  windowMinutes: number;
+  totalSent: number;
+  totalDelivered: number;
+  totalBounced: number;
+  bouncePct: number;
+  totalSpam: number;
+  spamPct: number;
+  totalOpen: number;
+  openPct: number;
+  totalClick: number;
+  clickPct: number;
+  errorEvents: number;
+  /** Optional baseline from a longer prior window for volume drop detection. */
+  baselineSent?: number;
+  baselineWindowMinutes?: number;
+}
+
+export interface AnomalyEval {
+  kind: AnomalyKind;
+  severity: AnomalySeverity;
+  metricValue: number;
+  threshold: number;
+  windowMinutes: number;
+  context: Record<string, unknown>;
+}
+
+export function evaluateThresholds(s: MetricSnapshot): AnomalyEval[] {
+  const out: AnomalyEval[] = [];
+
+  if (s.totalSent >= MIN_SENDS_FOR_PCT) {
+    if (s.bouncePct >= BOUNCE_CRIT_PCT) {
+      out.push({
+        kind: "bounce_spike", severity: "critical",
+        metricValue: s.bouncePct, threshold: BOUNCE_CRIT_PCT,
+        windowMinutes: s.windowMinutes,
+        context: { total_sent: s.totalSent, total_bounced: s.totalBounced, bounce_pct: s.bouncePct },
+      });
+    } else if (s.bouncePct >= BOUNCE_WARN_PCT) {
+      out.push({
+        kind: "bounce_spike", severity: "warn",
+        metricValue: s.bouncePct, threshold: BOUNCE_WARN_PCT,
+        windowMinutes: s.windowMinutes,
+        context: { total_sent: s.totalSent, total_bounced: s.totalBounced, bounce_pct: s.bouncePct },
+      });
+    }
+  }
+
+  if (s.totalDelivered >= MIN_SENDS_FOR_PCT) {
+    if (s.spamPct >= SPAM_CRIT_PCT) {
+      out.push({
+        kind: "spam_spike", severity: "critical",
+        metricValue: s.spamPct, threshold: SPAM_CRIT_PCT,
+        windowMinutes: s.windowMinutes,
+        context: { total_delivered: s.totalDelivered, total_spam: s.totalSpam, spam_pct: s.spamPct },
+      });
+    } else if (s.spamPct >= SPAM_WARN_PCT) {
+      out.push({
+        kind: "spam_spike", severity: "warn",
+        metricValue: s.spamPct, threshold: SPAM_WARN_PCT,
+        windowMinutes: s.windowMinutes,
+        context: { total_delivered: s.totalDelivered, total_spam: s.totalSpam, spam_pct: s.spamPct },
+      });
+    }
+  }
+
+  if (s.totalSent >= MIN_SENDS_FOR_PCT) {
+    const deliveryPct = (s.totalDelivered / Math.max(s.totalSent, 1)) * 100;
+    if (deliveryPct < DELIVERY_WARN_PCT) {
+      out.push({
+        kind: "delivery_drop",
+        severity: deliveryPct < DELIVERY_CRIT_PCT ? "critical" : "warn",
+        metricValue: deliveryPct, threshold: DELIVERY_WARN_PCT,
+        windowMinutes: s.windowMinutes,
+        context: { total_sent: s.totalSent, total_delivered: s.totalDelivered, delivery_pct: deliveryPct },
+      });
+    }
+  }
+
+  if (s.baselineSent !== undefined && s.baselineSent > 0) {
+    const ratio = (s.totalSent / s.baselineSent) * 100;
+    if (ratio < VOLUME_DROP_PCT) {
+      out.push({
+        kind: "volume_drop",
+        severity: ratio < VOLUME_CRIT_PCT ? "critical" : "warn",
+        metricValue: ratio, threshold: VOLUME_DROP_PCT,
+        windowMinutes: s.windowMinutes,
+        context: {
+          total_sent: s.totalSent,
+          baseline_sent: s.baselineSent,
+          baseline_window_minutes: s.baselineWindowMinutes,
+        },
+      });
+    }
+  }
+
+  return out;
+}
+
+export function severityRank(s: AnomalySeverity): number {
+  return s === "critical" ? 2 : 1;
+}

--- a/src/lib/email/pause.ts
+++ b/src/lib/email/pause.ts
@@ -179,9 +179,29 @@ interface PauseInput {
   pausedUntil?: string | null;
   actorUserId: string;
   actorEmail: string;
+  /**
+   * Optional severity tag — populated by the anomaly cron when triggering an
+   * automatic pause. Manual pauses from the killswitches admin route leave
+   * this undefined and the audit row's severity column stays NULL.
+   */
+  severity?: "warn" | "critical";
+  /**
+   * Optional FK to the email_anomaly_log row that triggered an automatic
+   * pause. Used to render the audit chain in the admin Event Monitor tab.
+   */
+  anomalyLogId?: string;
 }
 
-export async function pause(input: PauseInput): Promise<PauseState> {
+export interface PauseResult {
+  state: PauseState;
+  /**
+   * The id of the email_pause_audit_log row written for this pause. Returned
+   * so the anomaly cron can persist it back onto email_anomaly_log.pause_audit_id.
+   */
+  pauseAuditId: string | null;
+}
+
+export async function pause(input: PauseInput): Promise<PauseResult> {
   if (!input.reason || input.reason.trim().length < 3) {
     throw new Error("Pause requires a reason (>= 3 chars)");
   }
@@ -209,14 +229,28 @@ export async function pause(input: PauseInput): Promise<PauseState> {
 
   if (error) throw new Error(`Pause failed: ${error.message}`);
 
-  await supabase.from("email_pause_audit_log").insert({
-    scope: input.scope,
-    action: "pause",
-    reason: input.reason,
-    paused_until: input.pausedUntil ?? null,
-    actor_user_id: input.actorUserId,
-    actor_email: input.actorEmail,
-  });
+  const { data: auditRow, error: auditErr } = await supabase
+    .from("email_pause_audit_log")
+    .insert({
+      scope: input.scope,
+      action: "pause",
+      reason: input.reason,
+      paused_until: input.pausedUntil ?? null,
+      actor_user_id: input.actorUserId,
+      actor_email: input.actorEmail,
+      severity: input.severity ?? null,
+      anomaly_log_id: input.anomalyLogId ?? null,
+    })
+    .select("id")
+    .single();
+
+  // Audit insert failure must not roll back the pause itself — the killswitch
+  // is already active in email_pause_state. Log the error but continue so the
+  // operator still gets the rail notification and the send chokepoint stops.
+  if (auditErr) {
+    console.error("[email-pause] audit insert failed:", auditErr);
+  }
+  const pauseAuditId = (auditRow?.id as string | undefined) ?? null;
 
   await fanoutPauseNotifications({
     scope: input.scope,
@@ -224,7 +258,7 @@ export async function pause(input: PauseInput): Promise<PauseState> {
     actorEmail: input.actorEmail,
   });
 
-  return rowToState(data);
+  return { state: rowToState(data), pauseAuditId };
 }
 
 interface ResumeInput {

--- a/src/lib/utils/motion.ts
+++ b/src/lib/utils/motion.ts
@@ -609,3 +609,34 @@ export const suppressionDrawerVariants: Variants = {
     transition: { duration: 0.24, ease: EASE_SMOOTH },
   },
 };
+
+// ─── Email Event Monitor (PR 8) ──────────────────────────────────────────
+
+/**
+ * Bounce-rate gauge needle. Sweeps from -90deg (left, 0%) to +90deg (right, 15%+).
+ * Custom value is the absolute target angle in degrees.
+ */
+export const bounceGaugeNeedleVariants: Variants = {
+  hidden: { rotate: -90 },
+  visible: (angleDeg: number) => ({
+    rotate: angleDeg,
+    transition: { duration: 0.6, ease: EASE_SMOOTH },
+  }),
+};
+
+/** Live event stream row — slide from top, fade out on exit. */
+export const eventStreamRowVariants: Variants = {
+  hidden: { opacity: 0, y: -8 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.28, ease: EASE_SMOOTH } },
+  exit: { opacity: 0, y: -8, transition: { duration: 0.18, ease: EASE_SMOOTH } },
+};
+
+/** Sparkline path draw-on. Used for the 6 metric cards in the monitor bar. */
+export const sparklineVariants: Variants = {
+  hidden: { pathLength: 0, opacity: 0 },
+  visible: {
+    pathLength: 1,
+    opacity: 1,
+    transition: { duration: 0.7, ease: EASE_SMOOTH },
+  },
+};

--- a/supabase/migrations/104_email_pause_audit_log_anomaly_columns.sql
+++ b/supabase/migrations/104_email_pause_audit_log_anomaly_columns.sql
@@ -1,0 +1,29 @@
+-- 104_email_pause_audit_log_anomaly_columns.sql
+-- PR 8: Event Monitor + Anomaly Alerts
+--
+-- Extend email_pause_audit_log with severity + anomaly_log_id so that
+-- automatic pauses triggered by /api/cron/email/anomaly-check link back
+-- to the row in email_anomaly_log that produced them. Manual pauses from
+-- the killswitches admin route leave both columns NULL.
+--
+-- The FK to email_anomaly_log is added in migration 105 (after the table
+-- is created) using ALTER TABLE — splitting it avoids a forward reference.
+
+ALTER TABLE public.email_pause_audit_log
+  ADD COLUMN IF NOT EXISTS severity text NULL,
+  ADD COLUMN IF NOT EXISTS anomaly_log_id uuid NULL;
+
+DO $$ BEGIN
+  ALTER TABLE public.email_pause_audit_log
+    ADD CONSTRAINT email_pause_audit_log_severity_check
+    CHECK (severity IS NULL OR severity IN ('warn', 'critical'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS idx_email_pause_audit_log_anomaly_log_id
+  ON public.email_pause_audit_log (anomaly_log_id)
+  WHERE anomaly_log_id IS NOT NULL;
+
+COMMENT ON COLUMN public.email_pause_audit_log.severity IS
+  'For pause actions triggered by anomaly cron: warn | critical. NULL for manual pauses.';
+COMMENT ON COLUMN public.email_pause_audit_log.anomaly_log_id IS
+  'For automatic pauses, points at email_anomaly_log.id. NULL for manual pauses. FK constraint added in migration 105.';

--- a/supabase/migrations/105_email_anomaly_log.sql
+++ b/supabase/migrations/105_email_anomaly_log.sql
@@ -1,0 +1,58 @@
+-- 105_email_anomaly_log.sql
+-- PR 8: Event Monitor + Anomaly Alerts
+--
+-- Tamper-evident log of detected deliverability anomalies. The cron writes
+-- every breach. Dedup is enforced at write time by the cron, not the schema —
+-- we want to be able to backfill / re-run without losing audit trail.
+
+DO $$ BEGIN
+  CREATE TYPE email_anomaly_kind AS ENUM (
+    'bounce_spike', 'spam_spike', 'delivery_drop', 'volume_drop'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE email_anomaly_severity AS ENUM ('warn', 'critical');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS public.email_anomaly_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  detected_at timestamptz NOT NULL DEFAULT now(),
+  kind email_anomaly_kind NOT NULL,
+  severity email_anomaly_severity NOT NULL,
+  window_minutes int NOT NULL,
+  metric_value numeric NOT NULL,
+  threshold numeric NOT NULL,
+  context jsonb NOT NULL DEFAULT '{}'::jsonb,
+  action_taken text NULL,
+  notification_id uuid NULL,
+  pause_audit_id uuid NULL REFERENCES public.email_pause_audit_log (id) ON DELETE SET NULL,
+  resolved_at timestamptz NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_anomaly_log_detected_at
+  ON public.email_anomaly_log (detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_email_anomaly_log_kind_detected
+  ON public.email_anomaly_log (kind, detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_email_anomaly_log_unresolved
+  ON public.email_anomaly_log (kind, detected_at DESC) WHERE resolved_at IS NULL;
+
+-- Now wire migration 104's anomaly_log_id column with a real FK back to
+-- email_anomaly_log.id (forward-referenced from migration 104).
+DO $$ BEGIN
+  ALTER TABLE public.email_pause_audit_log
+    ADD CONSTRAINT email_pause_audit_log_anomaly_log_id_fkey
+    FOREIGN KEY (anomaly_log_id) REFERENCES public.email_anomaly_log (id) ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Defense in depth: revoke UPDATE/DELETE from non-service roles. The cron
+-- service-role bypasses RLS; admin reads are routed through admin-gated
+-- API routes (no direct table access for authenticated users).
+REVOKE UPDATE, DELETE ON public.email_anomaly_log FROM anon, authenticated;
+
+COMMENT ON TABLE public.email_anomaly_log IS
+  'Detected deliverability anomalies. Written by /api/cron/email/anomaly-check. Dedup is enforced at write time (60-min window per kind unless severity escalates). action_taken is human-readable description (e.g. "pause(global) escalated to critical").';
+COMMENT ON COLUMN public.email_anomaly_log.context IS
+  'Snapshot context: {window_minutes, total_sent, total_delivered, total_bounced, bounce_pct, spam_pct, top_domains?, [...]}.';
+COMMENT ON COLUMN public.email_anomaly_log.pause_audit_id IS
+  'For critical anomalies that triggered an automatic pause, points at email_pause_audit_log.id. NULL for warn-only anomalies.';

--- a/supabase/migrations/106_email_event_metrics_rpc.sql
+++ b/supabase/migrations/106_email_event_metrics_rpc.sql
@@ -1,0 +1,121 @@
+-- 106_email_event_metrics_rpc.sql
+-- PR 8: Event Monitor + Anomaly Alerts
+--
+-- Aggregates email_events into a single JSONB blob for the Event Monitor
+-- dashboard and the anomaly cron. SECURITY DEFINER + service-role only.
+
+CREATE OR REPLACE FUNCTION public.email_event_metrics(
+  p_minutes_back int DEFAULT 60,
+  p_bucket text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_window_start timestamptz := now() - (p_minutes_back || ' minutes')::interval;
+  v_total_sent int; v_total_delivered int; v_total_bounced int;
+  v_total_spam int; v_total_open int; v_total_click int;
+  v_bounce_pct numeric; v_spam_pct numeric;
+  v_open_pct numeric; v_click_pct numeric;
+  v_error_events int;
+  v_by_minute jsonb;
+  v_bucket_seconds int;
+BEGIN
+  IF p_bucket = '1m' THEN v_bucket_seconds := 60;
+  ELSIF p_bucket = '5m' THEN v_bucket_seconds := 300;
+  ELSIF p_bucket = '15m' THEN v_bucket_seconds := 900;
+  ELSE v_bucket_seconds := NULL;
+  END IF;
+
+  SELECT
+    count(*) FILTER (WHERE event = 'processed'),
+    count(*) FILTER (WHERE event = 'delivered'),
+    count(*) FILTER (WHERE event = 'bounce'),
+    count(*) FILTER (WHERE event = 'spamreport'),
+    count(*) FILTER (WHERE event = 'open'),
+    count(*) FILTER (WHERE event = 'click'),
+    count(*) FILTER (WHERE event IN ('dropped','deferred','blocked'))
+  INTO v_total_sent, v_total_delivered, v_total_bounced,
+       v_total_spam, v_total_open, v_total_click, v_error_events
+  FROM public.email_events
+  WHERE timestamp >= v_window_start;
+
+  v_bounce_pct := CASE WHEN v_total_sent > 0
+    THEN round((v_total_bounced::numeric / v_total_sent::numeric) * 100, 3)
+    ELSE 0 END;
+  v_spam_pct := CASE WHEN v_total_delivered > 0
+    THEN round((v_total_spam::numeric / v_total_delivered::numeric) * 100, 4)
+    ELSE 0 END;
+  v_open_pct := CASE WHEN v_total_delivered > 0
+    THEN round((v_total_open::numeric / v_total_delivered::numeric) * 100, 2)
+    ELSE 0 END;
+  v_click_pct := CASE WHEN v_total_delivered > 0
+    THEN round((v_total_click::numeric / v_total_delivered::numeric) * 100, 2)
+    ELSE 0 END;
+
+  IF v_bucket_seconds IS NOT NULL THEN
+    SELECT jsonb_agg(jsonb_build_object(
+      'bucket_at', to_char(bucket_at, 'YYYY-MM-DD"T"HH24:MI:SSOF'),
+      'sent', sent, 'delivered', delivered, 'bounced', bounced,
+      'spam', spam, 'open', open_count, 'click', click_count
+    ) ORDER BY bucket_at)
+    INTO v_by_minute
+    FROM (
+      SELECT
+        to_timestamp(floor(extract(epoch FROM timestamp) / v_bucket_seconds) * v_bucket_seconds) AS bucket_at,
+        count(*) FILTER (WHERE event = 'processed') AS sent,
+        count(*) FILTER (WHERE event = 'delivered') AS delivered,
+        count(*) FILTER (WHERE event = 'bounce') AS bounced,
+        count(*) FILTER (WHERE event = 'spamreport') AS spam,
+        count(*) FILTER (WHERE event = 'open') AS open_count,
+        count(*) FILTER (WHERE event = 'click') AS click_count
+      FROM public.email_events
+      WHERE timestamp >= v_window_start
+      GROUP BY bucket_at
+    ) sub;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'window_minutes', p_minutes_back,
+    'total_sent', v_total_sent,
+    'total_delivered', v_total_delivered,
+    'total_bounced', v_total_bounced,
+    'bounce_pct', v_bounce_pct,
+    'total_spam', v_total_spam,
+    'spam_pct', v_spam_pct,
+    'total_open', v_total_open,
+    'open_pct', v_open_pct,
+    'total_click', v_total_click,
+    'click_pct', v_click_pct,
+    'error_events', v_error_events,
+    'by_minute', COALESCE(v_by_minute, '[]'::jsonb)
+  );
+END $$;
+
+CREATE OR REPLACE FUNCTION public.email_top_bounce_domains(
+  p_minutes_back int DEFAULT 60,
+  p_limit int DEFAULT 10
+) RETURNS TABLE(domain text, bounce_count int, bounce_pct numeric)
+LANGUAGE sql SECURITY DEFINER SET search_path = public AS $$
+  WITH bounces AS (
+    SELECT lower(split_part(email, '@', 2)) AS domain
+    FROM public.email_events
+    WHERE event = 'bounce' AND timestamp >= now() - (p_minutes_back || ' minutes')::interval
+  ),
+  agg AS (
+    SELECT domain, count(*)::int AS bounce_count, sum(count(*)) OVER () AS total
+    FROM bounces
+    WHERE domain <> ''
+    GROUP BY domain
+  )
+  SELECT domain, bounce_count,
+    CASE WHEN total > 0
+      THEN round((bounce_count::numeric / total::numeric) * 100, 2)
+      ELSE 0 END AS bounce_pct
+  FROM agg
+  ORDER BY bounce_count DESC
+  LIMIT p_limit;
+$$;
+
+REVOKE ALL ON FUNCTION public.email_event_metrics(int, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.email_top_bounce_domains(int, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.email_event_metrics(int, text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.email_top_bounce_domains(int, int) TO service_role;

--- a/supabase/migrations/107_email_events_timestamp_event_idx.sql
+++ b/supabase/migrations/107_email_events_timestamp_event_idx.sql
@@ -1,0 +1,11 @@
+-- 107_email_events_timestamp_event_idx.sql
+-- PR 8: Event Monitor + Anomaly Alerts
+--
+-- The metrics RPCs scan email_events.timestamp + event. PR 1 already created
+-- idx_email_events_timestamp; this adds a composite covering index used by
+-- the FILTER clauses in email_event_metrics for the hot window scan.
+
+CREATE INDEX IF NOT EXISTS idx_email_events_timestamp_event
+  ON public.email_events (timestamp DESC, event);
+
+ANALYZE public.email_events;

--- a/tests/integration/email-anomaly-cron.test.ts
+++ b/tests/integration/email-anomaly-cron.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Integration tests for /api/cron/email/anomaly-check.
+ *
+ * Covers: auth gating, healthy snapshot → no writes, critical bounce snapshot
+ * triggers anomaly write + pause + notification, dedup suppression.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+interface CapturedInsert {
+  table: string;
+  payload: unknown;
+}
+interface CapturedUpdate {
+  table: string;
+  payload: unknown;
+}
+interface MetricsResp {
+  window_minutes: number;
+  total_sent: number;
+  total_delivered: number;
+  total_bounced: number;
+  bounce_pct: number;
+  total_spam: number;
+  spam_pct: number;
+  total_open: number;
+  open_pct: number;
+  total_click: number;
+  click_pct: number;
+  error_events: number;
+}
+
+interface AnomalyRow {
+  kind: string;
+  severity: "warn" | "critical";
+  detected_at: string;
+}
+
+const captures = {
+  inserts: [] as CapturedInsert[],
+  updates: [] as CapturedUpdate[],
+  metrics: { value: null as MetricsResp | null },
+  recent: [] as AnomalyRow[],
+};
+
+const pauseMock = vi.fn(async () => ({
+  state: {
+    scope: "global",
+    isPaused: true,
+    pauseReason: "test",
+    pausedUntil: null,
+    pausedAt: new Date().toISOString(),
+    pausedBy: "u-op",
+  },
+  pauseAuditId: "audit-1",
+}));
+
+vi.mock("@/lib/email/pause", () => ({
+  pause: (...args: unknown[]) => pauseMock(...(args as [unknown])),
+}));
+
+vi.mock("@/lib/supabase/server-client", () => {
+  const fromBuilder = (table: string) => {
+    const insertBuilder = (payload: unknown) => {
+      captures.inserts.push({ table, payload });
+      const insertedId =
+        table === "email_anomaly_log"
+          ? "anom-1"
+          : table === "notifications"
+            ? "notif-1"
+            : "row-1";
+      return {
+        select: () => ({
+          single: async () => ({ data: { id: insertedId }, error: null }),
+        }),
+      };
+    };
+    const updateBuilder = (payload: unknown) => {
+      captures.updates.push({ table, payload });
+      return {
+        eq: async () => ({ data: null, error: null }),
+      };
+    };
+    const selectChain = () => {
+      const chain = {
+        gte: async () => ({ data: captures.recent, error: null }),
+        eq: () => chain,
+        order: () => chain,
+        limit: async () => ({ data: [], error: null, count: 0 }),
+        range: async () => ({ data: [], error: null, count: 0 }),
+      };
+      return chain;
+    };
+    return {
+      select: selectChain,
+      insert: insertBuilder,
+      update: updateBuilder,
+    };
+  };
+  return {
+    getServiceRoleClient: () => ({
+      rpc: async (_name: string, _args: unknown) => ({
+        data: captures.metrics.value,
+        error: null,
+      }),
+      from: fromBuilder,
+    }),
+  };
+});
+
+beforeEach(() => {
+  captures.inserts = [];
+  captures.updates = [];
+  captures.recent = [];
+  captures.metrics.value = null;
+  pauseMock.mockClear();
+  process.env.CRON_SECRET = "test-secret";
+  process.env.PMF_OPERATOR_USER_ID = "u-op";
+  process.env.PMF_NOTIFICATION_EMAIL = "ops@opsapp.co";
+  process.env.PMF_OPERATOR_COMPANY_ID = "co-op";
+});
+
+function buildReq(auth?: string): NextRequest {
+  const headers = new Headers();
+  if (auth) headers.set("authorization", auth);
+  return new NextRequest(
+    new URL("https://example.com/api/cron/email/anomaly-check"),
+    { headers }
+  );
+}
+
+const HEALTHY: MetricsResp = {
+  window_minutes: 15,
+  total_sent: 100,
+  total_delivered: 99,
+  total_bounced: 0,
+  bounce_pct: 0,
+  total_spam: 0,
+  spam_pct: 0,
+  total_open: 40,
+  open_pct: 40.4,
+  total_click: 5,
+  click_pct: 5.05,
+  error_events: 0,
+};
+
+const CRITICAL_BOUNCE: MetricsResp = {
+  window_minutes: 15,
+  total_sent: 100,
+  total_delivered: 80,
+  total_bounced: 12,
+  bounce_pct: 12,
+  total_spam: 0,
+  spam_pct: 0,
+  total_open: 30,
+  open_pct: 37.5,
+  total_click: 5,
+  click_pct: 6.2,
+  error_events: 0,
+};
+
+describe("anomaly-check cron", () => {
+  it("returns 500 when CRON_SECRET unset", async () => {
+    delete process.env.CRON_SECRET;
+    const { GET } = await import("@/app/api/cron/email/anomaly-check/route");
+    const res = await GET(buildReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 without auth header", async () => {
+    const { GET } = await import("@/app/api/cron/email/anomaly-check/route");
+    const res = await GET(buildReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 with wrong bearer", async () => {
+    const { GET } = await import("@/app/api/cron/email/anomaly-check/route");
+    const res = await GET(buildReq("Bearer wrong"));
+    expect(res.status).toBe(401);
+  });
+
+  it("healthy snapshot writes nothing", async () => {
+    captures.metrics.value = HEALTHY;
+    const { GET } = await import("@/app/api/cron/email/anomaly-check/route");
+    const res = await GET(buildReq("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.evals).toBe(0);
+    expect(body.written).toBe(0);
+    expect(captures.inserts.length).toBe(0);
+    expect(pauseMock).not.toHaveBeenCalled();
+  });
+
+  it("critical bounce writes anomaly + pauses + notifies", async () => {
+    captures.metrics.value = CRITICAL_BOUNCE;
+    const { GET } = await import("@/app/api/cron/email/anomaly-check/route");
+    const res = await GET(buildReq("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    expect(captures.inserts.find((i) => i.table === "email_anomaly_log")).toBeTruthy();
+    expect(captures.inserts.find((i) => i.table === "notifications")).toBeTruthy();
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+    expect(pauseMock.mock.calls[0][0]).toMatchObject({
+      scope: "global",
+      severity: "critical",
+      anomalyLogId: "anom-1",
+    });
+    // The anomaly row gets a follow-up update with pauseAuditId + notification id
+    expect(
+      captures.updates.find(
+        (u) =>
+          u.table === "email_anomaly_log" &&
+          (u.payload as { pause_audit_id?: string }).pause_audit_id ===
+            "audit-1"
+      )
+    ).toBeTruthy();
+  });
+
+  it("dedup suppresses repeat critical within 60min", async () => {
+    captures.metrics.value = CRITICAL_BOUNCE;
+    captures.recent = [
+      {
+        kind: "bounce_spike",
+        severity: "critical",
+        detected_at: new Date().toISOString(),
+      },
+    ];
+    const { GET } = await import("@/app/api/cron/email/anomaly-check/route");
+    const res = await GET(buildReq("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.written).toBe(0);
+    expect(captures.inserts.find((i) => i.table === "email_anomaly_log")).toBeFalsy();
+    expect(pauseMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/email-anomaly-cron.test.ts
+++ b/tests/integration/email-anomaly-cron.test.ts
@@ -43,7 +43,7 @@ const captures = {
   recent: [] as AnomalyRow[],
 };
 
-const pauseMock = vi.fn(async () => ({
+const pauseMock = vi.fn(async (_input: unknown) => ({
   state: {
     scope: "global",
     isPaused: true,
@@ -56,7 +56,7 @@ const pauseMock = vi.fn(async () => ({
 }));
 
 vi.mock("@/lib/email/pause", () => ({
-  pause: (...args: unknown[]) => pauseMock(...(args as [unknown])),
+  pause: (input: unknown) => pauseMock(input),
 }));
 
 vi.mock("@/lib/supabase/server-client", () => {

--- a/tests/integration/email-pause-routes.test.ts
+++ b/tests/integration/email-pause-routes.test.ts
@@ -40,12 +40,15 @@ beforeEach(() => {
   getActivePausesSpy.mockReset();
   listAuditLogSpy.mockReset();
   pauseSpy.mockResolvedValue({
-    scope: "global",
-    isPaused: true,
-    pauseReason: "ok",
-    pausedUntil: null,
-    pausedAt: new Date().toISOString(),
-    pausedBy: "admin-uuid",
+    state: {
+      scope: "global",
+      isPaused: true,
+      pauseReason: "ok",
+      pausedUntil: null,
+      pausedAt: new Date().toISOString(),
+      pausedBy: "admin-uuid",
+    },
+    pauseAuditId: "audit-stub-id",
   });
   resumeSpy.mockResolvedValue(undefined);
   getActivePausesSpy.mockResolvedValue([]);

--- a/tests/unit/email/anomaly-thresholds.test.ts
+++ b/tests/unit/email/anomaly-thresholds.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateThresholds,
+  severityRank,
+  BOUNCE_WARN_PCT,
+  BOUNCE_CRIT_PCT,
+  SPAM_WARN_PCT,
+  SPAM_CRIT_PCT,
+  DELIVERY_WARN_PCT,
+  MIN_SENDS_FOR_PCT,
+  type MetricSnapshot,
+} from "@/lib/email/anomaly-thresholds";
+
+const baseSnapshot: MetricSnapshot = {
+  windowMinutes: 15,
+  totalSent: 100,
+  totalDelivered: 95,
+  totalBounced: 1,
+  bouncePct: 1,
+  totalSpam: 0,
+  spamPct: 0,
+  totalOpen: 30,
+  openPct: 31.5,
+  totalClick: 5,
+  clickPct: 5.2,
+  errorEvents: 0,
+};
+
+describe("evaluateThresholds", () => {
+  it("clean snapshot yields no anomalies", () => {
+    expect(evaluateThresholds(baseSnapshot)).toEqual([]);
+  });
+
+  it("bounce_pct >= 5% triggers warn", () => {
+    const r = evaluateThresholds({
+      ...baseSnapshot,
+      totalBounced: 5,
+      bouncePct: BOUNCE_WARN_PCT,
+    });
+    expect(r.find((x) => x.kind === "bounce_spike")?.severity).toBe("warn");
+  });
+
+  it("bounce_pct >= 10% escalates to critical", () => {
+    const r = evaluateThresholds({
+      ...baseSnapshot,
+      totalBounced: 12,
+      bouncePct: BOUNCE_CRIT_PCT + 2,
+    });
+    expect(r.find((x) => x.kind === "bounce_spike")?.severity).toBe("critical");
+  });
+
+  it("low send volume suppresses bounce alert (under MIN_SENDS_FOR_PCT)", () => {
+    const r = evaluateThresholds({
+      ...baseSnapshot,
+      totalSent: MIN_SENDS_FOR_PCT - 1,
+      totalBounced: 1,
+      bouncePct: 50,
+    });
+    expect(r.find((x) => x.kind === "bounce_spike")).toBeUndefined();
+  });
+
+  it("spam 0.1% triggers warn", () => {
+    const r = evaluateThresholds({ ...baseSnapshot, spamPct: SPAM_WARN_PCT });
+    expect(r.find((x) => x.kind === "spam_spike")?.severity).toBe("warn");
+  });
+
+  it("spam 0.5% escalates to critical", () => {
+    const r = evaluateThresholds({ ...baseSnapshot, spamPct: SPAM_CRIT_PCT });
+    expect(r.find((x) => x.kind === "spam_spike")?.severity).toBe("critical");
+  });
+
+  it("low delivered volume suppresses spam alert", () => {
+    const r = evaluateThresholds({
+      ...baseSnapshot,
+      totalDelivered: MIN_SENDS_FOR_PCT - 1,
+      spamPct: 99,
+    });
+    expect(r.find((x) => x.kind === "spam_spike")).toBeUndefined();
+  });
+
+  it("delivery 70% triggers warn", () => {
+    const r = evaluateThresholds({ ...baseSnapshot, totalDelivered: 70 });
+    expect(r.find((x) => x.kind === "delivery_drop")?.severity).toBe("warn");
+  });
+
+  it("delivery 50% escalates to critical", () => {
+    const r = evaluateThresholds({ ...baseSnapshot, totalDelivered: 50 });
+    expect(r.find((x) => x.kind === "delivery_drop")?.severity).toBe(
+      "critical"
+    );
+  });
+
+  it("delivery at threshold yields no alert", () => {
+    const r = evaluateThresholds({
+      ...baseSnapshot,
+      totalDelivered: DELIVERY_WARN_PCT,
+    });
+    expect(r.find((x) => x.kind === "delivery_drop")).toBeUndefined();
+  });
+
+  it("volume drop with baseline triggers warn", () => {
+    const r = evaluateThresholds({
+      ...baseSnapshot,
+      totalSent: 5,
+      baselineSent: 1000,
+      baselineWindowMinutes: 60,
+    });
+    expect(r.find((x) => x.kind === "volume_drop")).toBeTruthy();
+  });
+
+  it("volume drop ratio < 1% escalates to critical", () => {
+    const r = evaluateThresholds({
+      ...baseSnapshot,
+      totalSent: 5,
+      baselineSent: 100000,
+      baselineWindowMinutes: 60,
+    });
+    expect(r.find((x) => x.kind === "volume_drop")?.severity).toBe("critical");
+  });
+
+  it("no baseline → no volume_drop", () => {
+    const r = evaluateThresholds({ ...baseSnapshot, totalSent: 1 });
+    expect(r.find((x) => x.kind === "volume_drop")).toBeUndefined();
+  });
+
+  it("multiple anomalies stack independently", () => {
+    const r = evaluateThresholds({
+      ...baseSnapshot,
+      totalBounced: 12,
+      bouncePct: 12,
+      spamPct: 0.6,
+    });
+    expect(r.length).toBeGreaterThanOrEqual(2);
+    expect(r.find((x) => x.kind === "bounce_spike")?.severity).toBe("critical");
+    expect(r.find((x) => x.kind === "spam_spike")?.severity).toBe("critical");
+  });
+
+  it("severityRank orders critical above warn", () => {
+    expect(severityRank("critical")).toBeGreaterThan(severityRank("warn"));
+  });
+});

--- a/tests/unit/email/bounce-gauge.test.tsx
+++ b/tests/unit/email/bounce-gauge.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BounceGauge } from "@/app/admin/email/_components/bounce-gauge";
+
+describe("BounceGauge", () => {
+  it("renders 0% in green zone", () => {
+    render(<BounceGauge bouncePct={0} />);
+    expect(screen.getByText("0.00%")).toBeInTheDocument();
+  });
+
+  it("renders 7% in yellow zone", () => {
+    render(<BounceGauge bouncePct={7} />);
+    expect(screen.getByText("7.00%")).toBeInTheDocument();
+  });
+
+  it("renders 12% in red zone", () => {
+    render(<BounceGauge bouncePct={12} />);
+    expect(screen.getByText("12.00%")).toBeInTheDocument();
+  });
+
+  it("clamps the visual but still displays the raw value when over 15%", () => {
+    render(<BounceGauge bouncePct={50} />);
+    expect(screen.getByText("50.00%")).toBeInTheDocument();
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -134,6 +134,10 @@
     {
       "path": "/api/cron/email/auto-resume",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron/email/anomaly-check",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Live operational dashboard inside `/admin/email?tab=event-monitor` plus a 5-minute cron that detects deliverability anomalies, writes a tamper-evident audit log, fires notification rail entries, and (for critical bounce/spam spikes) auto-pauses global sending via PR 4's `pause()`.

- New `Event Monitor` sub-tab — bounce gauge, 6 metric cards with sparklines, live event stream (5s poll while visible), top-10 bounce domains, paginated anomaly history
- 5-min cron `/api/cron/email/anomaly-check` — evaluates against pure thresholds, dedups within 60-min window, writes `email_anomaly_log`, fires notification, calls `pause('global', severity='critical', anomalyLogId=…)` for critical bounce/spam
- `pause()` extended (backwards-compatible) to accept optional `severity` + `anomalyLogId` and return `pauseAuditId` so the full audit chain (anomaly → audit → pause state) is queryable

## Migrations

| # | File | Purpose |
|---|------|---------|
| 104 | `email_pause_audit_log_anomaly_columns.sql` | Adds `severity` + `anomaly_log_id` to existing PR 4 audit log |
| 105 | `email_anomaly_log.sql` | New table + FK back from pause audit log |
| 106 | `email_event_metrics_rpc.sql` | `email_event_metrics(int,text)` + `email_top_bounce_domains(int,int)` |
| 107 | `email_events_timestamp_event_idx.sql` | Composite covering index for the metrics RPC hot path |

All applied to prod via Supabase MCP during implementation; migration files committed for replay parity.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run build` succeeds
- [x] `npx vitest run` — 25 new tests pass (12 evaluator + 6 cron + 4 gauge + 3 from existing pause-routes mock update); only baseline Firebase init failures remain (preexisting on `main`)
- [ ] Verify Event Monitor tab loads in admin email page
- [ ] Verify cron registers in Vercel dashboard at `*/5 * * * *`
- [ ] Synthetic: insert 50 bounce events into `email_events` in last 5 min → next cron run writes a critical anomaly, pauses global, fires notification
- [ ] Re-run cron immediately after — dedup suppresses second insert

## Bible update

`ops-software-bible/07_SPECIALIZED_FEATURES.md` §14.12 added in a separate commit on the bible repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)