### PR TITLE
Nightly Bug Sweep — web — 2026-04-28 — Batch 01

### DIFF
--- a/src/app/(dashboard)/error.tsx
+++ b/src/app/(dashboard)/error.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { AlertCircle, RefreshCw, LayoutDashboard, ChevronDown } from "lucide-react";
+import { RefreshCw, LayoutDashboard, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { OpsLockup } from "@/components/brand";
 import { cn } from "@/lib/utils/cn";
@@ -23,87 +23,123 @@ export default function DashboardError({
 
   return (
     <div
-      className="flex flex-col items-center justify-center min-h-[calc(100vh-4rem)] px-3 py-6"
+      className="flex items-start justify-center min-h-[calc(100vh-4rem)] px-6 py-10"
       role="alert"
     >
-      <div className="flex flex-col items-center max-w-[440px] w-full">
-        {/* Icon */}
-        <div className="w-[56px] h-[56px] rounded-xl bg-ops-error-muted border border-ops-error/20 flex items-center justify-center mb-3">
-          <AlertCircle className="w-[28px] h-[28px] text-ops-error" />
+      <div className="w-full max-w-[520px] flex flex-col gap-3">
+        {/* Tactical header strip */}
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden="true"
+            className="inline-block h-2 w-2 rounded-full bg-status-rose animate-pulse-live"
+          />
+          <span className="font-mono text-micro uppercase tracking-wider text-text-mute">
+            SYS :: ROUTE FAULT
+          </span>
+          <span className="font-mono text-micro text-text-mute">//</span>
+          <span className="font-mono text-micro uppercase tracking-wider text-text-3">
+            HANDLER STOPPED
+          </span>
         </div>
 
-        {/* Title */}
-        <h2 className="font-mohave text-display text-text uppercase tracking-wider text-center">
-          Something broke
-        </h2>
+        {/* Title block */}
+        <div className="flex flex-col gap-1">
+          <h2 className="font-cakemono font-light uppercase text-[28px] leading-[1.1] text-text">
+            Something broke
+          </h2>
+          <p className="font-mohave text-body-sm text-text-3 leading-relaxed">
+            An unexpected error halted this view. The rest of the dashboard is
+            unaffected. Retry the action or fall back to the home deck.
+          </p>
+        </div>
 
-        {/* Subtitle */}
-        <p className="font-mohave text-body-sm text-text-3 text-center mt-1 max-w-[360px]">
-          An unexpected error occurred. You can retry or head back to the dashboard.
-        </p>
-
-        {/* Error detail card */}
-        <div className="w-full mt-3 ultrathin-material-dark rounded-lg overflow-hidden">
+        {/* Glass diagnostic panel */}
+        <div className="glass-surface px-3 py-2 mt-1">
           <button
             onClick={() => setShowDetails(!showDetails)}
-            className="w-full flex items-center justify-between px-2 py-1.5 hover:bg-[rgba(255,255,255,0.03)] transition-colors"
+            className="w-full flex items-center justify-between text-left -mx-1 px-1 py-1 rounded-[5px] hover:bg-surface-hover-subtle transition-colors"
+            aria-expanded={showDetails}
           >
-            <span className="font-mono text-caption-sm text-text-mute uppercase tracking-widest">
-              Error Details
+            <span className="font-mono text-micro uppercase tracking-wider text-text-3">
+              // DIAGNOSTIC
             </span>
-            <ChevronDown
-              className={cn(
-                "w-[14px] h-[14px] text-text-mute transition-transform duration-200",
-                showDetails && "rotate-180"
-              )}
-            />
+            <span className="flex items-center gap-1.5">
+              <span className="font-mono text-micro text-text-mute uppercase tracking-wider">
+                {showDetails ? "HIDE" : "SHOW"}
+              </span>
+              <ChevronDown
+                className={cn(
+                  "w-[12px] h-[12px] text-text-mute transition-transform duration-200",
+                  showDetails && "rotate-180"
+                )}
+                aria-hidden="true"
+              />
+            </span>
           </button>
 
           {showDetails && (
-            <div className="px-2 pb-2 border-t border-border-subtle animate-fade-in">
-              <p className="font-mono text-data-sm text-text-3 mt-1.5 break-all leading-relaxed">
-                {error.message}
-              </p>
-              {error.digest && (
-                <p className="font-mono text-micro text-text-mute mt-1">
-                  DIGEST: {error.digest}
+            <div className="mt-2 pt-2 border-t border-border-subtle animate-fade-in flex flex-col gap-1.5">
+              <div className="flex items-baseline gap-2">
+                <span className="font-mono text-micro uppercase tracking-wider text-text-mute shrink-0">
+                  [MSG]
+                </span>
+                <p className="font-mono text-data-sm text-text-2 break-all leading-relaxed">
+                  {error.message || "Unknown error"}
                 </p>
+              </div>
+              {error.digest && (
+                <div className="flex items-baseline gap-2">
+                  <span className="font-mono text-micro uppercase tracking-wider text-text-mute shrink-0">
+                    [DIGEST]
+                  </span>
+                  <p className="font-mono text-micro text-text-3 break-all">
+                    {error.digest}
+                  </p>
+                </div>
               )}
+              <div className="flex items-baseline gap-2">
+                <span className="font-mono text-micro uppercase tracking-wider text-text-mute shrink-0">
+                  [TIME]
+                </span>
+                <p className="font-mono text-micro text-text-3">
+                  {new Date().toISOString()}
+                </p>
+              </div>
             </div>
           )}
         </div>
 
         {/* Actions */}
-        <div className="flex items-center gap-1.5 mt-3 w-full">
+        <div className="flex items-center gap-2 mt-1">
           <Button
             variant="primary"
             size="sm"
             onClick={reset}
-            className="flex-1 gap-1"
+            className="gap-1.5"
           >
-            <RefreshCw className="w-[14px] h-[14px]" />
+            <RefreshCw className="w-[14px] h-[14px]" aria-hidden="true" />
             Retry
           </Button>
           <Button
             variant="default"
             size="sm"
             onClick={() => router.push("/dashboard")}
-            className="flex-1 gap-1"
+            className="gap-1.5"
           >
-            <LayoutDashboard className="w-[14px] h-[14px]" />
+            <LayoutDashboard className="w-[14px] h-[14px]" aria-hidden="true" />
             Dashboard
           </Button>
         </div>
 
-        {/* Branding */}
-        <div className="mt-5 flex items-center gap-1 opacity-30">
+        {/* Footer */}
+        <div className="flex items-center gap-1.5 mt-4 opacity-40">
           <OpsLockup
             orientation="horizontal"
             title=""
             className="select-none h-3 w-auto text-text-mute"
           />
-          <span className="font-mono text-micro text-text-mute select-none">
-            ERROR BOUNDARY
+          <span className="font-mono text-micro text-text-mute select-none uppercase tracking-wider">
+            // ERROR BOUNDARY
           </span>
         </div>
       </div>

--- a/src/app/api/stripe/subscribe/route.ts
+++ b/src/app/api/stripe/subscribe/route.ts
@@ -87,7 +87,15 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const priceId = getPriceId(plan, period);
     if (!priceId) {
       console.error(`[stripe/subscribe] Missing price env var for ${plan}_${period}`);
-      return NextResponse.json({ error: "Price configuration not found" }, { status: 500 });
+      return NextResponse.json(
+        {
+          error: `Price configuration not found for ${plan} ${period}. Contact support.`,
+          code: "price_env_missing",
+          plan,
+          period,
+        },
+        { status: 500 }
+      );
     }
 
     const supabase = getServiceRoleClient();
@@ -300,6 +308,36 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       clientSecret,
     });
   } catch (error) {
+    // Stripe errors carry a `code` field (e.g. "resource_missing") and a
+    // `param` (e.g. "items[0][price]") that pinpoint config issues. Surface
+    // them cleanly so users see a useful message instead of "no such price"
+    // and so logs identify the misconfigured env var.
+    if (error instanceof Stripe.errors.StripeInvalidRequestError) {
+      const code = error.code ?? "stripe_invalid_request";
+      const param = error.param ?? null;
+      console.error(
+        `[stripe/subscribe] StripeInvalidRequestError code=${code} param=${param ?? "?"} msg=${error.message}`
+      );
+      if (code === "resource_missing" && (param === "price" || param?.includes("price"))) {
+        return NextResponse.json(
+          {
+            error:
+              "This plan is currently unavailable. Contact support so we can update the pricing configuration.",
+            code: "price_not_found",
+            stripeMessage: error.message,
+          },
+          { status: 500 }
+        );
+      }
+      return NextResponse.json(
+        {
+          error: error.message,
+          code,
+          param,
+        },
+        { status: 400 }
+      );
+    }
     const message = error instanceof Error ? error.message : "Failed to create subscription";
     console.error("[stripe/subscribe] Error:", error);
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/api/stripe/subscribe/route.ts
+++ b/src/app/api/stripe/subscribe/route.ts
@@ -187,6 +187,37 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       await stripe.customers.update(stripeCustomerId, {
         invoice_settings: { default_payment_method: paymentMethodId },
       });
+    } else {
+      // Lockout enforcement — refuse to create a subscription without a
+      // confirmed payment method. Without this guard, a UI bug or stale
+      // upgrade modal can call /subscribe with no paymentMethodId, Stripe
+      // creates an `incomplete` subscription that never becomes active, but
+      // the company row gets `subscription_plan` written + a success toast
+      // surfaces — granting the user the upgraded tier UX before any money
+      // changes hands.
+      //
+      // If a paymentMethodId was not passed, require that the Stripe customer
+      // already has a default payment method on file (set via SetupIntent in
+      // /settings/billing or attached on a prior subscribe call). Otherwise
+      // reject with 402 so the frontend can route the user to add a card.
+      const customer = await stripe.customers.retrieve(stripeCustomerId);
+      if (customer.deleted) {
+        return NextResponse.json(
+          { error: "Stripe customer was deleted" },
+          { status: 500 }
+        );
+      }
+      const defaultPm = customer.invoice_settings?.default_payment_method;
+      if (!defaultPm) {
+        return NextResponse.json(
+          {
+            error:
+              "A payment method is required to subscribe. Add a card in Settings → Billing first.",
+            code: "payment_method_required",
+          },
+          { status: 402 }
+        );
+      }
     }
 
     // Create subscription.

--- a/src/components/settings/ai-intake-interview.tsx
+++ b/src/components/settings/ai-intake-interview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   Send,
@@ -68,9 +69,15 @@ const CATEGORY_I18N: Record<QuestionCategory, string> = {
 
 function ProgressBar() {
   const { t } = useDictionary("ai-setup");
-  const categoryProgress = useInterviewStore(selectCategoryProgress);
+  // selectCategoryProgress and selectProgress synthesize fresh objects every
+  // call. Without useShallow, Zustand v5 / React 19 useSyncExternalStore
+  // re-fires on every render — surfacing as
+  // "The result of getSnapshot should be cached to avoid an infinite loop"
+  // and a Maximum-update-depth crash. useShallow does a shallow compare on
+  // the returned object so identical content does not retrigger renders.
+  const categoryProgress = useInterviewStore(useShallow(selectCategoryProgress));
   const currentCategory = useInterviewStore(selectCurrentCategory);
-  const overall = useInterviewStore(selectProgress);
+  const overall = useInterviewStore(useShallow(selectProgress));
 
   return (
     <div className="space-y-2">

--- a/src/components/settings/portal-branding-tab.tsx
+++ b/src/components/settings/portal-branding-tab.tsx
@@ -125,14 +125,63 @@ async function updateBranding(
   if (updates.showTax !== undefined) row.show_tax = updates.showTax;
   if (updates.showDiscount !== undefined) row.show_discount = updates.showDiscount;
 
-  const { data, error } = await supabase
+  // Visibility-override columns are added in migration 044. If migration 044
+  // has not yet been applied to the target Postgres/PostgREST schema cache,
+  // upserts that include any of these columns fail with:
+  //   "Could not find the '<col>' column of 'portal_branding' in the schema cache"
+  // Strip any unknown visibility columns and retry transparently so the user's
+  // core branding (logo / accent / template / theme / welcome) still saves.
+  const VISIBILITY_COLS = [
+    "show_quantities",
+    "show_unit_prices",
+    "show_line_totals",
+    "show_descriptions",
+    "show_tax",
+    "show_discount",
+  ] as const;
+
+  let attempt = await supabase
     .from("portal_branding")
     .upsert(row, { onConflict: "company_id" })
     .select()
     .single();
 
-  if (error) throw new Error(`Failed to update branding: ${error.message}`);
-  return mapBrandingFromDb(data);
+  if (attempt.error) {
+    const msg = attempt.error.message ?? "";
+    const schemaCacheMatch = /Could not find the '([^']+)' column of 'portal_branding' in the schema cache/i.exec(msg);
+    if (schemaCacheMatch) {
+      const missingCol = schemaCacheMatch[1];
+      // Strip the offending column and any other visibility overrides — the
+      // feature degrades gracefully until migration 044 lands.
+      const sanitized = { ...row };
+      delete sanitized[missingCol];
+      let strippedAny = false;
+      for (const col of VISIBILITY_COLS) {
+        if (col in sanitized) {
+          delete sanitized[col];
+          strippedAny = true;
+        }
+      }
+      attempt = await supabase
+        .from("portal_branding")
+        .upsert(sanitized, { onConflict: "company_id" })
+        .select()
+        .single();
+      if (attempt.error) {
+        throw new Error(`Failed to update branding: ${attempt.error.message}`);
+      }
+      if (strippedAny) {
+        // Soft warning — the save succeeded for everything visibility
+        // overrides. Caller surfaces the original toast on success.
+        console.warn(
+          "[portal-branding] Document visibility overrides not saved: schema is missing migration 044 (portal_branding visibility columns)."
+        );
+      }
+      return mapBrandingFromDb(attempt.data);
+    }
+    throw new Error(`Failed to update branding: ${attempt.error.message}`);
+  }
+  return mapBrandingFromDb(attempt.data);
 }
 
 // ─── Preset accent colors (centralized palette) ─────────────────────────────

--- a/src/components/settings/subscription-tab.tsx
+++ b/src/components/settings/subscription-tab.tsx
@@ -105,7 +105,26 @@ function UpgradeModal({
         }),
       });
       const data = await res.json();
-      if (!res.ok) throw new Error(data.error ?? "Subscription failed");
+      if (!res.ok) {
+        // 402 from /api/stripe/subscribe means the company has no payment
+        // method on file. Surface a specific, actionable toast that routes
+        // the user to Settings → Billing instead of the generic failure
+        // message — and bail BEFORE showing the success toast.
+        if (res.status === 402 || data?.code === "payment_method_required") {
+          toast.error("Payment method required", {
+            description:
+              "Add a card in Settings → Billing, then try the upgrade again.",
+            action: {
+              label: "Open Billing",
+              onClick: () => {
+                window.location.assign("/settings?tab=billing");
+              },
+            },
+          });
+          return;
+        }
+        throw new Error(data.error ?? "Subscription failed");
+      }
       toast.success(t("subscription.toast.subscribed"));
       onClose();
     } catch (err) {


### PR DESCRIPTION
## Summary

Nightly bug sweep covering 6 web bugs (5 fixed, 1 escalated for human review).

`npm run type-check` passes on every commit. `npm run build` fails on this branch AND on `main` with the same pre-existing error: `supabaseUrl is required` during page-data collection at `/api/admin/whats-new/categories` — environmental, unrelated to these fixes.

---

## Bugs landed

### fix(bug-fd1f8302) — Inbox error screen redesigned to v2 spec  *(ui_issue)*
Old error.tsx used legacy Mohave display tokens and centered layout, conflicting with spec v2 (Cake Mono Light display, left-only alignment, glass surfaces, tactical voice). Rebuilt with `font-cakemono font-light uppercase` 28px title, left-aligned column, `glass-surface` diagnostic panel, status-rose pulse dot, `// SYS :: ROUTE FAULT` voice, `[MSG] / [DIGEST] / [TIME]` bracketed metadata.

### fix(bug-08571812) — portal_branding visibility-column save failure  *(bug · urgent)*
`SAVE BRANDING` was failing entirely with "Could not find the 'show_descriptions' column of 'portal_branding' in the schema cache" because migration 044 (visibility columns: show_quantities/unit_prices/line_totals/descriptions/tax/discount) hasn't been applied to the target Postgres / PostgREST schema cache. The error blocked every branding edit including logo / accent / template / theme. Fix: detect the schema-cache missing-column error in `updateBranding`, strip every visibility-override column from the payload, and retry. Core branding now saves; a console warning surfaces that migration 044 is missing.

### fix(bug-ac030a6c) — Subscription lockout bypassed (no payment info)  **COMPLEX**  *(bug · subscription·payment·lockout)*
Pete Mitchell could click `UPGRADE TO STARTER` and be granted the upgraded UX without entering payment info. Root cause: `/api/stripe/subscribe` accepted requests with no `paymentMethodId`, created an `incomplete` Stripe sub (mapper returns null → `subscription_status` untouched), but still wrote `subscription_plan` / `subscription_period` / `max_seats` / `subscription_end` / `subscription_ids_json` and surfaced a "Subscribed!" toast. Server now requires either a passed `paymentMethodId` OR an existing `default_payment_method` on the Stripe customer; rejects with HTTP 402 `code:"payment_method_required"` otherwise. Frontend `UpgradeModal` intercepts the 402 and routes the user to Settings → Billing instead of showing success.

### fix(bug-50248c4d) — Stripe price id "no such price"  **COMPLEX**  *(bug · subscription)*
`UPGRADE TO STARTER` surfaced raw Stripe error "no such price id". Root cause: `STRIPE_PRICE_STARTER_*` env var points at a price id that doesn't exist in the connected Stripe account; `stripe.subscriptions.create` throws `StripeInvalidRequestError code=resource_missing param=items[0][price]`. Fix: catch the error type explicitly, return a user-friendly "This plan is currently unavailable. Contact support…" with `code:"price_not_found"` + the original Stripe message attached for diagnostics. Other Stripe invalid-request errors return 400 with `code` + `param`. The misconfigured env var still needs operator action; this fix surfaces the misconfiguration rather than crashing.

### fix(bug-bffbad6b) — Calibration interview crash: getSnapshot infinite loop  *(bug · urgent · crash-shaped)*
Starting an interview crashed with "The result of getSnapshot should be cached to avoid an infinite loop" → Maximum update depth exceeded. Root cause: `ProgressBar` (`ai-intake-interview.tsx:71`) subscribes to `selectCategoryProgress` and `selectProgress`, both of which build a fresh object on every call. Zustand v5 wraps subscriptions in `useSyncExternalStore`, which compares snapshot reference equality — a new object every render means React re-fires unbounded. Fix: wrapped both object-returning selectors in `useShallow` from `zustand/react/shallow` at the call site. Primitive selectors (`selectCurrentCategory`, etc.) untouched.

---

## Bugs escalated

### bug-1c468d20 — Uniform layouts/toggles across data tabs  *(ui_issue · high)*
Reporter asks for unified list/grid view toggles across Clients / Projects / Inventory / Invoices / Estimates. Each page currently has bespoke layouts (e.g. Projects has ProjectCanvas + ProjectSpreadsheet + StageStack). This is a multi-PR design+engineering initiative requiring a shared DataView/ViewToggle primitive, per-entity column maps, preferences persistence, and migration of every existing layout — not a nightly bugfix. Escalated for product/design alignment.

---

## Test plan

- [ ] Visit `/inbox` and trigger a route error — verify new tactical error screen renders (left-aligned, Cake Mono title, glass panel, "// SYS :: ROUTE FAULT")
- [ ] Settings → Portal Branding → change logo/template and `SAVE BRANDING` — verify save succeeds even when migration 044 is unapplied (visibility overrides silently skip; console warns)
- [ ] Settings → Subscription → click `UPGRADE TO STARTER` as a user with no card on file — verify 402 → "Payment method required" toast with "Open Billing" action
- [ ] With the misconfigured Stripe price env, click `UPGRADE TO STARTER` — verify "This plan is currently unavailable…" message instead of "no such price id"
- [ ] Calibration → start interview — verify no infinite-loop / Maximum-update-depth crash; ProgressBar renders with category segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)