### PR TITLE
chore(lint): clear pre-existing baseline (react/jsx-no-comment-textnodes + prefer-const + rules-of-hooks)

### DIFF
--- a/src/app/(dashboard)/calibration/_components/first-run-wizard.tsx
+++ b/src/app/(dashboard)/calibration/_components/first-run-wizard.tsx
@@ -71,7 +71,7 @@ export function FirstRunWizard({ onDone }: Props) {
     <div className="max-w-[720px] mx-auto px-6 py-10 w-full">
       <div className="flex items-center justify-between mb-4">
         <h1 className="font-cakemono font-light uppercase text-[22px] text-text">
-          <span className="text-text-mute mr-2">//</span>
+          <span className="text-text-mute mr-2">{"//"}</span>
           {t("firstRun.header").replace("// ", "")}
         </h1>
         <span className="font-mono text-micro uppercase tracking-wider text-text-2 tabular-nums">

--- a/src/app/(dashboard)/calibration/_components/recent-rail.tsx
+++ b/src/app/(dashboard)/calibration/_components/recent-rail.tsx
@@ -45,7 +45,7 @@ export function RecentRail() {
     >
       <div className="flex items-center gap-3 shrink-0">
         <span className="font-mono text-micro uppercase tracking-wider text-text-3">
-          <span className="text-text-mute mr-[6px]">//</span>
+          <span className="text-text-mute mr-[6px]">{"//"}</span>
           {t("recent.title").slice(3).trim()}
         </span>
         <span className="font-mono text-micro uppercase tracking-wider text-text-mute">

--- a/src/app/(dashboard)/calibration/_components/section-activity.tsx
+++ b/src/app/(dashboard)/calibration/_components/section-activity.tsx
@@ -84,7 +84,7 @@ export function SectionActivity() {
     <div className="px-11 py-9 max-w-[1320px] mx-auto">
       <SectionBreadcrumb currentSection="activity" />
       <h2 className="font-cakemono font-light uppercase text-[22px] text-text mb-4">
-        <span className="text-text-mute mr-2">//</span>ACTIVITY
+        <span className="text-text-mute mr-2">{"//"}</span>ACTIVITY
       </h2>
 
       {/* Live sensor strip */}

--- a/src/app/(dashboard)/calibration/_components/section-config.tsx
+++ b/src/app/(dashboard)/calibration/_components/section-config.tsx
@@ -42,7 +42,7 @@ export function SectionConfig() {
     <div className="px-11 py-9 max-w-[1080px] mx-auto">
       <SectionBreadcrumb currentSection="config" />
       <h2 className="font-cakemono font-light uppercase text-[22px] text-text mb-6">
-        <span className="text-text-mute mr-2">//</span>CONFIG
+        <span className="text-text-mute mr-2">{"//"}</span>CONFIG
       </h2>
 
       {/* AUTONOMY panel — summary + RE-RUN WIZARD */}
@@ -121,7 +121,7 @@ export function SectionConfig() {
       {/* EXTERNAL links — per V6, only TASK TYPES. Duplicate Detection dropped. */}
       <div className="mt-6">
         <h4 className="font-mono text-micro uppercase tracking-wider text-text-mute mb-3">
-          <span className="mr-[6px]">//</span>
+          <span className="mr-[6px]">{"//"}</span>
           {t("sections.config.external.heading")}
         </h4>
         <a

--- a/src/app/(dashboard)/calibration/_components/section-corpus.tsx
+++ b/src/app/(dashboard)/calibration/_components/section-corpus.tsx
@@ -59,7 +59,7 @@ export function SectionCorpus() {
       <SectionBreadcrumb currentSection="corpus" />
       <div className="flex items-baseline justify-between mb-6">
         <h2 className="font-cakemono font-light uppercase text-[22px] text-text">
-          <span className="text-text-mute mr-2">//</span>CORPUS
+          <span className="text-text-mute mr-2">{"//"}</span>CORPUS
         </h2>
         <span className="font-mono text-data-sm text-text-2 tabular-nums">
           {t("sections.corpus.header")
@@ -77,7 +77,7 @@ export function SectionCorpus() {
           {/* FACTS drawer — scrollable list of extracted facts. */}
           <div className="glass-surface rounded-panel p-4 h-[600px] overflow-y-auto scrollbar-hide">
             <div className="font-mono text-micro uppercase tracking-wider text-text-3 mb-3">
-              <span className="text-text-mute mr-[6px]">//</span>
+              <span className="text-text-mute mr-[6px]">{"//"}</span>
               {t("sections.corpus.drawers.facts").slice(3).trim()}
             </div>
             <p className="font-mohave text-body-sm text-text-2">
@@ -106,7 +106,7 @@ export function SectionCorpus() {
           {/* ENTITY drawer — selection detail. */}
           <div className="glass-surface rounded-panel p-4 h-[600px]">
             <div className="font-mono text-micro uppercase tracking-wider text-text-3 mb-3">
-              <span className="text-text-mute mr-[6px]">//</span>
+              <span className="text-text-mute mr-[6px]">{"//"}</span>
               {t("sections.corpus.drawers.entity").slice(3).trim()}
             </div>
             <p className="font-mono text-micro uppercase tracking-wider text-text-mute">

--- a/src/app/(dashboard)/calibration/_components/section-inputs.tsx
+++ b/src/app/(dashboard)/calibration/_components/section-inputs.tsx
@@ -194,7 +194,7 @@ export function SectionInputs() {
     <div className="px-11 py-9 max-w-[1080px] mx-auto">
       <SectionBreadcrumb currentSection="inputs" />
       <h2 className="font-cakemono font-light uppercase text-[22px] text-text mb-6">
-        <span className="text-text-mute mr-2">//</span>INPUTS
+        <span className="text-text-mute mr-2">{"//"}</span>INPUTS
       </h2>
       <div className="flex flex-col gap-4">
         {(["interview", "scan", "mining"] as const).map((src) => (

--- a/src/app/(dashboard)/calibration/_components/section-milestones.tsx
+++ b/src/app/(dashboard)/calibration/_components/section-milestones.tsx
@@ -118,7 +118,7 @@ export function SectionMilestones() {
       <SectionBreadcrumb currentSection="milestones" />
       <div className="flex items-baseline justify-between mb-6">
         <h2 className="font-cakemono font-light uppercase text-[22px] text-text">
-          <span className="text-text-mute mr-2">//</span>MILESTONES
+          <span className="text-text-mute mr-2">{"//"}</span>MILESTONES
         </h2>
         <span className="font-mono text-data text-text-2 tabular-nums">
           {t("sections.milestones.overallHeader").replace(

--- a/src/app/(dashboard)/calibration/page.tsx
+++ b/src/app/(dashboard)/calibration/page.tsx
@@ -66,8 +66,8 @@ export default function CalibrationPage() {
         </h1>
       </div>
       <p className="font-mono text-micro uppercase tracking-wider text-text-3 px-11 pb-2">
-        <span className="text-text-mute">//</span> COMMAND
-        <span className="text-text-mute mx-1">//</span> CALIBRATION
+        <span className="text-text-mute">{"//"}</span> COMMAND
+        <span className="text-text-mute mx-1">{"//"}</span> CALIBRATION
       </p>
       <CommandDeck deck={deck} />
     </>

--- a/src/app/(dashboard)/inbox/page.tsx
+++ b/src/app/(dashboard)/inbox/page.tsx
@@ -564,7 +564,7 @@ export default function InboxPage() {
     return (
       <div className="flex flex-col items-start justify-start px-6 py-10">
         <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-rose">
-          // Access denied
+          {"// Access denied"}
         </p>
         <p className="font-mohave text-[14px] text-text mt-1">
           You don&apos;t have permission to view the inbox.

--- a/src/app/admin/email/_components/audience-builder-tab.tsx
+++ b/src/app/admin/email/_components/audience-builder-tab.tsx
@@ -81,7 +81,7 @@ export function AudienceBuilderTab() {
       <header className="flex items-center justify-between">
         <div>
           <h3 className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED]">
-            // AUDIENCE BUILDER
+            {"// AUDIENCE BUILDER"}
           </h3>
           <p className="font-mono text-[11px] text-[#8A8A8A]">
             [build a filter, save it, point a campaign at it]
@@ -207,7 +207,7 @@ export function AudienceBuilderTab() {
       {(templates.data?.length ?? 0) > 0 && (
         <div>
           <h4 className="font-cakemono font-light text-[11px] tracking-[0.06em] text-[#8A8A8A] mb-2">
-            // SAVED TEMPLATES
+            {"// SAVED TEMPLATES"}
           </h4>
           <div className="space-y-1">
             {templates.data!.map((t) => {

--- a/src/app/admin/email/_components/audience-save-template-modal.tsx
+++ b/src/app/admin/email/_components/audience-save-template-modal.tsx
@@ -68,7 +68,7 @@ export function AudienceSaveTemplateModal({
             }}
           >
             <h2 className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED] mb-4">
-              // SAVE AUDIENCE
+              {"// SAVE AUDIENCE"}
             </h2>
             <label className="block mb-3">
               <span className="font-cakemono font-light text-[10px] tracking-[0.06em] text-[#B5B5B5] block mb-1">

--- a/src/app/admin/email/_components/campaign-create-modal.tsx
+++ b/src/app/admin/email/_components/campaign-create-modal.tsx
@@ -225,7 +225,7 @@ export function CampaignCreateModal({
               id="campaign-create-title"
               className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED] mb-1"
             >
-              // NEW CAMPAIGN
+              {"// NEW CAMPAIGN"}
             </h2>
             <p className="font-mono text-[11px] text-[#8A8A8A] mb-5">
               [save as draft now, schedule once you&apos;re ready]

--- a/src/app/admin/email/_components/campaign-detail-modal.tsx
+++ b/src/app/admin/email/_components/campaign-detail-modal.tsx
@@ -141,7 +141,7 @@ export function CampaignDetailModal({ campaignId, onClose }: Props) {
                   id="campaign-detail-title"
                   className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED] mb-1 truncate"
                 >
-                  // {c.name.toUpperCase()}
+                  {"// "}{c.name.toUpperCase()}
                 </h2>
                 <span className="font-mono text-[11px] text-[#8A8A8A]">
                   [{c.slug}] [template = {c.templateId}]

--- a/src/app/admin/email/_components/scheduled-sends-tab.tsx
+++ b/src/app/admin/email/_components/scheduled-sends-tab.tsx
@@ -64,7 +64,7 @@ export function ScheduledSendsTab() {
       <header className="flex items-center justify-between">
         <div>
           <h3 className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED]">
-            // SCHEDULED SENDS
+            {"// SCHEDULED SENDS"}
           </h3>
           <p
             className="font-mono text-[11px] text-[#8A8A8A]"

--- a/src/app/admin/email/_components/suppression-bulk-add-modal.tsx
+++ b/src/app/admin/email/_components/suppression-bulk-add-modal.tsx
@@ -79,7 +79,7 @@ export function SuppressionBulkAddModal({ open, onClose }: Props) {
             }}
           >
             <h2 className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED] mb-1">
-              // BULK SUPPRESS
+              {"// BULK SUPPRESS"}
             </h2>
             <p className="font-mono text-[11px] text-[#8A8A8A] mb-4">
               [paste email list — comma, space, or newline separated]

--- a/src/app/admin/email/_components/suppression-detail-drawer.tsx
+++ b/src/app/admin/email/_components/suppression-detail-drawer.tsx
@@ -30,7 +30,7 @@ export function SuppressionDetailDrawer({ row, onClose, onDelete }: Props) {
         >
           <header className="flex items-center justify-between mb-5">
             <h3 className="font-cakemono font-light text-[12px] tracking-[0.06em] text-[#B5B5B5]">
-              // SUPPRESSION
+              {"// SUPPRESSION"}
             </h3>
             <button
               onClick={onClose}

--- a/src/app/admin/email/_components/suppression-import-modal.tsx
+++ b/src/app/admin/email/_components/suppression-import-modal.tsx
@@ -82,7 +82,7 @@ export function SuppressionImportModal({ open, onClose }: Props) {
             }}
           >
             <h2 className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED] mb-1">
-              // IMPORT CSV
+              {"// IMPORT CSV"}
             </h2>
             <p className="font-mono text-[11px] text-[#8A8A8A] mb-4">
               [first column = email; one per row]

--- a/src/app/admin/email/_components/suppressions-tab.tsx
+++ b/src/app/admin/email/_components/suppressions-tab.tsx
@@ -73,7 +73,7 @@ export function SuppressionsTab() {
       <header className="flex items-center justify-between gap-3 flex-wrap">
         <div>
           <h3 className="font-cakemono font-light text-[14px] tracking-[0.06em] text-[#EDEDED]">
-            // SUPPRESSIONS
+            {"// SUPPRESSIONS"}
           </h3>
           <p
             className="font-mono text-[11px] text-[#8A8A8A]"

--- a/src/app/admin/email/_components/templates-tab.tsx
+++ b/src/app/admin/email/_components/templates-tab.tsx
@@ -7,7 +7,7 @@ export function TemplatesTab() {
   return (
     <div className="rounded-panel border border-white/[0.09] p-8 max-w-[640px]">
       <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A]">
-        // TEMPLATE REGISTRY
+        {"// TEMPLATE REGISTRY"}
       </div>
       <h2 className="mt-2 font-cakemono font-light text-[20px] uppercase tracking-[0.04em] text-[#EDEDED]">
         Versioned email templates

--- a/src/app/admin/email/templates/[templateId]/page.tsx
+++ b/src/app/admin/email/templates/[templateId]/page.tsx
@@ -46,7 +46,7 @@ export default function TemplateDetailPage() {
     return (
       <div className="min-h-screen bg-black text-[#EDEDED] px-[44px] py-[36px]">
         <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A]">
-          // SYS :: LOADING TEMPLATE
+          {"// SYS :: LOADING TEMPLATE"}
         </div>
       </div>
     );
@@ -59,10 +59,10 @@ export default function TemplateDetailPage() {
           href="/admin/email/templates"
           className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A] hover:text-[#EDEDED]"
         >
-          // / TEMPLATES
+          {"// / TEMPLATES"}
         </Link>
         <div className="mt-4 font-mono text-[11px] uppercase tracking-[0.16em] text-[#B58289]">
-          // ERROR :: {data?.error ?? "template not found"}
+          {"// ERROR :: "}{data?.error ?? "template not found"}
         </div>
       </div>
     );
@@ -77,7 +77,7 @@ export default function TemplateDetailPage() {
         className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A] hover:text-[#EDEDED] transition-colors"
         style={{ transitionDuration: "180ms" }}
       >
-        // / TEMPLATES
+        {"// / TEMPLATES"}
       </Link>
       <h1 className="mt-2 font-cakemono font-light text-[28px] uppercase tracking-[0.04em] text-[#EDEDED]">
         {tpl.displayName}
@@ -103,7 +103,7 @@ export default function TemplateDetailPage() {
                 transitionTimingFunction: "cubic-bezier(0.22, 1, 0.36, 1)",
               }}
             >
-              // {label}
+              {"// "}{label}
               {active && (
                 <span
                   className="absolute bottom-0 left-0 right-0 h-[1px]"

--- a/src/app/admin/email/templates/page.tsx
+++ b/src/app/admin/email/templates/page.tsx
@@ -28,7 +28,7 @@ export default function TemplatesListPage() {
     <div className="min-h-screen bg-black text-[#EDEDED] px-[44px] py-[36px]">
       <header className="mb-8">
         <div className="font-mono text-[11px] uppercase tracking-[0.18em] text-[#8A8A8A]">
-          // OPS LTD. / EMAIL / TEMPLATES
+          {"// OPS LTD. / EMAIL / TEMPLATES"}
         </div>
         <h1 className="mt-2 font-cakemono font-light text-[28px] uppercase tracking-[0.04em] text-[#EDEDED]">
           Templates
@@ -41,7 +41,7 @@ export default function TemplatesListPage() {
       <div className="rounded-panel border border-white/[0.09] overflow-hidden">
         {templates.length === 0 && !isLoading && (
           <div className="px-5 py-6 font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A]">
-            // NO TEMPLATES REGISTERED
+            {"// NO TEMPLATES REGISTERED"}
           </div>
         )}
         {templates.map((t) => (

--- a/src/app/admin/pmf/marker/[id]/page.tsx
+++ b/src/app/admin/pmf/marker/[id]/page.tsx
@@ -50,7 +50,7 @@ export default async function MarkerDrillInPage({ params }: { params: Promise<{ 
           <SlashHeader variant="section">COHORT RETENTION</SlashHeader>
           {cohortRows.length === 0 ? (
             <div className="mt-4 font-mono text-[11px] text-[color:var(--text-mute)]">
-              // NO COHORTS YET
+              {"// NO COHORTS YET"}
             </div>
           ) : (
             <table className="w-full mt-4 font-mono text-[11px]">

--- a/src/app/admin/pmf/page.tsx
+++ b/src/app/admin/pmf/page.tsx
@@ -44,7 +44,7 @@ export default async function PmfDashboardPage() {
       {/* Hero strip */}
       <div className="flex items-center justify-between">
         <h1 className="font-cakemono font-light uppercase text-[22px] tracking-[0.02em] leading-none">
-          <span className="text-[color:var(--text-mute)] font-mono mr-2">//</span>
+          <span className="text-[color:var(--text-mute)] font-mono mr-2">{"//"}</span>
           PMF TRACKING DECK
         </h1>
         <div className="flex items-center gap-4">

--- a/src/app/api/integrations/ai-setup/email-scan/route.ts
+++ b/src/app/api/integrations/ai-setup/email-scan/route.ts
@@ -261,7 +261,7 @@ async function runFullHistoryScan(
   const twelveMonthsAgo = new Date();
   twelveMonthsAgo.setMonth(twelveMonthsAgo.getMonth() - 12);
 
-  let allSentEmails: NormalizedEmail[] = [];
+  const allSentEmails: NormalizedEmail[] = [];
   let pageToken: string | undefined;
   const GMAIL_API = "https://gmail.googleapis.com/gmail/v1/users/me";
 
@@ -311,7 +311,7 @@ async function runFullHistoryScan(
   const BATCH_SIZE = 50;
   let totalProcessed = 0;
   let totalFactsExtracted = 0;
-  let totalEntitiesCreated = 0;
+  const totalEntitiesCreated = 0;
   let totalProfileUpdates = 0;
 
   for (let i = 0; i < allMessageIds.length; i += BATCH_SIZE) {

--- a/src/components/admin/email/template-preview-tab.tsx
+++ b/src/components/admin/email/template-preview-tab.tsx
@@ -51,7 +51,7 @@ export function TemplatePreviewTab({ templateId, initialProps }: Props) {
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div>
         <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A] mb-2">
-          // PROPS / JSON
+          {"// PROPS / JSON"}
         </div>
         <textarea
           value={propsText}
@@ -63,18 +63,18 @@ export function TemplatePreviewTab({ templateId, initialProps }: Props) {
         />
         {error && (
           <div className="mt-2 font-mono text-[11px] uppercase tracking-[0.14em] text-[#B58289]">
-            // ERROR :: {error}
+            {"// ERROR :: "}{error}
           </div>
         )}
         {isRendering && !error && (
           <div className="mt-2 font-mono text-[11px] uppercase tracking-[0.14em] text-[#8A8A8A]">
-            // SYS :: RENDERING
+            {"// SYS :: RENDERING"}
           </div>
         )}
       </div>
       <div>
         <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A] mb-2">
-          // RENDERED PREVIEW
+          {"// RENDERED PREVIEW"}
         </div>
         <iframe
           srcDoc={html}

--- a/src/components/admin/email/template-send-test-tab.tsx
+++ b/src/components/admin/email/template-send-test-tab.tsx
@@ -97,12 +97,12 @@ export function TemplateSendTestTab({ templateId, initialProps }: Props) {
 
       {status === "success" && (
         <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-[#9DB582]">
-          // SENT — check the inbox
+          {"// SENT — check the inbox"}
         </div>
       )}
       {status === "error" && errorMessage && (
         <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-[#B58289]">
-          // ERROR :: {errorMessage}
+          {"// ERROR :: "}{errorMessage}
         </div>
       )}
     </div>

--- a/src/components/admin/email/template-versions-tab.tsx
+++ b/src/components/admin/email/template-versions-tab.tsx
@@ -21,7 +21,7 @@ export function TemplateVersionsTab({ versions }: Props) {
   if (versions.length === 0) {
     return (
       <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A]">
-        // NO VERSIONS RECORDED
+        {"// NO VERSIONS RECORDED"}
       </div>
     );
   }
@@ -70,7 +70,7 @@ export function TemplateVersionsTab({ versions }: Props) {
                   />
                 ) : (
                   <div className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#8A8A8A]">
-                    // NO RENDERED SAMPLE STORED FOR THIS VERSION
+                    {"// NO RENDERED SAMPLE STORED FOR THIS VERSION"}
                   </div>
                 )}
               </div>

--- a/src/components/dashboard/widgets/estimates-overview-widget.tsx
+++ b/src/components/dashboard/widgets/estimates-overview-widget.tsx
@@ -154,6 +154,11 @@ export function EstimatesOverviewWidget({
     [filtered]
   );
 
+  // Hooks must be called unconditionally (Rules of Hooks). The MD/LG
+  // expand/collapse state is hoisted above the SM early-return so render
+  // order stays stable across size transitions.
+  const [listExpanded, setListExpanded] = useState(false);
+
   // ── SM: Hero + title + total value ──────────────────────────────────────
   if (size === "sm") {
     return (
@@ -177,7 +182,6 @@ export function EstimatesOverviewWidget({
   }
 
   // ── MD / LG: List with send button ───────────────────────────────────────
-  const [listExpanded, setListExpanded] = useState(false);
   const defaultMax = size === "lg" ? 15 : 5;
   const maxItems = listExpanded ? filtered.length : defaultMax;
   const remaining = filtered.length - defaultMax;

--- a/src/components/dashboard/widgets/inbox-leads-widget.tsx
+++ b/src/components/dashboard/widgets/inbox-leads-widget.tsx
@@ -274,7 +274,7 @@ export function InboxLeadsWidget({ size, config: _config }: InboxLeadsWidgetProp
         {/* Header */}
         <div className="flex items-center justify-between mb-2">
           <span className="font-mono text-micro uppercase tracking-wider text-text-3">
-            // New leads
+            {"// New leads"}
           </span>
           <button
             type="button"

--- a/src/components/dashboard/widgets/phase-c-autonomy-widget.tsx
+++ b/src/components/dashboard/widgets/phase-c-autonomy-widget.tsx
@@ -213,7 +213,7 @@ export function PhaseCAutonomyWidget({ size, config: _config }: PhaseCAutonomyWi
         {/* Header */}
         <div className="flex items-center justify-between mb-2">
           <span className="font-mono text-micro uppercase tracking-wider text-text-3">
-            // Phase C · last 7 days
+            {"// Phase C · last 7 days"}
           </span>
           <button
             type="button"
@@ -237,7 +237,7 @@ export function PhaseCAutonomyWidget({ size, config: _config }: PhaseCAutonomyWi
           {activeCategories.length === 0 ? (
             <div className="py-6 flex flex-col items-start">
               <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-mute">
-                // Phase C standing by
+                {"// Phase C standing by"}
               </p>
               <p className="font-mohave text-[12.5px] text-text-2 mt-1">
                 Nothing configured yet.

--- a/src/components/dashboard/widgets/task-list-widget.tsx
+++ b/src/components/dashboard/widgets/task-list-widget.tsx
@@ -118,6 +118,14 @@ export function TaskListWidget({
     };
   }, [filteredTasks, today]);
 
+  // ── Visibility toggle options (hoisted above SM early-return so the
+  //    useMemo call order stays stable across size transitions per Rules
+  //    of Hooks). Only consumed in MD+ render paths below. ─────────────
+  const viewToggleOptions = useMemo(() => [
+    { value: "all" as const, label: t("taskList.all") ?? "All" },
+    { value: "mine" as const, label: t("taskList.mine") ?? "Mine" },
+  ], [t]);
+
   // ── SM: hero + title + next task ──────────────────────────────────────
   if (size === "sm") {
     const nextTask = todayTasks[0];
@@ -142,11 +150,6 @@ export function TaskListWidget({
   }
 
   // ── Visibility toggle (MD+) ───────────────────────────────────────────
-  const viewToggleOptions = useMemo(() => [
-    { value: "all" as const, label: t("taskList.all") ?? "All" },
-    { value: "mine" as const, label: t("taskList.mine") ?? "Mine" },
-  ], [t]);
-
   const viewToggle = canViewAll ? (
     <SegmentedPicker
       options={viewToggleOptions}

--- a/src/components/layouts/notifications-drawer.tsx
+++ b/src/components/layouts/notifications-drawer.tsx
@@ -244,7 +244,7 @@ export function NotificationsDrawer() {
                 letterSpacing: "0.16em",
               }}
             >
-              //
+              {"//"}
             </span>
             <span
               style={{

--- a/src/components/layouts/quick-actions-drawer.tsx
+++ b/src/components/layouts/quick-actions-drawer.tsx
@@ -180,7 +180,7 @@ export function QuickActionsDrawer() {
                     letterSpacing: "0.16em",
                   }}
                 >
-                  //
+                  {"//"}
                 </span>
                 <span
                   style={{

--- a/src/components/ops/inbox/conversation-list.tsx
+++ b/src/components/ops/inbox/conversation-list.tsx
@@ -757,7 +757,7 @@ export function ConversationList({
       return (
         <div className="flex-1 flex flex-col items-start justify-start px-4 py-6">
           <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-mute">
-            // No drafts
+            {"// No drafts"}
           </p>
           <p className="font-mohave text-[13px] text-text mt-1">
             Nothing in progress.
@@ -811,7 +811,7 @@ export function ConversationList({
     return (
       <div className="flex-1 flex flex-col items-start justify-start px-4 py-6">
         <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-rose">
-          // Error
+          {"// Error"}
         </p>
         <p className="font-mohave text-[13px] text-text mt-1">
           Couldn&apos;t load your inbox.
@@ -827,7 +827,7 @@ export function ConversationList({
     return (
       <div className="flex-1 flex flex-col items-start justify-start px-4 py-6">
         <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-mute">
-          // Inbox zero
+          {"// Inbox zero"}
         </p>
         <p className="font-mohave text-[13px] text-text mt-1">
           Nothing to triage here.

--- a/src/components/ops/inbox/empty-status-drafts.tsx
+++ b/src/components/ops/inbox/empty-status-drafts.tsx
@@ -60,7 +60,7 @@ export function EmptyStatusDrafts({
     <section className="px-3 py-3">
       <div className="flex items-baseline justify-between">
         <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
-          <span className="text-text-mute">// </span>DRAFTS
+          <span className="text-text-mute">{"// "}</span>DRAFTS
         </p>
         <span
           className={cn(

--- a/src/components/ops/inbox/empty-status-header.tsx
+++ b/src/components/ops/inbox/empty-status-header.tsx
@@ -53,7 +53,7 @@ export function EmptyStatusHeader({ unreadCount }: EmptyStatusHeaderProps) {
   return (
     <header className="px-3 py-3 border-b border-[rgba(255,255,255,0.10)]">
       <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
-        <span className="text-text-mute">// </span>INBOX STATUS
+        <span className="text-text-mute">{"// "}</span>INBOX STATUS
       </p>
       <div className="mt-1 flex items-baseline justify-between gap-3">
         <span

--- a/src/components/ops/inbox/empty-status-reply-debt.tsx
+++ b/src/components/ops/inbox/empty-status-reply-debt.tsx
@@ -64,7 +64,7 @@ export function EmptyStatusReplyDebt({
     <section className="px-3 py-3 border-b border-[rgba(255,255,255,0.10)]">
       <div className="flex items-baseline justify-between">
         <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
-          <span className="text-text-mute">// </span>REPLY DEBT
+          <span className="text-text-mute">{"// "}</span>REPLY DEBT
         </p>
         <span
           className={cn(

--- a/src/components/ops/inbox/empty-status-velocity.tsx
+++ b/src/components/ops/inbox/empty-status-velocity.tsx
@@ -82,7 +82,7 @@ export function EmptyStatusVelocity({ scope }: EmptyStatusVelocityProps) {
   return (
     <section className="px-3 py-3 border-b border-[rgba(255,255,255,0.10)]">
       <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-3">
-        <span className="text-text-mute">// </span>CLASSIFIED · LAST 14D
+        <span className="text-text-mute">{"// "}</span>CLASSIFIED · LAST 14D
       </p>
 
       <div className="mt-3">

--- a/src/components/ops/inbox/recategorize-menu.tsx
+++ b/src/components/ops/inbox/recategorize-menu.tsx
@@ -134,7 +134,7 @@ export function RecategorizeMenu({
         {/* Header */}
         <div className="px-3 pt-2.5 pb-1.5 border-b border-border-subtle">
           <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-mute">
-            // Reclassify
+            {"// Reclassify"}
           </p>
           <p className="font-cakemono font-light uppercase text-[13px] tracking-[0.14em] text-text mt-0.5">
             Move thread to

--- a/src/components/ops/inbox/snooze-picker.tsx
+++ b/src/components/ops/inbox/snooze-picker.tsx
@@ -189,7 +189,7 @@ export function SnoozePicker({
       >
         <div className="px-3 pt-2.5 pb-1.5 border-b border-border-subtle">
           <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-mute">
-            // Snooze
+            {"// Snooze"}
           </p>
           <p className="font-cakemono font-light uppercase text-[13px] tracking-[0.14em] text-text mt-0.5">
             Come back when

--- a/src/components/ops/inbox/thread-context-panel.tsx
+++ b/src/components/ops/inbox/thread-context-panel.tsx
@@ -263,7 +263,7 @@ export function ThreadContextPanel({
             {/* Header */}
             <div className="flex items-center justify-between p-3 border-b border-border-subtle">
               <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-mute">
-                // Context
+                {"// Context"}
               </span>
               <button
                 type="button"

--- a/src/components/ops/inbox/thread-detail-view.tsx
+++ b/src/components/ops/inbox/thread-detail-view.tsx
@@ -677,7 +677,7 @@ export function ThreadDetailView({
     return (
       <div className="flex flex-col items-start justify-start h-full px-6 py-10">
         <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-mute">
-          // Nothing selected
+          {"// Nothing selected"}
         </p>
       </div>
     );
@@ -716,7 +716,7 @@ export function ThreadDetailView({
                 />
               )}
               <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-mute">
-                // {participants.length} {participants.length === 1 ? "person" : "people"}
+                {"// "}{participants.length} {participants.length === 1 ? "person" : "people"}
                 {messageCount > 0 && ` · ${messageCount} msg${messageCount === 1 ? "" : "s"}`}
               </p>
             </div>
@@ -841,7 +841,7 @@ export function ThreadDetailView({
         {!isLoading && messagesWithDates.length === 0 && (
           <div className="flex flex-col items-start justify-start py-8">
             <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-text-mute">
-              // Empty thread
+              {"// Empty thread"}
             </p>
             <p className="font-mohave text-[13px] text-text mt-1">
               No messages to show.
@@ -868,7 +868,7 @@ export function ThreadDetailView({
                 strokeWidth={1.75}
               />
               <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[#C4A868]">
-                // {threadDraft.source === "ai" ? "AI draft" : "Draft"}
+                {"// "}{threadDraft.source === "ai" ? "AI draft" : "Draft"}
               </span>
               <span className="font-mono text-[10px] text-text-mute ml-auto">
                 Updated {formatTime(new Date(threadDraft.updatedAt))}

--- a/src/components/ops/inbox/writeback-preference-modal.tsx
+++ b/src/components/ops/inbox/writeback-preference-modal.tsx
@@ -109,7 +109,7 @@ export function WritebackPreferenceModal({
       <DialogContent className="max-w-[520px] p-0">
         <div className="px-4 pt-4 pb-3 border-b border-border-subtle">
           <p className="font-mono text-[10px] uppercase tracking-[0.20em] text-text-mute">
-            // First archive
+            {"// First archive"}
           </p>
           <DialogTitle className="font-cakemono font-light uppercase text-[20px] tracking-[0.10em] text-text mt-1">
             What should archive do?

--- a/src/components/pmf/ad-spend-form.tsx
+++ b/src/components/pmf/ad-spend-form.tsx
@@ -101,7 +101,7 @@ export function AdSpendForm() {
           )}
           {status === "error" && (
             <span className="font-mono text-[11px] text-[color:var(--rose)]">
-              // ERROR
+              {"// ERROR"}
             </span>
           )}
         </div>

--- a/src/components/pmf/indicator-card.tsx
+++ b/src/components/pmf/indicator-card.tsx
@@ -22,7 +22,7 @@ export function IndicatorCard({ state }: IndicatorCardProps) {
         <StatusDot status={state.status} size={5} />
       </div>
       <div className="font-mono uppercase text-[11px] tracking-[0.16em] text-[color:var(--text-3)]">
-        <span className="text-[color:var(--text-mute)] mr-1">//</span>
+        <span className="text-[color:var(--text-mute)] mr-1">{"//"}</span>
         {state.label}
       </div>
       <div className="mt-3 font-mono text-[20px] font-semibold tabular-nums text-[color:var(--text)]">

--- a/src/components/pmf/mrr-trend-chart.tsx
+++ b/src/components/pmf/mrr-trend-chart.tsx
@@ -45,7 +45,7 @@ export function MrrTrendChart() {
       <PmfCard className="p-4">
         <SlashHeader variant="section">BASE SAAS · MRR TREND</SlashHeader>
         <div className="h-[460px] mt-4 flex items-center justify-center font-mono text-[11px] text-[color:var(--rose)]">
-          // ERROR — FAILED TO LOAD<br />
+          {"// ERROR — FAILED TO LOAD"}<br />
           {error}
         </div>
       </PmfCard>

--- a/src/components/pmf/new-prospect-modal.tsx
+++ b/src/components/pmf/new-prospect-modal.tsx
@@ -261,7 +261,7 @@ export function NewProspectModal() {
             role="alert"
             className="font-mono text-[11px] text-[color:var(--rose)]"
           >
-            // ERROR — {error}
+            {"// ERROR — "}{error}
           </div>
         )}
 

--- a/src/components/pmf/pipeline-kanban.tsx
+++ b/src/components/pmf/pipeline-kanban.tsx
@@ -206,7 +206,7 @@ export function PipelineKanban() {
           <SlashHeader variant="section">TIER A PIPELINE</SlashHeader>
         </div>
         <div className="font-mono text-[11px] text-[color:var(--rose)] py-12 text-center">
-          // ERROR — FAILED TO LOAD
+          {"// ERROR — FAILED TO LOAD"}
           <br />
           {initialFetchError}
         </div>
@@ -222,7 +222,7 @@ export function PipelineKanban() {
         <SlashHeader variant="section">TIER A PIPELINE</SlashHeader>
         {errorMessages.length > 0 && (
           <span className="font-mono text-[11px] text-[color:var(--rose)]">
-            // {errorMessages[errorMessages.length - 1]}
+            {"// "}{errorMessages[errorMessages.length - 1]}
             {errorMessages.length > 1 && ` (+${errorMessages.length - 1} more)`}
           </span>
         )}

--- a/src/components/pmf/prospect-sheet.tsx
+++ b/src/components/pmf/prospect-sheet.tsx
@@ -150,7 +150,7 @@ export function ProspectSheet({ prospectId }: ProspectSheetProps) {
       <PmfCard className="p-6">
         <SlashHeader variant="page-title">PROSPECT</SlashHeader>
         <div className="font-mono text-[11px] text-[color:var(--rose)] py-12 text-center">
-          // ERROR — FAILED TO LOAD
+          {"// ERROR — FAILED TO LOAD"}
           <br />
           {fetchError ?? "no data"}
         </div>
@@ -214,7 +214,7 @@ export function ProspectSheet({ prospectId }: ProspectSheetProps) {
         <PmfCard className="p-6">
           <SlashHeader variant="section">DEAL</SlashHeader>
           <div className="font-mono text-[11px] text-[color:var(--text-mute)] mt-4">
-            // no deal attached
+            {"// no deal attached"}
           </div>
         </PmfCard>
       ) : (
@@ -233,7 +233,7 @@ export function ProspectSheet({ prospectId }: ProspectSheetProps) {
           role="alert"
           className="font-mono text-[11px] text-[color:var(--rose)]"
         >
-          // ERROR — {saveError}
+          {"// ERROR — "}{saveError}
         </div>
       )}
     </div>

--- a/src/components/pmf/ui/slash-header.tsx
+++ b/src/components/pmf/ui/slash-header.tsx
@@ -17,7 +17,7 @@ export function SlashHeader({ children, variant = 'section', className, trailing
   return (
     <div className={cn('flex items-center justify-between', className)}>
       <h2 className={cn(VARIANT_CLASS[variant])}>
-        <span className="mr-1 text-[color:var(--text-mute)] font-mono">//</span>
+        <span className="mr-1 text-[color:var(--text-mute)] font-mono">{"//"}</span>
         {children}
       </h2>
       {trailing && <div>{trailing}</div>}


### PR DESCRIPTION
## Summary

Clears the pre-existing lint baseline on `main` so `lint-and-test` is once again a meaningful CI signal. Build was already green via `eslint.ignoreDuringBuilds: true`, but every PR was merging red — making it impossible to spot regressions.

Pure mechanical fixes. No behavioral changes. Visual output is byte-identical to before for the JSX changes.

### Fixes by rule (75 errors -> 0)

- **71 `react/jsx-no-comment-textnodes`** — JSX text nodes starting with `// ` (OPS tactical voice prefix) trigger this rule because ESLint reads the `//` as a JS comment. Wrapped each occurrence as a string expression: `<span>// LABEL</span>` -> `<span>{"// LABEL"}</span>` (or `{"// "}{var}` for interpolated forms). Preserves the OPS visual treatment and the `font-mono` `text-text-mute` slash-prefix pattern that lives in 50+ tactical surfaces.
- **2 `prefer-const`** in `src/app/api/integrations/ai-setup/email-scan/route.ts`:
  - `allSentEmails` (line 264) — array, only `.push()`'d into; `let` -> `const`
  - `totalEntitiesCreated` (line 314) — value is read into the response payload but never reassigned in the current code path; `let` -> `const`
- **2 `react-hooks/rules-of-hooks`** — both widgets had a hook called *after* an `if (size === "sm") return ...` early return, which means hook order changes when the widget resizes between SM and MD/LG. Hoisted both above the early return:
  - `src/components/dashboard/widgets/estimates-overview-widget.tsx` — `useState(listExpanded)` moved up
  - `src/components/dashboard/widgets/task-list-widget.tsx` — `useMemo(viewToggleOptions)` moved up

  These are real correctness fixes, not silencing — without them, the SM-only render path skips a hook the MD path expects, which can crash on resize.

### Files touched
50 files, +86 / -79.

## Verification

- `npm run lint` -> 0 errors (warnings unchanged from baseline)
- `npm run type-check` -> clean
- `npm run build` -> clean
- `npx vitest run` -> 772 passed, 5 skipped, 2 failed (Firebase env-init only — matches baseline; not introduced by this PR)

## Test plan

- [x] Lint clean
- [x] Type-check clean
- [x] Build clean
- [x] Test suite matches baseline (only known Firebase env-init failures remain)
- [ ] After merge: confirm `lint-and-test` is green on main and on next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)