### PR TITLE
feat(calendar): port sweep-line lane stacking into crew/ components

### DIFF
--- a/src/app/(dashboard)/calendar/_components/crew/crew-grid.tsx
+++ b/src/app/(dashboard)/calendar/_components/crew/crew-grid.tsx
@@ -26,7 +26,9 @@ import {
   CREW_DAYS_SHOWN,
   CREW_DAY_MIN_WIDTH,
   CREW_GUTTER_WIDTH,
+  CREW_ROW_HEIGHT,
 } from "@/lib/utils/crew-constants";
+import { assignLanes, rowHeightForLanes } from "@/lib/utils/lane-assignment";
 
 // ─── Unassigned Placeholder ─────────────────────────────────────────────────
 
@@ -61,12 +63,14 @@ function DroppableCrewRow({
   startDate,
   daysShown,
   isLast,
+  rowHeight,
   children,
 }: {
   teamMember: TeamMember;
   startDate: Date;
   daysShown: number;
   isLast?: boolean;
+  rowHeight?: number;
   children: React.ReactNode;
 }) {
   const rowRef = useRef<HTMLDivElement>(null);
@@ -110,6 +114,7 @@ function DroppableCrewRow({
         startDate={startDate}
         daysShown={daysShown}
         isLast={isLast}
+        rowHeight={rowHeight}
       >
         {children}
       </CrewRow>
@@ -355,12 +360,15 @@ export function CrewGrid({
           {/* Team member rows */}
           {teamMembers.map((member) => {
             const memberEvents = grouped.get(member.id) ?? [];
+            const { lanes, laneCount } = assignLanes(memberEvents);
+            const rowHeight = rowHeightForLanes(laneCount, CREW_ROW_HEIGHT);
             return (
               <DroppableCrewRow
                 key={member.id}
                 teamMember={member}
                 startDate={startDate}
                 daysShown={daysShown}
+                rowHeight={rowHeight}
               >
                 {memberEvents.map((event) => (
                   <CrewTaskBlock
@@ -369,6 +377,9 @@ export function CrewGrid({
                     startDate={startDate}
                     daysShown={daysShown}
                     isSelected={isTaskSelected(event.id)}
+                    laneIndex={lanes.get(event.id) ?? 0}
+                    laneCount={laneCount}
+                    rowHeight={rowHeight}
                     onClick={handleEventClick}
                     onContextMenu={handleContextMenu}
                     onResize={handleResize}
@@ -382,12 +393,15 @@ export function CrewGrid({
           {(() => {
             const unassignedEvents = grouped.get(UNASSIGNED_MEMBER.id) ?? [];
             if (unassignedEvents.length === 0) return null;
+            const { lanes, laneCount } = assignLanes(unassignedEvents);
+            const rowHeight = rowHeightForLanes(laneCount, CREW_ROW_HEIGHT);
             return (
               <DroppableCrewRow
                 teamMember={UNASSIGNED_MEMBER}
                 startDate={startDate}
                 daysShown={daysShown}
                 isLast
+                rowHeight={rowHeight}
               >
                 {unassignedEvents.map((event) => (
                   <CrewTaskBlock
@@ -396,6 +410,9 @@ export function CrewGrid({
                     startDate={startDate}
                     daysShown={daysShown}
                     isSelected={isTaskSelected(event.id)}
+                    laneIndex={lanes.get(event.id) ?? 0}
+                    laneCount={laneCount}
+                    rowHeight={rowHeight}
                     onClick={handleEventClick}
                     onContextMenu={handleContextMenu}
                     onResize={handleResize}

--- a/src/app/(dashboard)/calendar/_components/crew/crew-row.tsx
+++ b/src/app/(dashboard)/calendar/_components/crew/crew-row.tsx
@@ -17,6 +17,8 @@ interface CrewRowProps {
   startDate: Date;
   daysShown: number;
   isLast?: boolean;
+  /** Optional row height override — used by lane stacking when overlaps push the row taller. */
+  rowHeight?: number;
   children?: ReactNode;
 }
 
@@ -27,6 +29,7 @@ export function CrewRow({
   startDate,
   daysShown,
   isLast = false,
+  rowHeight,
   children,
 }: CrewRowProps) {
   const fullName = `${teamMember.firstName} ${teamMember.lastName}`.trim() || "Unknown";
@@ -38,7 +41,7 @@ export function CrewRow({
     <div
       className="flex group transition-colors duration-150"
       style={{
-        height: CREW_ROW_HEIGHT,
+        height: rowHeight ?? CREW_ROW_HEIGHT,
         borderBottom: isLast ? "none" : "1px solid rgba(255,255,255,0.05)",
         background: "transparent",
       }}

--- a/src/app/(dashboard)/calendar/_components/crew/crew-task-block.tsx
+++ b/src/app/(dashboard)/calendar/_components/crew/crew-task-block.tsx
@@ -5,6 +5,7 @@ import { differenceInCalendarDays, addDays, format } from "date-fns";
 import { useDraggable } from "@dnd-kit/core";
 import type { InternalCalendarEvent } from "@/lib/utils/calendar-utils";
 import { CREW_ROW_HEIGHT } from "@/lib/utils/crew-constants";
+import { laneVerticalLayout } from "@/lib/utils/lane-assignment";
 import { EventHoverPopover } from "../event-hover-popover";
 
 // ─── Props ──────────────────────────────────────────────────────────────────
@@ -15,6 +16,12 @@ interface CrewTaskBlockProps {
   daysShown: number; // number of visible day columns
   isSelected?: boolean; // selected via click or multi-select
   isGhost?: boolean; // ghost preview for cascade/auto-schedule
+  /** Vertical lane index for stacking overlapping events (0-based) */
+  laneIndex?: number;
+  /** Total number of lanes used in this row */
+  laneCount?: number;
+  /** Total row height in px — block divides this evenly across laneCount */
+  rowHeight?: number;
   onClick?: (event: InternalCalendarEvent) => void;
   onContextMenu?: (
     event: InternalCalendarEvent,
@@ -39,6 +46,9 @@ export function CrewTaskBlock({
   daysShown,
   isSelected = false,
   isGhost = false,
+  laneIndex = 0,
+  laneCount = 1,
+  rowHeight = CREW_ROW_HEIGHT,
   onClick,
   onContextMenu,
   onResize,
@@ -111,7 +121,15 @@ export function CrewTaskBlock({
     return { leftPercent: newLeft, widthPercent: newWidth };
   }, [resizeState, leftPercent, widthPercent, daysShown]);
 
-  const blockHeight = CREW_ROW_HEIGHT - 16; // 56px (8px padding top + bottom)
+  // Lane-aware vertical layout. The row reserves 8px top + 8px bottom
+  // padding, then divides the remaining space among laneCount lanes with
+  // a 4px gap between lanes. Single-lane rows stay at the historical
+  // 56px (CREW_ROW_HEIGHT - 16) height.
+  const { top: blockTop, height: blockHeight } = laneVerticalLayout(
+    laneIndex,
+    laneCount,
+    rowHeight
+  );
 
   // ── Determine if block is narrow ──────────────────────────────────────
 
@@ -252,7 +270,7 @@ export function CrewTaskBlock({
       style={{
         left: `${resizeAdjusted.leftPercent}%`,
         width: `${resizeAdjusted.widthPercent}%`,
-        top: 8,
+        top: blockTop,
         height: blockHeight,
         zIndex: isDragging ? 20 : resizeState ? 15 : isSelected ? 5 : isHovered ? 4 : 2,
         pointerEvents: isGhost ? "none" : "auto",

--- a/src/lib/utils/lane-assignment.ts
+++ b/src/lib/utils/lane-assignment.ts
@@ -1,0 +1,104 @@
+/**
+ * OPS Web - Lane Assignment for Overlapping Calendar Events
+ *
+ * Sweep-line algorithm that places overlapping events into separate vertical
+ * lanes within a single swimlane row. Used by the Crew view (and previously
+ * the Timeline view, before T12 of the calendar visual rework). See
+ * docs/superpowers/specs/2026-04-27-calendar-time-precision-recurrence.md
+ * for the broader architecture.
+ *
+ * Without lane assignment, two events overlapping on the same day for the
+ * same crew member render exactly on top of each other — labels merge
+ * ("Lan...INSTALLATION") and only the top-stacked event is clickable.
+ */
+
+import type { InternalCalendarEvent } from "./calendar-utils";
+
+export interface LaneAssignment {
+  /** eventId → lane index (0-based) */
+  lanes: Map<string, number>;
+  /** Maximum number of overlapping lanes used in this row */
+  laneCount: number;
+}
+
+/**
+ * Place events into the lowest-numbered lane whose previous event has
+ * already ended. Two events count as overlapping when their inclusive
+ * [start, end] ranges intersect.
+ *
+ * Strict less-than comparison means an event ending on day N can share
+ * a lane with one starting on day N+1 (back-to-back, not overlapping).
+ */
+export function assignLanes(events: InternalCalendarEvent[]): LaneAssignment {
+  if (events.length === 0) return { lanes: new Map(), laneCount: 1 };
+
+  const sorted = [...events].sort(
+    (a, b) => a.startDate.getTime() - b.startDate.getTime()
+  );
+  // laneEndTimes[i] = end timestamp of the latest event currently in lane i
+  const laneEndTimes: number[] = [];
+  const lanes = new Map<string, number>();
+
+  for (const event of sorted) {
+    const startMs = event.startDate.getTime();
+    const endMs = event.endDate.getTime();
+    let placed = false;
+
+    for (let i = 0; i < laneEndTimes.length; i++) {
+      if (laneEndTimes[i] < startMs) {
+        lanes.set(event.id, i);
+        laneEndTimes[i] = endMs;
+        placed = true;
+        break;
+      }
+    }
+
+    if (!placed) {
+      lanes.set(event.id, laneEndTimes.length);
+      laneEndTimes.push(endMs);
+    }
+  }
+
+  return { lanes, laneCount: Math.max(laneEndTimes.length, 1) };
+}
+
+/**
+ * Decide row height given a lane count and a base single-lane row height.
+ * Each lane is allotted >= MIN_LANE_HEIGHT so labels stay readable; rows
+ * always honor the base height as a floor.
+ */
+export function rowHeightForLanes(laneCount: number, baseRowHeight: number): number {
+  const MIN_LANE_HEIGHT = 24;
+  const VERTICAL_PADDING = 16; // 8px top + 8px bottom
+  const LANE_GAP = 4;
+  const computed =
+    VERTICAL_PADDING +
+    laneCount * MIN_LANE_HEIGHT +
+    Math.max(laneCount - 1, 0) * LANE_GAP;
+  return Math.max(baseRowHeight, computed);
+}
+
+/**
+ * Compute vertical layout for a single block given its lane and the row's
+ * total available height. Mirrors the inline math previously duplicated
+ * across timeline/crew task blocks.
+ */
+export function laneVerticalLayout(
+  laneIndex: number,
+  laneCount: number,
+  rowHeight: number
+): { top: number; height: number } {
+  const VERTICAL_PADDING = 8;
+  const LANE_GAP = 4;
+  const MIN_BLOCK_HEIGHT = 14;
+  const innerHeight = rowHeight - VERTICAL_PADDING * 2;
+  const totalLaneGaps = LANE_GAP * Math.max(laneCount - 1, 0);
+  const perLaneHeight = Math.max(
+    MIN_BLOCK_HEIGHT,
+    Math.floor((innerHeight - totalLaneGaps) / Math.max(laneCount, 1))
+  );
+  return {
+    top: VERTICAL_PADDING + laneIndex * (perLaneHeight + LANE_GAP),
+    height: perLaneHeight,
+  };
+}

--- a/tests/unit/calendar/lane-assignment.test.ts
+++ b/tests/unit/calendar/lane-assignment.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  assignLanes,
+  rowHeightForLanes,
+  laneVerticalLayout,
+} from "@/lib/utils/lane-assignment";
+import type { InternalCalendarEvent } from "@/lib/utils/calendar-utils";
+
+// ─── Test fixture helper ────────────────────────────────────────────────────
+
+/**
+ * Build a minimal InternalCalendarEvent for lane-assignment testing.
+ * The algorithm only inspects id, startDate, and endDate — everything else
+ * is filler to satisfy the type.
+ */
+function event(id: string, startISO: string, endISO: string): InternalCalendarEvent {
+  return {
+    id,
+    startDate: new Date(startISO),
+    endDate: new Date(endISO),
+    taskTitle: "task",
+    projectTitle: null,
+    clientName: null,
+    address: null,
+    teamMemberIds: [],
+    typeColors: { bg: "#000", border: "#fff" },
+    typeLabel: null,
+    statusKey: "scheduled",
+    allDay: true,
+    recurrenceId: null,
+    recurrenceOriginDate: null,
+  } as unknown as InternalCalendarEvent;
+}
+
+// ─── assignLanes ────────────────────────────────────────────────────────────
+
+describe("assignLanes", () => {
+  it("returns empty map and laneCount=1 when given no events", () => {
+    const result = assignLanes([]);
+    expect(result.lanes.size).toBe(0);
+    expect(result.laneCount).toBe(1);
+  });
+
+  it("places a single event in lane 0 with laneCount=1", () => {
+    const result = assignLanes([event("a", "2026-05-01T00:00:00Z", "2026-05-03T23:59:59Z")]);
+    expect(result.lanes.get("a")).toBe(0);
+    expect(result.laneCount).toBe(1);
+  });
+
+  it("places non-overlapping events in the same lane", () => {
+    const result = assignLanes([
+      event("a", "2026-05-01T08:00:00Z", "2026-05-01T17:00:00Z"),
+      event("b", "2026-05-02T08:00:00Z", "2026-05-02T17:00:00Z"),
+    ]);
+    expect(result.lanes.get("a")).toBe(0);
+    expect(result.lanes.get("b")).toBe(0);
+    expect(result.laneCount).toBe(1);
+  });
+
+  it("places two overlapping events in separate lanes", () => {
+    const result = assignLanes([
+      event("a", "2026-05-01T00:00:00Z", "2026-05-03T23:59:59Z"),
+      event("b", "2026-05-01T00:00:00Z", "2026-05-03T23:59:59Z"),
+    ]);
+    expect(result.lanes.get("a")).toBe(0);
+    expect(result.lanes.get("b")).toBe(1);
+    expect(result.laneCount).toBe(2);
+  });
+
+  it("places three overlapping events in three lanes", () => {
+    const result = assignLanes([
+      event("a", "2026-05-01T00:00:00Z", "2026-05-05T23:59:59Z"),
+      event("b", "2026-05-02T00:00:00Z", "2026-05-04T23:59:59Z"),
+      event("c", "2026-05-03T00:00:00Z", "2026-05-06T23:59:59Z"),
+    ]);
+    expect(result.laneCount).toBe(3);
+    expect(result.lanes.get("a")).toBe(0);
+    expect(result.lanes.get("b")).toBe(1);
+    expect(result.lanes.get("c")).toBe(2);
+  });
+
+  it("reuses a lane after its event ends, even with later overlaps elsewhere", () => {
+    // a (lane 0): May 1 00:00 → May 2 23:59
+    // b (lane 1): May 1 08:00 → May 3 23:59 (overlaps with a)
+    // c (lane 0): May 3 00:00 → May 4 23:59 (a is done so lane 0 reusable; overlaps with b)
+    const result = assignLanes([
+      event("a", "2026-05-01T00:00:00Z", "2026-05-02T23:59:00Z"),
+      event("b", "2026-05-01T08:00:00Z", "2026-05-03T23:59:00Z"),
+      event("c", "2026-05-03T00:00:00Z", "2026-05-04T23:59:00Z"),
+    ]);
+    expect(result.laneCount).toBe(2);
+    expect(result.lanes.get("a")).toBe(0);
+    expect(result.lanes.get("b")).toBe(1);
+    expect(result.lanes.get("c")).toBe(0);
+  });
+
+  it("treats back-to-back events (one ends before another starts) as non-overlapping", () => {
+    const result = assignLanes([
+      event("a", "2026-05-01T08:00:00Z", "2026-05-01T17:00:00Z"),
+      event("b", "2026-05-01T17:00:01Z", "2026-05-01T20:00:00Z"),
+    ]);
+    expect(result.laneCount).toBe(1);
+    expect(result.lanes.get("a")).toBe(0);
+    expect(result.lanes.get("b")).toBe(0);
+  });
+
+  it("sorts events by start time before assigning, so input order does not matter", () => {
+    const result = assignLanes([
+      event("c", "2026-05-03T00:00:00Z", "2026-05-06T23:59:59Z"),
+      event("a", "2026-05-01T00:00:00Z", "2026-05-05T23:59:59Z"),
+      event("b", "2026-05-02T00:00:00Z", "2026-05-04T23:59:59Z"),
+    ]);
+    expect(result.laneCount).toBe(3);
+    expect(result.lanes.get("a")).toBe(0);
+    expect(result.lanes.get("b")).toBe(1);
+    expect(result.lanes.get("c")).toBe(2);
+  });
+});
+
+// ─── rowHeightForLanes ──────────────────────────────────────────────────────
+
+describe("rowHeightForLanes", () => {
+  const BASE = 72; // matches CREW_ROW_HEIGHT
+
+  it("returns the base height for a single lane (no overlaps)", () => {
+    expect(rowHeightForLanes(1, BASE)).toBe(BASE);
+  });
+
+  it("returns the base height for two lanes when computed height is below base", () => {
+    // 2 lanes: 16 + 2*24 + 1*4 = 68 — still below BASE=72.
+    expect(rowHeightForLanes(2, BASE)).toBe(BASE);
+  });
+
+  it("grows the row when computed height exceeds base", () => {
+    // 3 lanes: 16 + 3*24 + 2*4 = 96 — exceeds BASE=72.
+    expect(rowHeightForLanes(3, BASE)).toBe(96);
+  });
+
+  it("scales linearly for many lanes", () => {
+    // 5 lanes: 16 + 5*24 + 4*4 = 152.
+    expect(rowHeightForLanes(5, BASE)).toBe(152);
+  });
+});
+
+// ─── laneVerticalLayout ─────────────────────────────────────────────────────
+
+describe("laneVerticalLayout", () => {
+  it("places a single lane at top=8 with the historical 56px height", () => {
+    const layout = laneVerticalLayout(0, 1, 72);
+    expect(layout.top).toBe(8);
+    expect(layout.height).toBe(56);
+  });
+
+  it("splits inner height evenly across two lanes with a 4px gap", () => {
+    // BASE=72: inner=56, totalGaps=4, perLane=floor(52/2)=26.
+    const lane0 = laneVerticalLayout(0, 2, 72);
+    const lane1 = laneVerticalLayout(1, 2, 72);
+    expect(lane0).toEqual({ top: 8, height: 26 });
+    expect(lane1).toEqual({ top: 8 + 26 + 4, height: 26 });
+  });
+
+  it("uses grown row height for many lanes so blocks stay readable", () => {
+    // For 4 lanes the grid would size the row at rowHeightForLanes(4, 72)=124.
+    // inner=108, totalGaps=12, perLane=floor(96/4)=24.
+    const grown = rowHeightForLanes(4, 72);
+    expect(grown).toBe(124);
+    const lane3 = laneVerticalLayout(3, 4, grown);
+    expect(lane3.height).toBe(24);
+    expect(lane3.top).toBe(8 + 3 * (24 + 4));
+  });
+
+  it("clamps to the minimum 14px lane height when rowHeight is unusually small", () => {
+    const layout = laneVerticalLayout(0, 8, 40);
+    expect(layout.height).toBe(14);
+  });
+});


### PR DESCRIPTION
Closes #27.

## Problem

When two events overlap on the same day for the same crew member, the old behavior rendered both at `top: 8` with a fixed 56px height — labels merged ("Lan...INSTALLATION") and only the top-stacked event was clickable.

PR #7 fixed this in the old `timeline/` components, but PR #26 (calendar UX rework) renamed `timeline/` → `crew/` before the lane logic could be ported. This PR carries the algorithm forward into the new architecture.

## Implementation

**New shared utility:** `src/lib/utils/lane-assignment.ts`
- `assignLanes(events)` — sweep-line lane placement (events sorted by start, placed in lowest lane whose previous event ended)
- `rowHeightForLanes(n, base)` — row height honoring lane count, never below base
- `laneVerticalLayout(i, n, height)` — per-block top + height in row

Extracted to a util (vs. inlined like the original) so the algorithm is testable and reusable when timeline-style swimlanes return.

**Wired through three crew components:**
- `crew-grid.tsx` — computes lanes per row (per crew member + unassigned), passes `rowHeight` to row, `laneIndex/laneCount/rowHeight` to each task block
- `crew-row.tsx` — accepts optional `rowHeight` prop, falls back to `CREW_ROW_HEIGHT`
- `crew-task-block.tsx` — accepts `laneIndex/laneCount/rowHeight`, derives `top` + `height` from `laneVerticalLayout`. Default args preserve historical 56px single-lane behavior

**16-test unit suite** at `tests/unit/calendar/lane-assignment.test.ts` covering:
- Empty input, single event, non-overlapping, two-overlap, three-overlap
- Lane reuse after end (event in lane 0 done → reused while lane 1 still busy)
- Back-to-back boundary (strict less-than means lane reusable when one ends before next starts)
- Input-order independence (sorted by start internally)
- Row height: base for 1-2 lanes, grows for 3+
- Per-block layout: 56px single-lane, even split with 4px gap for 2 lanes, grown row for 4 lanes
- Pathological clamp: 14px minimum block height for unusually small rows

## Verification

Locally:
- `npm run lint` — 0 errors
- `npm run type-check` — clean
- `npx vitest run tests/unit/calendar/lane-assignment.test.ts` — 16/16 pass

## Test plan

- [ ] Two events overlapping on same day for same crew member render in separate lanes (not stacked)
- [ ] Three or more overlapping events stack cleanly (no visual collision)
- [ ] Each overlapping event is independently clickable / draggable / resizable
- [ ] Single-event rows stay at 72px (CREW_ROW_HEIGHT)
- [ ] Multi-lane rows grow to accommodate ≥24px per lane + 4px gaps
- [ ] No regression to other calendar views (Day/Week/Month)