### PR TITLE
fix(uploads): allow application/json content-type for training_data/ prefix

### DIFF
--- a/src/app/api/uploads/presign/route.ts
+++ b/src/app/api/uploads/presign/route.ts
@@ -18,6 +18,30 @@ const ALLOWED_TYPES = [
   "image/heic",
 ];
 
+// Folder prefixes allowed to upload non-image content via presign.
+// Currently scoped to deck-scanner cleanup-edit JSON logs (see iOS
+// `CleanupEditLogger.uploadPending()` — branch `claude/deck-scanner-rebuild`,
+// commit 9dffeb7) which ship base64-embedded crops + cleanup metadata to
+// `training_data/deck_scanner/{company_id}/{user_id}/{yyyy-mm-dd}/{entry_id}.json`
+// for the upcoming deck-scanner ML model training set.
+//
+// Rules for additions to this list:
+//   1. Must be an internal write path the iOS/web app fully controls — no
+//      user-supplied folder values reach this carve-out.
+//   2. Pair with an explicit content-type allowlist (see `TRAINING_DATA_TYPES`).
+//   3. Per-object size is hard-capped at the bucket level: the `images`
+//      Supabase Storage bucket has `file_size_limit = 10485760` (10 MB)
+//      set in migration `014_create_storage_bucket.sql`. Any client PUT
+//      that exceeds this gets rejected by Supabase Storage with a 413
+//      regardless of what the presign endpoint returned. Cleanup-edit
+//      entries run well under 5 MB in practice.
+const TRAINING_DATA_PREFIXES = ["training_data/"] as const;
+const TRAINING_DATA_TYPES = ["application/json"] as const;
+
+function isTrainingDataPath(folder: string): boolean {
+  return TRAINING_DATA_PREFIXES.some((prefix) => folder.startsWith(prefix));
+}
+
 export async function POST(req: NextRequest) {
   try {
     const contentType = req.headers.get("content-type") || "";
@@ -55,7 +79,18 @@ async function handlePresign(req: NextRequest) {
     );
   }
 
-  if (!ALLOWED_TYPES.includes(fileContentType)) {
+  // Content-type validation:
+  //   - Image types are allowed for any folder (the original behavior).
+  //   - `application/json` is allowed ONLY when the upload targets a
+  //     training-data folder (e.g. deck-scanner cleanup-edit logs). This
+  //     prevents arbitrary JSON dumping into image folders while letting
+  //     the iOS app accumulate ML training data.
+  const isImage = (ALLOWED_TYPES as readonly string[]).includes(fileContentType);
+  const isTrainingData =
+    isTrainingDataPath(folder) &&
+    (TRAINING_DATA_TYPES as readonly string[]).includes(fileContentType);
+
+  if (!isImage && !isTrainingData) {
     return NextResponse.json(
       { error: `Invalid content type: ${fileContentType}` },
       { status: 400 }
@@ -64,8 +99,15 @@ async function handlePresign(req: NextRequest) {
 
   const timestamp = Date.now();
   const random = Math.random().toString(36).slice(2, 8);
-  const ext = filename.split(".").pop() || "jpg";
-  const filePath = `${folder}/${timestamp}-${random}.${ext}`;
+  // Preserve the original filename's extension when present; fall back to
+  // a sensible default per content-type so JSON uploads don't end up
+  // labelled `.jpg`.
+  const inferredExt = filename.includes(".")
+    ? filename.split(".").pop()!
+    : isTrainingData
+      ? "json"
+      : "jpg";
+  const filePath = `${folder}/${timestamp}-${random}.${inferredExt}`;
 
   const supabase = getServiceRoleClient();
 

--- a/tests/integration/uploads-presign.test.ts
+++ b/tests/integration/uploads-presign.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Integration tests for POST /api/uploads/presign (presign flow only)
+ *
+ * Covers:
+ *   - Image content-types are allowed for any folder (existing behavior).
+ *   - `application/json` is allowed when folder begins with `training_data/`
+ *     (deck-scanner cleanup-edit log path — iOS commit 9dffeb7 on
+ *     `claude/deck-scanner-rebuild`).
+ *   - `application/json` is REJECTED for non-training-data folders.
+ *   - Disallowed image-ish types (e.g. `image/gif`) are rejected.
+ *   - Missing `filename` / `contentType` returns 400.
+ *   - File extension is inferred from contentType when filename has no
+ *     extension (JSON → `.json`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Capture the path passed to createSignedUploadUrl so we can assert on
+// extension inference.
+let capturedPath = "";
+
+// ─── Supabase service-role client mock ──────────────────────────────────────
+vi.mock("@/lib/supabase/server-client", () => ({
+  getServiceRoleClient: () => ({
+    storage: {
+      from: (_bucket: string) => ({
+        createSignedUploadUrl: async (path: string) => {
+          capturedPath = path;
+          return {
+            data: {
+              signedUrl: `https://example.supabase.co/storage/v1/upload/sign/${path}?token=test`,
+              token: "test",
+              path,
+            },
+            error: null,
+          };
+        },
+        getPublicUrl: (path: string) => ({
+          data: {
+            publicUrl: `https://example.supabase.co/storage/v1/object/public/images/${path}`,
+          },
+        }),
+      }),
+    },
+  }),
+}));
+
+// Import AFTER mocks are registered so the route picks up the stub.
+import { POST } from "@/app/api/uploads/presign/route";
+
+function makePresignRequest(params: Record<string, string>): Request {
+  const body = new URLSearchParams(params).toString();
+  return new Request("http://localhost/api/uploads/presign", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+}
+
+describe("POST /api/uploads/presign — presign (iOS) flow", () => {
+  beforeEach(() => {
+    capturedPath = "";
+  });
+
+  describe("content-type validation", () => {
+    it("allows image/jpeg for an arbitrary image folder", async () => {
+      const req = makePresignRequest({
+        filename: "shot.jpg",
+        contentType: "image/jpeg",
+        folder: "projects/co_123/proj_456",
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { uploadUrl: string; publicUrl: string };
+      expect(json.uploadUrl).toContain("/upload/sign/");
+      expect(json.publicUrl).toContain("/object/public/images/");
+      expect(capturedPath).toMatch(/^projects\/co_123\/proj_456\/\d+-[a-z0-9]+\.jpg$/);
+    });
+
+    it("allows application/json for the training_data/ folder prefix", async () => {
+      const req = makePresignRequest({
+        filename: "entry_abc123.json",
+        contentType: "application/json",
+        folder: "training_data/deck_scanner/co_123/usr_456/2026-04-29",
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { uploadUrl: string; publicUrl: string };
+      expect(json.uploadUrl).toContain("/upload/sign/");
+      expect(capturedPath).toMatch(
+        /^training_data\/deck_scanner\/co_123\/usr_456\/2026-04-29\/\d+-[a-z0-9]+\.json$/
+      );
+    });
+
+    it("rejects application/json when folder is NOT training_data/", async () => {
+      const req = makePresignRequest({
+        filename: "payload.json",
+        contentType: "application/json",
+        folder: "projects/co_123/proj_456",
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(400);
+      const json = (await res.json()) as { error: string };
+      expect(json.error).toMatch(/Invalid content type/i);
+    });
+
+    it("rejects image/gif everywhere (not on the allowlist)", async () => {
+      const req = makePresignRequest({
+        filename: "shot.gif",
+        contentType: "image/gif",
+        folder: "training_data/deck_scanner/co_123/usr_456/2026-04-29",
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects application/javascript even when path is training_data/", async () => {
+      const req = makePresignRequest({
+        filename: "evil.js",
+        contentType: "application/javascript",
+        folder: "training_data/deck_scanner/co_123/usr_456/2026-04-29",
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("required fields", () => {
+    it("returns 400 when filename is missing", async () => {
+      const req = makePresignRequest({
+        contentType: "image/jpeg",
+        folder: "projects/co_123/proj_456",
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when contentType is missing", async () => {
+      const req = makePresignRequest({
+        filename: "shot.jpg",
+        folder: "projects/co_123/proj_456",
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("file extension inference", () => {
+    it("preserves the original extension when present", async () => {
+      const req = makePresignRequest({
+        filename: "entry_abc.json",
+        contentType: "application/json",
+        folder: "training_data/deck_scanner/co_123/usr_456/2026-04-29",
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(200);
+      expect(capturedPath.endsWith(".json")).toBe(true);
+    });
+
+    it("falls back to .json when filename has no extension and type is JSON", async () => {
+      const req = makePresignRequest({
+        filename: "entry_abc",
+        contentType: "application/json",
+        folder: "training_data/deck_scanner/co_123/usr_456/2026-04-29",
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(200);
+      expect(capturedPath.endsWith(".json")).toBe(true);
+    });
+
+    it("falls back to .jpg when filename has no extension and type is image", async () => {
+      const req = makePresignRequest({
+        filename: "shot",
+        contentType: "image/jpeg",
+        folder: "projects/co_123/proj_456",
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(200);
+      expect(capturedPath.endsWith(".jpg")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Why

iOS branch [`claude/deck-scanner-rebuild`](https://github.com/jack-opsapp/ops-app-ios/commit/9dffeb7) (commit `9dffeb7`) wired `CleanupEditLogger.uploadPending()` to ship deck-scanner cleanup-edit logs to storage via the existing `PresignedURLUploadService`. Those logs are JSON payloads (with base64-embedded image crops inside) destined for:

```
training_data/deck_scanner/{company_id}/{user_id}/{yyyy-mm-dd}/{entry_id}.json
```

The OPS-Web presign endpoint at `/api/uploads/presign` was hard-coded to a 4-entry image MIME allowlist (`image/jpeg`, `image/png`, `image/webp`, `image/heic`). Any iOS call with `contentType=application/json` returned **400 Invalid content type** silently — no telemetry on the iOS side flagged this, so for the next ~6 weeks of dogfooding we'd have accumulated zero ML training data.

## What changed

`src/app/api/uploads/presign/route.ts`:

**Before:**
```ts
if (!ALLOWED_TYPES.includes(fileContentType)) {
  return NextResponse.json({ error: `Invalid content type: ${fileContentType}` }, { status: 400 });
}
```

**After:**
```ts
const isImage = (ALLOWED_TYPES as readonly string[]).includes(fileContentType);
const isTrainingData =
  isTrainingDataPath(folder) &&
  (TRAINING_DATA_TYPES as readonly string[]).includes(fileContentType);

if (!isImage && !isTrainingData) {
  return NextResponse.json({ error: `Invalid content type: ${fileContentType}` }, { status: 400 });
}
```

`isTrainingDataPath()` checks `folder.startsWith("training_data/")`. `TRAINING_DATA_TYPES = ["application/json"]`.

Also: when the original filename has no extension, the stored object's extension now derives from the content-type (`.json` for training data, `.jpg` otherwise) instead of always defaulting to `.jpg`.

## Security reasoning

- **Path-prefix carve-out, not a global whitelist.** `application/json` is rejected for any folder that doesn't start with `training_data/`. Image folders stay image-only.
- **Per-object size already capped at 10 MB** by the bucket-level `file_size_limit` in `supabase/migrations/014_create_storage_bucket.sql`. Cleanup-edit entries run well under 5 MB in practice; any oversized PUT gets a 413 from Supabase Storage regardless of what the presign endpoint returned.
- **Auth behavior unchanged** — see "Other concerns" below.

## Tests

New file: `tests/integration/uploads-presign.test.ts` (10 tests, all passing on vitest):

- Image content-types still allowed for arbitrary folders
- `application/json` allowed for `training_data/...` paths
- `application/json` rejected for non-training-data folders
- `image/gif` rejected everywhere
- `application/javascript` rejected even on training_data path
- Missing `filename` / `contentType` returns 400
- Filename extension preserved when present
- Extension inferred from content-type when filename has no extension

`npm test -- tests/integration/uploads-presign.test.ts` → 10/10 pass.
`npx tsc --noEmit` → clean.
`npx next lint --file ...` → clean.

## Manual test plan (post-merge + deploy)

- [ ] On a device with the `claude/deck-scanner-rebuild` build, run a deck scan and a cleanup edit.
- [ ] Within ~30 seconds, confirm a JSON file appears at `s3://ops-app-files-prod/training_data/deck_scanner/{company_id}/{user_id}/{yyyy-mm-dd}/{entry_id}.json`.

> **Note for reviewer:** The iOS implementer described the destination as `s3://ops-app-files-prod/training_data/...`, but this presign endpoint actually returns a **Supabase Storage** signed URL for the `images` bucket — not S3. So files will land at `https://<project>.supabase.co/storage/v1/object/public/images/training_data/deck_scanner/...`. If the goal really is S3 (`ops-app-files-prod`), the presign endpoint itself needs a separate refactor — flagging here so we don't get surprised.

## Other concerns spotted (NOT fixed in this PR — flagging only)

These are pre-existing issues in the route, unrelated to the JSON content-type fix. Documenting so they don't get lost:

1. **No authentication on presign.** The endpoint accepts an `Authorization: Bearer <Firebase ID token>` header from iOS but never verifies it. Any unauthenticated caller can request a signed upload URL. Should pair with `verifyFirebaseToken()` (or whatever the project's auth helper is) before signing.
2. **No path-prefix authz.** A logged-in user from company A can request a presigned URL for `projects/CO_B/...`. The folder string is taken from the request as-is.
3. **No rate limiting** on signed URL generation.
4. **Bucket destination mismatch** with iOS expectation — see manual test plan note above.
5. **Anonymous file_size_limit reliance** — the 10 MB cap is enforced by Supabase, not the endpoint. If we ever migrate this route to S3 directly, that cap moves to a presigned POST policy.

Happy to spin separate PRs for any of these on request.

## Related

- iOS commit pending this merge: `9dffeb7` on `claude/deck-scanner-rebuild` (OPS sub-repo)
- Bucket config: `supabase/migrations/014_create_storage_bucket.sql`