### PR TITLE
Nightly Bug Sweep — web — 2026-04-30 — Batch 01

### DIFF
--- a/.interface-design/system.md
+++ b/.interface-design/system.md
@@ -642,6 +642,28 @@ import { KeyHint } from "@/components/ui/key-hint";
 - Color pattern: `text-{color} bg-{color}/15 border-{color}/30`
 - MUST use WidgetStatusBadge component — never hand-roll badge styling
 
+### Calendar event badges & bars (frosted-glass tinted fill)
+
+Calendar event chips, bars, and the type/status sub-badges paint over a busy
+canvas (grid lines, day numbers, drop targets). Their fill MUST be a frosted-
+glass-tinted layer so content behind them never bleeds through and hurts
+legibility.
+
+**Recipe (canonical — exposed via `frostedBadgeStyle()` in `calendar-utils.ts`):**
+
+- `background: linear-gradient({typeColors.bg}, {typeColors.bg}), rgba(18, 18, 20, 0.78)`
+  — type tint stacked over the dense-glass dark base.
+- `backdrop-filter: blur(28px) saturate(1.3)` (and the `-webkit-` prefix).
+- Border: `1px solid {typeColors.border}` (full-strength type color).
+- Type tint alpha stays at `0.18` (`colorTripleFromHex` default) — do not
+  raise it; the dark base is what guarantees legibility.
+
+Use `frostedBadgeStyle(event.typeColors)` for type-driven fills (Month bars,
+Crew blocks, Day card type badges, hover-popover type chip) and
+`frostedBadgeStyleFromBg(event.statusColors.bg)` for status-driven fills
+(Day timed blocks, all-day strip pills). Never paint a calendar badge with
+just the raw `typeColors.bg` — the result is unreadable over busy grids.
+
 ---
 
 ## Scroll Containers

--- a/src/app/(dashboard)/calendar/_components/calendar-dnd-shell.tsx
+++ b/src/app/(dashboard)/calendar/_components/calendar-dnd-shell.tsx
@@ -186,9 +186,7 @@ export function CalendarDndShell({ children }: CalendarDndShellProps) {
       const overData = over.data?.current as
         | { type?: string; day?: Date }
         | undefined;
-      if (!activeData?.type || !overData?.day) return;
-
-      const targetDay = overData.day;
+      if (!activeData?.type) return;
 
       // Recurrence-aware dispatcher
       const dispatchUpdate = async (
@@ -221,6 +219,42 @@ export function CalendarDndShell({ children }: CalendarDndShellProps) {
           }
         );
       };
+
+      // ── Drop on the unscheduled dock → unschedule the event ─────────────
+      // Only existing calendar events can be unscheduled; tasks already in
+      // the tray (`unscheduled-task`) have no schedule to clear.
+      if (overData?.type === "unscheduled-dock") {
+        const calEvent = activeData.event;
+        if (
+          !calEvent ||
+          (activeData.type !== "month-event" &&
+            activeData.type !== "week-event" &&
+            activeData.type !== "day-hourly-event" &&
+            activeData.type !== "day-list-event")
+        ) {
+          return;
+        }
+        // Clear startDate / endDate. Recurrence-aware to mirror reschedule
+        // behavior: a series occurrence opens the prompt; a one-off updates
+        // directly. startTime / endTime are explicitly cleared so the row
+        // doesn't carry a phantom time slot.
+        const patch: Partial<ProjectTask> = {
+          startDate: null,
+          endDate: null,
+          startTime: null,
+          endTime: null,
+        };
+        await dispatchUpdate(
+          calEvent.id,
+          patch,
+          "Unschedule this occurrence, or unschedule the entire series?"
+        );
+        return;
+      }
+
+      if (!overData?.day) return;
+
+      const targetDay = overData.day;
 
       // ── month-event / week-event: whole-day reschedule ───────────────
       if (

--- a/src/app/(dashboard)/calendar/_components/calendar-dnd-shell.tsx
+++ b/src/app/(dashboard)/calendar/_components/calendar-dnd-shell.tsx
@@ -24,6 +24,7 @@ import {
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -92,6 +93,43 @@ export function useCalendarResizeContext(): CalendarResizeAPI {
   return ctx;
 }
 
+// ─── Auxiliary drag handlers ────────────────────────────────────────────────
+//
+// CrewGrid used to mount its own <DndContext> with `useCrewDnd` handlers,
+// which broke cross-surface drags (the unscheduled tray is registered with
+// the outer CalendarDndShell context, so its drags could not reach the
+// inner crew DndContext). The crew grid now registers its handler via this
+// bridge instead — CalendarDndShell.handleDragEnd invokes any registered
+// auxiliary handlers when the active drag type matches their `match` set,
+// which lets `useCrewDnd` keep its per-grid state (gridWidth ref, cascade
+// preview, dependency check) while sharing the single outer context.
+
+type AuxDragHandler = {
+  /** Set of activeData.type values this handler will receive */
+  matchTypes: Set<string>;
+  onDragStart?: (e: DragStartEvent) => void;
+  onDragEnd: (e: DragEndEvent) => void | Promise<void>;
+  onDragCancel?: (e: DragCancelEvent) => void;
+};
+
+interface CalendarDragBridgeAPI {
+  register: (id: string, handler: AuxDragHandler) => () => void;
+}
+
+const CalendarDragBridgeContext = createContext<CalendarDragBridgeAPI | null>(
+  null
+);
+
+export function useCalendarDragBridge(): CalendarDragBridgeAPI {
+  const ctx = useContext(CalendarDragBridgeContext);
+  if (!ctx) {
+    throw new Error(
+      "useCalendarDragBridge must be used inside <CalendarDndShell>"
+    );
+  }
+  return ctx;
+}
+
 // ─── Active drag descriptor ────────────────────────────────────────────────
 
 interface ActiveDrag {
@@ -146,35 +184,80 @@ export function CalendarDndShell({ children }: CalendarDndShellProps) {
 
   const [activeDrag, setActiveDrag] = useState<ActiveDrag | null>(null);
 
+  // Auxiliary handler registry — see useCalendarDragBridge above. Map keyed
+  // by handler id so an unmount removes only that handler.
+  const auxHandlersRef = useRef(new Map<string, AuxDragHandler>());
+  const dragBridge = useMemo<CalendarDragBridgeAPI>(
+    () => ({
+      register: (id, handler) => {
+        auxHandlersRef.current.set(id, handler);
+        return () => {
+          auxHandlersRef.current.delete(id);
+        };
+      },
+    }),
+    []
+  );
+
+  const dispatchAux = useCallback(
+    (
+      method: "onDragStart" | "onDragEnd" | "onDragCancel",
+      e: DragStartEvent | DragEndEvent | DragCancelEvent,
+      activeType: string | undefined
+    ) => {
+      if (!activeType) return false;
+      let handled = false;
+      for (const handler of auxHandlersRef.current.values()) {
+        if (!handler.matchTypes.has(activeType)) continue;
+        const fn = handler[method];
+        if (!fn) continue;
+        // Aux handlers are typed loosely above; the runtime guarantees the
+        // event shape matches the method we're calling.
+        (fn as (evt: typeof e) => void | Promise<void>)(e);
+        handled = true;
+      }
+      return handled;
+    },
+    []
+  );
+
   // ── Lifecycle handlers ───────────────────────────────────────────────────
 
-  const handleDragStart = useCallback((e: DragStartEvent) => {
-    const data = e.active.data?.current as
-      | {
-          type?: string;
-          event?: InternalCalendarEvent;
-          task?: { id: string; duration: number; title?: string };
-        }
-      | undefined;
-    if (!data?.type) return;
-    setActiveDrag({
-      id: String(e.active.id),
-      type: data.type,
-      event: data.event,
-      task: data.task,
-    });
-  }, []);
+  const handleDragStart = useCallback(
+    (e: DragStartEvent) => {
+      const data = e.active.data?.current as
+        | {
+            type?: string;
+            event?: InternalCalendarEvent;
+            task?: { id: string; duration: number; title?: string };
+          }
+        | undefined;
+      if (!data?.type) return;
+      setActiveDrag({
+        id: String(e.active.id),
+        type: data.type,
+        event: data.event,
+        task: data.task,
+      });
+      dispatchAux("onDragStart", e, data.type);
+    },
+    [dispatchAux]
+  );
 
-  const handleDragCancel = useCallback((_e: DragCancelEvent) => {
-    setActiveDrag(null);
-  }, []);
+  const handleDragCancel = useCallback(
+    (e: DragCancelEvent) => {
+      setActiveDrag(null);
+      const data = e.active?.data?.current as { type?: string } | undefined;
+      dispatchAux("onDragCancel", e, data?.type);
+    },
+    [dispatchAux]
+  );
 
   const handleDragEnd = useCallback(
     async (dragEvent: DragEndEvent) => {
       setActiveDrag(null);
 
       const { active, over, delta } = dragEvent;
-      if (!over) return;
 
       const activeData = active.data?.current as
         | {
@@ -183,10 +266,23 @@ export function CalendarDndShell({ children }: CalendarDndShellProps) {
             task?: { id: string; duration: number };
           }
         | undefined;
-      const overData = over.data?.current as
-        | { type?: string; day?: Date }
-        | undefined;
+      // Always dispatch to aux handlers first — they get the full event
+      // object (including null `over` so they can no-op cleanly) and may
+      // own the resolution for crew-event / unscheduled→crew-row /
+      // project-drawer→crew-row drops. The shell's own branches still run
+      // afterwards for any types the aux handler didn't claim (e.g. drops
+      // on month/week day cells, the unscheduled dock, etc.).
+      const auxHandled = dispatchAux("onDragEnd", dragEvent, activeData?.type);
+
+      if (!over) return;
       if (!activeData?.type) return;
+      const overData = over.data?.current as
+        | { type?: string; day?: Date; teamMemberId?: string }
+        | undefined;
+      // Crew-row drops are owned by the crew aux handler exclusively to
+      // avoid double-applying when both the shell and the aux handler
+      // recognize the type.
+      if (auxHandled && overData?.type === "crew-row") return;
 
       // Recurrence-aware dispatcher
       const dispatchUpdate = async (
@@ -410,29 +506,31 @@ export function CalendarDndShell({ children }: CalendarDndShellProps) {
   return (
     <DragStateContext.Provider value={dragState}>
       <CalendarResizeContext.Provider value={resizeApi}>
-        <DndContext
-          sensors={sensors}
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
-          onDragCancel={handleDragCancel}
-          autoScroll={{
-            // Tight edge zone (~5% of axis = ~40-60px on typical layouts).
-            // dnd-kit walks up to scrollable ancestors and scrolls them when
-            // the pointer enters the threshold band. Each scroll container
-            // toggles off scroll-snap during drag (see useCalendarDragState),
-            // which lets autoscroll move the viewport across panel boundaries
-            // without the snap engine yanking it back.
-            threshold: { x: 0.05, y: 0.05 },
-            acceleration: 12,
-          }}
-        >
-          {children}
-          <DragOverlay dropAnimation={null}>
-            {activeDrag?.event ? <DragPreview event={activeDrag.event} /> : null}
-          </DragOverlay>
-          {recurrencePrompt.promptElement}
-          {resize.promptElement}
-        </DndContext>
+        <CalendarDragBridgeContext.Provider value={dragBridge}>
+          <DndContext
+            sensors={sensors}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+            autoScroll={{
+              // Tight edge zone (~5% of axis = ~40-60px on typical layouts).
+              // dnd-kit walks up to scrollable ancestors and scrolls them when
+              // the pointer enters the threshold band. Each scroll container
+              // toggles off scroll-snap during drag (see useCalendarDragState),
+              // which lets autoscroll move the viewport across panel boundaries
+              // without the snap engine yanking it back.
+              threshold: { x: 0.05, y: 0.05 },
+              acceleration: 12,
+            }}
+          >
+            {children}
+            <DragOverlay dropAnimation={null}>
+              {activeDrag?.event ? <DragPreview event={activeDrag.event} /> : null}
+            </DragOverlay>
+            {recurrencePrompt.promptElement}
+            {resize.promptElement}
+          </DndContext>
+        </CalendarDragBridgeContext.Provider>
       </CalendarResizeContext.Provider>
     </DragStateContext.Provider>
   );

--- a/src/app/(dashboard)/calendar/_components/crew/crew-grid.tsx
+++ b/src/app/(dashboard)/calendar/_components/crew/crew-grid.tsx
@@ -3,13 +3,8 @@
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { toast } from "sonner";
 import { isToday, differenceInCalendarDays, getHours, getMinutes, format } from "date-fns";
-import {
-  DndContext,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  useDroppable,
-} from "@dnd-kit/core";
+import { useDroppable } from "@dnd-kit/core";
+import { useCalendarDragBridge } from "../calendar-dnd-shell";
 import type { ProjectTask, TeamMember } from "@/lib/types/models";
 import type { InternalCalendarEvent } from "@/lib/utils/calendar-utils";
 import { UserRole } from "@/lib/types/models";
@@ -252,10 +247,13 @@ export function CrewGrid({
   );
 
   // ── DnD ───────────────────────────────────────────────────────────────
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
-  );
+  //
+  // Crew used to mount its own <DndContext>; that broke cross-surface drags
+  // (the unscheduled tray's draggable was registered with the outer
+  // CalendarDndShell context and could not reach a nested context's
+  // droppables). Instead, use the outer CalendarDndShell context and route
+  // crew-specific drag types (`crew-event`, `unscheduled-task` →
+  // `crew-row`, `project-drawer-task` → `crew-row`) through the bridge.
 
   const { handleDragStart, handleDragEnd, handleDragCancel } = useCrewDnd({
     events,
@@ -264,6 +262,20 @@ export function CrewGrid({
     onRecurringEdit: handleRecurringEdit,
     tasksById,
   });
+
+  const dragBridge = useCalendarDragBridge();
+  useEffect(() => {
+    return dragBridge.register("crew-grid", {
+      matchTypes: new Set([
+        "crew-event",
+        "unscheduled-task",
+        "project-drawer-task",
+      ]),
+      onDragStart: handleDragStart,
+      onDragEnd: handleDragEnd,
+      onDragCancel: handleDragCancel,
+    });
+  }, [dragBridge, handleDragStart, handleDragEnd, handleDragCancel]);
 
   // ── Resize callback ───────────────────────────────────────────────────
 
@@ -340,12 +352,7 @@ export function CrewGrid({
   });
 
   return (
-    <DndContext
-      sensors={sensors}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-      onDragCancel={handleDragCancel}
-    >
+    <>
       <div className="flex flex-col h-full overflow-hidden relative">
         {/* Header row — day labels */}
         <CrewHeader startDate={startDate} daysShown={daysShown} />
@@ -437,6 +444,6 @@ export function CrewGrid({
 
       {/* Phase 3 — recurrence scope prompt for drag-rescheduled series tasks */}
       {recurrencePrompt.promptElement}
-    </DndContext>
+    </>
   );
 }

--- a/src/app/(dashboard)/calendar/_components/crew/crew-header.tsx
+++ b/src/app/(dashboard)/calendar/_components/crew/crew-header.tsx
@@ -58,7 +58,13 @@ export function CrewHeader({ startDate, daysShown }: CrewHeaderProps) {
                 // without horizontal overflow.
                 flex: "1 1 0%",
                 opacity: weekend ? 0.6 : 1,
-                background: today ? "rgba(111, 148, 176, 0.06)" : "transparent",
+                background: today
+                  ? "linear-gradient(rgba(111, 148, 176, 0.22), rgba(111, 148, 176, 0.22)), rgba(18, 18, 20, 0.78)"
+                  : "transparent",
+                backdropFilter: today ? "blur(28px) saturate(1.3)" : undefined,
+                WebkitBackdropFilter: today
+                  ? "blur(28px) saturate(1.3)"
+                  : undefined,
                 borderTop: today ? "2px solid var(--ops-accent)" : "2px solid transparent",
               }}
             >

--- a/src/app/(dashboard)/calendar/_components/crew/crew-row.tsx
+++ b/src/app/(dashboard)/calendar/_components/crew/crew-row.tsx
@@ -112,7 +112,13 @@ export function CrewRow({
                   idx < daysShown - 1
                     ? "1px solid rgba(255,255,255,0.05)"
                     : "none",
-                background: today ? "rgba(111, 148, 176, 0.06)" : "transparent",
+                background: today
+                  ? "linear-gradient(rgba(111, 148, 176, 0.22), rgba(111, 148, 176, 0.22)), rgba(18, 18, 20, 0.78)"
+                  : "transparent",
+                backdropFilter: today ? "blur(28px) saturate(1.3)" : undefined,
+                WebkitBackdropFilter: today
+                  ? "blur(28px) saturate(1.3)"
+                  : undefined,
               }}
             />
           );

--- a/src/app/(dashboard)/calendar/_components/crew/crew-task-block.tsx
+++ b/src/app/(dashboard)/calendar/_components/crew/crew-task-block.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { differenceInCalendarDays, addDays, format } from "date-fns";
 import { useDraggable } from "@dnd-kit/core";
-import type { InternalCalendarEvent } from "@/lib/utils/calendar-utils";
+import { type InternalCalendarEvent, frostedBadgeStyle } from "@/lib/utils/calendar-utils";
 import { CREW_ROW_HEIGHT } from "@/lib/utils/crew-constants";
 import { laneVerticalLayout } from "@/lib/utils/lane-assignment";
 import { EventHoverPopover } from "../event-hover-popover";
@@ -309,7 +309,7 @@ export function CrewTaskBlock({
       <div
         className="flex-1 relative flex items-center min-w-0"
         style={{
-          background: event.typeColors.bg,
+          ...frostedBadgeStyle(event.typeColors),
           border: `1px ${isGhost ? "dashed" : "solid"} ${event.typeColors.border}`,
           borderRadius: 4,
           paddingLeft: 11, // 8 (text) + 3 (stripe gutter)

--- a/src/app/(dashboard)/calendar/_components/day/day-hourly-grid.tsx
+++ b/src/app/(dashboard)/calendar/_components/day/day-hourly-grid.tsx
@@ -34,6 +34,7 @@ import {
   getEventHeight,
   resolveEventColumns,
   type InternalCalendarEvent,
+  frostedBadgeStyleFromBg,
 } from "@/lib/utils/calendar-utils";
 import { useTeamMembers } from "@/lib/hooks";
 import { UserAvatar } from "@/components/ops/user-avatar";
@@ -195,7 +196,7 @@ function TimedBlock({
               ? 0.85
               : 1,
         filter: highlightedByLegend ? "brightness(1.25)" : "none",
-        background: event.statusColors.bg,
+        ...frostedBadgeStyleFromBg(event.statusColors.bg),
         border: `1px solid ${event.statusColors.border}`,
         borderRadius: 4,
         zIndex: isDragging ? 30 : resize ? 20 : 5,
@@ -315,7 +316,7 @@ function AllDayStrip({
           className="px-[8px] py-[3px] rounded-[4px] font-mohave text-[12px] truncate"
           style={{
             maxWidth: 240,
-            background: event.statusColors.bg,
+            ...frostedBadgeStyleFromBg(event.statusColors.bg),
             border: `1px solid ${event.statusColors.border}`,
             color: "var(--text)",
           }}

--- a/src/app/(dashboard)/calendar/_components/day/day-task-card.tsx
+++ b/src/app/(dashboard)/calendar/_components/day/day-task-card.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useCallback, useState, useRef, useEffect } from "react";
 import { format, differenceInCalendarDays, addDays } from "date-fns";
 import { motion } from "framer-motion";
-import type { InternalCalendarEvent } from "@/lib/utils/calendar-utils";
+import { type InternalCalendarEvent, frostedBadgeStyle } from "@/lib/utils/calendar-utils";
 import { useCalendarStore } from "@/stores/calendar-store";
 import { useTeamMembers } from "@/lib/hooks";
 import { UserAvatar } from "@/components/ops/user-avatar";
@@ -442,7 +442,7 @@ export function DayTaskCard({
             right: 8,
             padding: "2px 6px",
             borderRadius: 2,
-            background: event.typeColors.bg,
+            ...frostedBadgeStyle(event.typeColors),
             border: `1px solid ${event.typeColors.border}`,
             color: event.typeColors.text,
             fontFamily: "var(--font-cakemono), sans-serif",

--- a/src/app/(dashboard)/calendar/_components/event-hover-popover.tsx
+++ b/src/app/(dashboard)/calendar/_components/event-hover-popover.tsx
@@ -5,7 +5,7 @@ import { format, formatDistanceToNowStrict } from "date-fns";
 import * as HoverCard from "@radix-ui/react-hover-card";
 import { useTeamMembers } from "@/lib/hooks";
 import { useProjectPreview } from "@/lib/hooks/use-project-preview";
-import type { InternalCalendarEvent } from "@/lib/utils/calendar-utils";
+import { type InternalCalendarEvent, frostedBadgeStyle } from "@/lib/utils/calendar-utils";
 
 // ─── Props ──────────────────────────────────────────────────────────────────
 
@@ -144,7 +144,7 @@ function PopoverBody({ event }: { event: InternalCalendarEvent }) {
           className="px-[6px] py-[2px] font-cakemono font-light uppercase"
           style={{
             color: event.typeColors.text,
-            background: event.typeColors.bg,
+            ...frostedBadgeStyle(event.typeColors),
             border: `1px solid ${event.typeColors.border}`,
             borderRadius: 4,
             fontSize: 10,

--- a/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
+++ b/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { format } from "date-fns";
-import { type InternalCalendarEvent } from "@/lib/utils/calendar-utils";
+import { type InternalCalendarEvent, frostedBadgeStyle } from "@/lib/utils/calendar-utils";
 import { useCalendarStore } from "@/stores/calendar-store";
 import { EventHoverPopover } from "../event-hover-popover";
 
@@ -307,7 +307,7 @@ export function MonthEventBar({
           className="cursor-pointer truncate relative"
           style={{
             height: 14,
-            background: event.typeColors.bg,
+            ...frostedBadgeStyle(event.typeColors),
             border: `1px solid ${event.typeColors.border}`,
             borderRadius,
             color: event.typeColors.text,
@@ -357,7 +357,7 @@ export function MonthEventBar({
           className="cursor-pointer truncate relative"
           style={{
             height: 14,
-            background: event.typeColors.bg,
+            ...frostedBadgeStyle(event.typeColors),
             border: `1px solid ${event.typeColors.border}`,
             borderRadius,
             color: event.typeColors.text,
@@ -415,7 +415,7 @@ export function MonthEventBar({
         className="cursor-pointer relative"
         style={{
           height: 42,
-          background: event.typeColors.bg,
+          ...frostedBadgeStyle(event.typeColors),
           border: `1px solid ${event.typeColors.border}`,
           borderRadius: "4px",
           color: event.typeColors.text,
@@ -481,7 +481,7 @@ export function MonthEventBar({
             className="px-[5px] py-[1px] font-cakemono font-light uppercase"
             style={{
               color: event.typeColors.text,
-              background: event.typeColors.bg,
+              ...frostedBadgeStyle(event.typeColors),
               border: `1px solid ${event.typeColors.border}`,
               borderRadius: 4,
               fontSize: 9,

--- a/src/app/(dashboard)/calendar/_components/month/month-scroll-container.tsx
+++ b/src/app/(dashboard)/calendar/_components/month/month-scroll-container.tsx
@@ -329,20 +329,33 @@ function MonthDayCell({
     data: { type: "month-day", day },
   });
 
+  // Spec v2: Today cell paints a brighter, frosted-glass-tinted primary
+  // accent fill. The 0.06-alpha tint barely registered against the canvas;
+  // 0.18 over the dense-glass base keeps it readable without bleeding.
+  const todayBg = isCurrentDay
+    ? {
+        background:
+          "linear-gradient(rgba(111, 148, 176, 0.22), rgba(111, 148, 176, 0.22)), rgba(18, 18, 20, 0.78)",
+        backdropFilter: "blur(28px) saturate(1.3)",
+        WebkitBackdropFilter: "blur(28px) saturate(1.3)",
+      }
+    : undefined;
+  const cellStyle: React.CSSProperties = {
+    borderRight: "1px solid rgba(255,255,255,0.10)",
+  };
+  if (isOver) {
+    cellStyle.backgroundColor = "rgba(111, 148, 176, 0.10)";
+  } else if (todayBg) {
+    Object.assign(cellStyle, todayBg);
+  } else if (isWeekend) {
+    cellStyle.backgroundColor = "rgba(255,255,255,0.02)";
+  }
+
   return (
     <div
       ref={setNodeRef}
       className="relative overflow-hidden group"
-      style={{
-        borderRight: "1px solid rgba(255,255,255,0.10)",
-        backgroundColor: isOver
-          ? "rgba(111, 148, 176, 0.10)"
-          : isCurrentDay
-            ? "rgba(111, 148, 176, 0.06)"
-            : isWeekend
-              ? "rgba(255,255,255,0.02)"
-              : undefined,
-      }}
+      style={cellStyle}
     >
       <div
         className="flex items-center"

--- a/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
+++ b/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { Search, ChevronRight, ChevronLeft, GripVertical } from "lucide-react";
-import { useDraggable } from "@dnd-kit/core";
+import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTasks } from "@/lib/hooks";
 import { TaskStatus, type ProjectTask } from "@/lib/types/models";
@@ -137,19 +137,35 @@ export function UnscheduledTray({ view }: UnscheduledTrayProps) {
   const dockSide: "left" | "right" = view === "day" ? "left" : "right";
   const count = allUnscheduled.length;
 
+  // Drop target — accepts existing calendar events (month/week/day-hourly/
+  // day-list) and unschedules them. Type `unscheduled-dock` is matched in
+  // CalendarDndShell's handleDragEnd to clear startDate / endDate.
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: "unscheduled-dock",
+    data: { type: "unscheduled-dock" },
+  });
+  const dropOutline = isOver
+    ? "1px dashed var(--ops-accent)"
+    : undefined;
+
   // ── Collapsed state ─────────────────────────────────────────────────────
 
   if (unscheduledTrayCollapsed) {
     return (
       <button
+        ref={setDropRef}
         type="button"
         onClick={toggleUnscheduledTray}
         className="shrink-0 h-full flex flex-col items-center justify-start gap-3 cursor-pointer group"
         style={{
           width: COLLAPSED_WIDTH,
-          background: "var(--glass-bg)",
-          borderLeft: dockSide === "right" ? "1px solid var(--line)" : "none",
-          borderRight: dockSide === "left" ? "1px solid var(--line)" : "none",
+          background: isOver ? "var(--surface-active)" : "var(--glass-bg)",
+          borderLeft:
+            dropOutline ??
+            (dockSide === "right" ? "1px solid var(--line)" : "none"),
+          borderRight:
+            dropOutline ??
+            (dockSide === "left" ? "1px solid var(--line)" : "none"),
           padding: "16px 0",
           transition: "background 0.15s cubic-bezier(0.22, 1, 0.36, 1)",
         }}
@@ -202,15 +218,21 @@ export function UnscheduledTray({ view }: UnscheduledTrayProps) {
 
   return (
     <motion.div
+      ref={setDropRef}
       initial={false}
       animate={{ width: EXPANDED_WIDTH }}
       transition={{ duration: 0.22, ease: EASE_SMOOTH }}
       className="shrink-0 h-full flex flex-col min-h-0"
       style={{
         width: EXPANDED_WIDTH,
-        background: "var(--glass-bg)",
-        borderLeft: dockSide === "right" ? "1px solid var(--line)" : "none",
-        borderRight: dockSide === "left" ? "1px solid var(--line)" : "none",
+        background: isOver ? "var(--surface-active)" : "var(--glass-bg)",
+        borderLeft:
+          dropOutline ??
+          (dockSide === "right" ? "1px solid var(--line)" : "none"),
+        borderRight:
+          dropOutline ??
+          (dockSide === "left" ? "1px solid var(--line)" : "none"),
+        transition: "background 0.15s cubic-bezier(0.22, 1, 0.36, 1)",
       }}
     >
       {/* Header row */}

--- a/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
+++ b/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
@@ -5,6 +5,7 @@ import { Search, ChevronRight, ChevronLeft, GripVertical } from "lucide-react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTasks } from "@/lib/hooks";
+import { useClients } from "@/lib/hooks/use-clients";
 import { TaskStatus, type ProjectTask } from "@/lib/types/models";
 import {
   useCalendarStore,
@@ -51,6 +52,17 @@ export function UnscheduledTray({ view }: UnscheduledTrayProps) {
   } = useCalendarStore();
 
   const { data: taskData } = useTasks();
+  // Group-by-client needs client.name; the cached project on each task only
+  // carries clientId. Pull the company's clients list once and resolve
+  // each task's client via the project → client foreign key.
+  const { data: clientsData } = useClients();
+  const clientNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of clientsData?.clients ?? []) {
+      if (c.id && c.name) map.set(c.id, c.name);
+    }
+    return map;
+  }, [clientsData]);
 
   // Tasks: unscheduled, not completed/cancelled, not deleted
   const allUnscheduled = useMemo(() => {
@@ -111,10 +123,15 @@ export function UnscheduledTray({ view }: UnscheduledTrayProps) {
       switch (unscheduledTrayGroupBy) {
         case "project":
           return t.project?.title ?? "// NO PROJECT";
-        case "client":
-          // ProjectTask doesn't expose client directly; project carries clientId.
-          // Without joining, fall back to project title (best available proxy).
-          return t.project?.title ?? "// NO CLIENT";
+        case "client": {
+          // Resolve client name via project.clientId -> clients list. The
+          // previous fallback (project.title) collapsed every project for
+          // the same client into separate groups labeled by project — the
+          // user's bug report said "not showing client names for groups".
+          const clientId = t.project?.clientId ?? null;
+          if (!clientId) return "// NO CLIENT";
+          return clientNameById.get(clientId) ?? "// NO CLIENT";
+        }
         case "type":
           return t.taskType?.display?.toUpperCase() ?? "// NO TYPE";
       }

--- a/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
+++ b/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
@@ -134,7 +134,13 @@ export function UnscheduledTray({ view }: UnscheduledTrayProps) {
     }));
   }, [sorted, unscheduledTrayGroupBy]);
 
-  const dockSide: "left" | "right" = view === "day" ? "left" : "right";
+  // Spec v2 — tray always docks on the right edge, regardless of the
+  // active view. The prior view-dependent split (left in Day, right
+  // everywhere else) was visually disorienting. `view` is still consumed
+  // upstream so we keep it on the prop.
+  void view;
+  type DockSide = "left" | "right";
+  const dockSide = "right" as DockSide;
   const count = allUnscheduled.length;
 
   // Drop target — accepts existing calendar events (month/week/day-hourly/

--- a/src/app/(dashboard)/calendar/_components/week/week-day-column.tsx
+++ b/src/app/(dashboard)/calendar/_components/week/week-day-column.tsx
@@ -95,11 +95,16 @@ export function WeekDayColumn({ day, events, onCardResize }: WeekDayColumnProps)
         // card titles inflate the column and bleed across siblings.
         flex: "1 1 0%",
         opacity: weekend ? 0.85 : 1,
+        // Today column: spec v2 "frosted-glass tinted primary accent" — bright
+        // enough to read against the canvas without bleeding behind events.
         background: isOver
           ? "rgba(111, 148, 176, 0.10)"
           : today
-            ? "rgba(111, 148, 176, 0.06)"
+            ? "linear-gradient(rgba(111, 148, 176, 0.22), rgba(111, 148, 176, 0.22)), rgba(18, 18, 20, 0.78)"
             : "transparent",
+        backdropFilter: today && !isOver ? "blur(28px) saturate(1.3)" : undefined,
+        WebkitBackdropFilter:
+          today && !isOver ? "blur(28px) saturate(1.3)" : undefined,
         borderRight: "1px solid var(--line)",
         // Today column: 2px accent top border (T14 — today indicator signal #2)
         borderTop: today ? "2px solid var(--ops-accent)" : "2px solid transparent",

--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -272,8 +272,10 @@ export default function CalendarPage() {
         {/* Filter sidebar (left) — hidden on mobile */}
         {!isMobile && <FilterSidebar />}
 
-        {/* Day view: tray docks LEFT (mirrors Jobber/Housecall) */}
-        {!isMobile && view === "day" && <UnscheduledTray view={view} />}
+        {/* Tray now docks RIGHT in every view (was left for Day, right
+            for Week/Month/Crew — visually disorienting when switching
+            views per the user's bug report). The single placement below
+            handles all views including Day. */}
 
         {/* Main calendar grid */}
         <div className="flex-1 flex flex-col min-h-0 min-w-0 relative">
@@ -369,8 +371,8 @@ export default function CalendarPage() {
           )}
         </div>
 
-        {/* Week / Month / Crew view: tray docks RIGHT */}
-        {!isMobile && view !== "day" && <UnscheduledTray view={view} />}
+        {/* Tray dock — RIGHT in every view */}
+        {!isMobile && <UnscheduledTray view={view} />}
 
       </div>
 

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -57,6 +57,7 @@ import { ProjectSpreadsheet } from "./_components/project-spreadsheet";
 import { useProjectDetailPopoverStore } from "./_components/project-detail-popover-store";
 import { useSetupGate } from "@/hooks/useSetupGate";
 import { SetupInterceptionModal } from "@/components/setup/SetupInterceptionModal";
+import { useWindowStore } from "@/stores/window-store";
 
 // ── Active statuses for the canvas columns ──
 const ACTIVE_STATUSES: ProjectStatus[] = [
@@ -546,10 +547,27 @@ export default function ProjectsPage() {
     [projectMap, openPopover]
   );
 
-  const handleAddTask = useCallback((_projectId: string) => {
-    // TODO: Open task creation form — integrate with existing window system
-    toast.info("Task creation coming soon");
-  }, []);
+  const handleAddTask = useCallback(
+    (projectId: string) => {
+      const project = projectMap.get(projectId);
+      const titleSuffix = project?.title
+        ? ` — ${project.title}`
+        : project?.address
+          ? ` — ${project.address.split(",")[0]}`
+          : "";
+      // Open the floating create-task window with the project preselected. A
+      // per-project window id keeps multiple "Add task" clicks from stacking
+      // duplicate windows for the same project; clicking the same project's
+      // Add task again restores the existing window.
+      useWindowStore.getState().openWindow({
+        id: `create-task:${projectId}`,
+        title: `New Task${titleSuffix}`,
+        type: "create-task",
+        metadata: { projectId },
+      });
+    },
+    [projectMap]
+  );
 
   const handleRecordPayment = useCallback((_projectId: string) => {
     // TODO: Open payment recording form

--- a/src/components/brand/logo-loader.tsx
+++ b/src/components/brand/logo-loader.tsx
@@ -70,27 +70,65 @@ export const LogoLoader: React.FC<LogoLoaderProps> = ({
   if (color) params.set("chevronColor", color);
   const src = `/v2-loader/index.html?${params.toString()}`;
 
+  // Track iframe readiness — Babel + React CDN bootstraps inside the iframe
+  // can take 1-2s before LogoLoaderScene mounts. Until `onLoad` fires we
+  // paint the static lockup behind the iframe so the slot is never blank
+  // (the original bug — blank area while the iframe was loading or when its
+  // CDN scripts were blocked / failed silently).
+  const [iframeReady, setIframeReady] = React.useState(false);
+
   return (
     <div
-      className={cn("inline-flex items-center justify-center", className)}
+      className={cn("relative inline-flex items-center justify-center", className)}
       style={{ width: size, height: size }}
     >
+      {/* Static fallback skeleton — visible until the iframe reports load.
+          Mirrors the reduced-motion path so users see the brand even before
+          the animated mark boots. */}
+      <motion.span
+        aria-hidden="true"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: iframeReady ? 0 : 1 }}
+        transition={{ duration: 0.3, ease: EASE_SMOOTH }}
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: color ?? "#EDEDED",
+          pointerEvents: "none",
+        }}
+      >
+        <OpsLockup
+          orientation="horizontal"
+          title=""
+          style={{ height: "1em", width: "auto", color: "currentColor" }}
+        />
+      </motion.span>
       <iframe
         src={src}
         title="OPS"
+        onLoad={() => setIframeReady(true)}
         style={{
           width: "100%",
           height: "100%",
           border: 0,
           background: "transparent",
+          position: "relative",
         }}
         // Sandbox: allow-scripts to run React/Babel, allow-same-origin so
         // Babel can fetch the .jsx source files from /v2-loader/. Without
         // allow-same-origin the inline `<script type="text/babel" src=...>`
         // tags fail silently and the iframe renders blank.
         sandbox="allow-scripts allow-same-origin"
-        // Don't gate page LCP on this — it's a loading affordance.
-        loading="lazy"
+        // The iframe IS the loading affordance — do NOT lazy-load. Lazy
+        // mode delays src fetch until the iframe enters the viewport, which
+        // for a centered loading screen means it never renders the loop
+        // until the user scrolls. (Loading-screen containers have no scroll
+        // and the iframe was already in view, but Safari occasionally read
+        // the lazy hint as "defer indefinitely" in this configuration —
+        // dropping the hint guarantees an immediate fetch.)
       />
     </div>
   );

--- a/src/components/brand/logo-loader.tsx
+++ b/src/components/brand/logo-loader.tsx
@@ -42,6 +42,16 @@ export const LogoLoader: React.FC<LogoLoaderProps> = ({
 }) => {
   const reduced = useReducedMotion();
 
+  // Track iframe readiness — Babel + React CDN bootstraps inside the iframe
+  // can take 1-2s before LogoLoaderScene mounts. Until `onLoad` fires we
+  // paint the static lockup behind the iframe so the slot is never blank
+  // (the original bug — blank area while the iframe was loading or when its
+  // CDN scripts were blocked / failed silently).
+  //
+  // Hook must be called unconditionally — declared above the reduced-motion
+  // early return per React rules-of-hooks. Unused on the reduced path.
+  const [iframeReady, setIframeReady] = React.useState(false);
+
   if (reduced) {
     return (
       <div
@@ -69,13 +79,6 @@ export const LogoLoader: React.FC<LogoLoaderProps> = ({
   const params = new URLSearchParams({ mode });
   if (color) params.set("chevronColor", color);
   const src = `/v2-loader/index.html?${params.toString()}`;
-
-  // Track iframe readiness — Babel + React CDN bootstraps inside the iframe
-  // can take 1-2s before LogoLoaderScene mounts. Until `onLoad` fires we
-  // paint the static lockup behind the iframe so the slot is never blank
-  // (the original bug — blank area while the iframe was loading or when its
-  // CDN scripts were blocked / failed silently).
-  const [iframeReady, setIframeReady] = React.useState(false);
 
   return (
     <div

--- a/src/components/layouts/dashboard-layout.tsx
+++ b/src/components/layouts/dashboard-layout.tsx
@@ -122,6 +122,11 @@ function FloatingWindows() {
             <CreateTaskForm
               onSuccess={() => closeWindow(win.id)}
               onCancel={() => closeWindow(win.id)}
+              initialProjectId={
+                typeof win.metadata?.projectId === "string"
+                  ? win.metadata.projectId
+                  : null
+              }
             />
           )}
           {win.type === "create-estimate" && (

--- a/src/components/ops/command-palette.tsx
+++ b/src/components/ops/command-palette.tsx
@@ -472,7 +472,12 @@ export function CommandPalette() {
                 {entityResults.projects.map((p) => (
                   <CommandItem
                     key={`project-${p.id}`}
-                    value={`project-${p.id} ${p.title}`}
+                    // cmdk scores on `value`. Including the UUID prefix
+                    // collapsed scores to 0 for matches mid-string, so the
+                    // item rendered hidden even with forceMount. Use only the
+                    // user-meaningful searchable text; cmdk dedupes by ref so
+                    // duplicate titles still render distinctly via React key.
+                    value={`project ${p.title} ${p.address ?? ""}`}
                     onSelect={() => navigate(`/projects/${p.id}`)}
                     forceMount
                   >
@@ -492,7 +497,7 @@ export function CommandPalette() {
                 {entityResults.clients.map((c) => (
                   <CommandItem
                     key={`client-${c.id}`}
-                    value={`client-${c.id} ${c.name}`}
+                    value={`client ${c.name} ${c.email ?? ""}`}
                     onSelect={() => navigate(`/clients/${c.id}`)}
                     forceMount
                   >
@@ -512,7 +517,7 @@ export function CommandPalette() {
                 {entityResults.tasks.map((t) => (
                   <CommandItem
                     key={`task-${t.id}`}
-                    value={`task-${t.id} ${t.customTitle ?? ""}`}
+                    value={`task ${t.customTitle ?? ""} ${t.taskNotes ?? ""}`}
                     onSelect={() => navigate(`/projects/${t.projectId}`)}
                     forceMount
                   >

--- a/src/components/ops/create-task-modal.tsx
+++ b/src/components/ops/create-task-modal.tsx
@@ -174,13 +174,19 @@ function ProjectSelector({
 interface CreateTaskFormProps {
   onSuccess?: () => void;
   onCancel?: () => void;
+  /**
+   * Pre-select a project (e.g. when launched from the Projects spreadsheet's
+   * "Add task" button or the project detail Tasks tab). The project picker
+   * still renders so the user can change selection if needed.
+   */
+  initialProjectId?: string | null;
 }
 
-export function CreateTaskForm({ onSuccess, onCancel }: CreateTaskFormProps) {
+export function CreateTaskForm({ onSuccess, onCancel, initialProjectId }: CreateTaskFormProps) {
   const { company } = useAuthStore();
   const companyId = company?.id ?? "";
 
-  const [projectId, setProjectId] = useState<string | null>(null);
+  const [projectId, setProjectId] = useState<string | null>(initialProjectId ?? null);
   const [showCreateProject, setShowCreateProject] = useState(false);
 
   const { data: taskTypes } = useTaskTypes();

--- a/src/lib/hooks/use-crew-dnd.ts
+++ b/src/lib/hooks/use-crew-dnd.ts
@@ -224,6 +224,14 @@ export function useCrewDnd({
       const dayColumnWidth = gridWidth > 0 ? gridWidth / daysShown : 0;
 
       // ── Handle unscheduled-task drops ─────────────────────────────────
+      // The dragged task already exists (it lives in the unscheduled tray
+      // because its start_date / end_date are null). The original code
+      // called `createMutation` here, which produced a *duplicate* task —
+      // the original would still appear in the tray and a brand new task
+      // would land on the calendar with default fields and no project
+      // history. Drop semantics per the bug report: assign the dropped
+      // crew row's team member, schedule for the day under the cursor,
+      // preserve duration. Update — never create.
       if (
         activeData?.type === "unscheduled-task" &&
         activeData.task &&
@@ -235,10 +243,11 @@ export function useCrewDnd({
         // Calculate target day from horizontal drop offset
         const dayDelta = dayColumnWidth > 0 ? Math.round(delta.x / dayColumnWidth) : 0;
         const targetDate = addDays(startDate, Math.max(0, Math.min(dayDelta, daysShown - 1)));
-        const targetEndDate = addDays(targetDate, 1); // Default 1-day duration
+        const durationDays = Math.max(task.duration ?? 1, 1);
+        const targetEndDate = addDays(targetDate, durationDays);
 
         // Smart insert: check if dropping between existing events
-        if (overData.teamMemberId) {
+        if (overData.teamMemberId && overData.teamMemberId !== "__unassigned__") {
           const insertPoint = detectInsertPoint(
             task.id,
             overData.teamMemberId,
@@ -250,7 +259,7 @@ export function useCrewDnd({
 
           if (insertPoint && insertPoint.after) {
             const pushOffsets = calculatePushOffsets(
-              1, // Default 1-day duration for new tasks
+              durationDays,
               insertPoint.before,
               insertPoint.after,
               events,
@@ -267,17 +276,22 @@ export function useCrewDnd({
           }
         }
 
-        createMutation.mutate({
-          customTitle: task.customTitle || task.taskType?.display || "Untitled Task",
-          projectId: task.projectId,
-          companyId: company.id,
-          taskTypeId: task.taskTypeId || task.taskType?.id || "",
-          startDate: targetDate,
-          endDate: targetEndDate,
-          taskColor: task.taskColor || "#59779F",
-          teamMemberIds: overData.teamMemberId
+        // Resolve the team member set for the assignment patch. Dropping
+        // on the placeholder "Unassigned" row leaves teamMemberIds empty
+        // (so the task moves out of the tray onto the unassigned strip);
+        // dropping on a member row replaces any prior assignment.
+        const newTeamMemberIds =
+          overData.teamMemberId && overData.teamMemberId !== "__unassigned__"
             ? [overData.teamMemberId]
-            : task.teamMemberIds,
+            : [];
+
+        updateMutation.mutate({
+          id: task.id,
+          data: {
+            startDate: targetDate,
+            endDate: targetEndDate,
+            teamMemberIds: newTeamMemberIds,
+          },
         });
         return;
       }

--- a/src/lib/hooks/use-tasks.ts
+++ b/src/lib/hooks/use-tasks.ts
@@ -246,9 +246,15 @@ export function useUpdateTask() {
     }) => TaskService.updateTask(id, data),
 
     onMutate: async ({ id, data }) => {
-      await queryClient.cancelQueries({
-        queryKey: queryKeys.tasks.detail(id),
-      });
+      // Cancel ongoing fetches against any cache that contains this task —
+      // detail, list, project tasks, AND the calendar scheduled-range
+      // queries — so a refetch landing mid-mutation can't overwrite our
+      // optimistic snapshot.
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: queryKeys.tasks.detail(id) }),
+        queryClient.cancelQueries({ queryKey: queryKeys.tasks.lists() }),
+        queryClient.cancelQueries({ queryKey: queryKeys.calendar.all }),
+      ]);
 
       const previousTask = queryClient.getQueryData<ProjectTask>(
         queryKeys.tasks.detail(id)
@@ -261,7 +267,58 @@ export function useUpdateTask() {
         });
       }
 
-      return { previousTask };
+      // Snapshot of every list/calendar query that contains this task's row
+      // so onError can restore them. Each entry maps the queryKey to the
+      // previous value; we update in place.
+      const previousLists: Array<{
+        queryKey: readonly unknown[];
+        data: unknown;
+      }> = [];
+
+      const patchTaskInList = (
+        list: ProjectTask[] | undefined
+      ): ProjectTask[] | undefined => {
+        if (!list) return list;
+        let mutated = false;
+        const next = list.map((t) => {
+          if (t.id !== id) return t;
+          mutated = true;
+          return { ...t, ...data };
+        });
+        return mutated ? next : list;
+      };
+
+      // tasks.list / tasks.projectTasks are stored as
+      // `{ tasks: ProjectTask[]; remaining: number; count: number }`.
+      const taskListQueries = queryClient.getQueriesData<{
+        tasks: ProjectTask[];
+        remaining: number;
+        count: number;
+      }>({ queryKey: queryKeys.tasks.lists() });
+      for (const [queryKey, value] of taskListQueries) {
+        if (!value) continue;
+        const nextTasks = patchTaskInList(value.tasks);
+        if (nextTasks === value.tasks) continue;
+        previousLists.push({ queryKey, data: value });
+        queryClient.setQueryData(queryKey, { ...value, tasks: nextTasks });
+      }
+
+      // calendar.scheduled is stored as a flat ProjectTask[]. Spread fix
+      // here — without it, the calendar grid keeps painting the badge in
+      // the source cell until refetch returns and jumps it to the new
+      // cell, producing the "jumps back, then jumps forward" glitch.
+      const calendarQueries = queryClient.getQueriesData<ProjectTask[]>({
+        queryKey: queryKeys.calendar.all,
+      });
+      for (const [queryKey, value] of calendarQueries) {
+        if (!Array.isArray(value)) continue;
+        const next = patchTaskInList(value);
+        if (next === value) continue;
+        previousLists.push({ queryKey, data: value });
+        queryClient.setQueryData(queryKey, next);
+      }
+
+      return { previousTask, previousLists };
     },
 
     onError: (_err, { id }, context) => {
@@ -270,6 +327,11 @@ export function useUpdateTask() {
           queryKeys.tasks.detail(id),
           context.previousTask
         );
+      }
+      if (context?.previousLists) {
+        for (const { queryKey, data } of context.previousLists) {
+          queryClient.setQueryData(queryKey, data);
+        }
       }
     },
 

--- a/src/lib/utils/calendar-utils.ts
+++ b/src/lib/utils/calendar-utils.ts
@@ -154,6 +154,52 @@ export function colorTripleFromHex(hex: string | null | undefined): TaskTypeColo
   };
 }
 
+// ─── Frosted Badge Style ────────────────────────────────────────────────────
+
+/**
+ * Spec v2: Calendar event badges/bars use a frosted-glass-tinted fill so the
+ * content behind them never bleeds through and hurts legibility. Layered
+ * background = type tint over a glass-dense (`rgba(18,18,20,0.78)`) base, plus
+ * `backdrop-filter: blur(28px) saturate(1.3)` matching the global glass-dense
+ * surface from `.interface-design/system.md`.
+ *
+ * Use this helper everywhere a calendar event chip/bar/card paints its body
+ * fill so the frosted treatment stays consistent across Day, Week, Month,
+ * Crew and the hover popover.
+ */
+export function frostedBadgeStyle(
+  typeColors: TaskTypeColors,
+  baseAlpha: number = 0.78
+): {
+  background: string;
+  backdropFilter: string;
+  WebkitBackdropFilter: string;
+} {
+  return frostedBadgeStyleFromBg(typeColors.bg, baseAlpha);
+}
+
+/**
+ * Same frosted-glass treatment as `frostedBadgeStyle` but accepts an arbitrary
+ * tint color (e.g. status-driven fills used by the Day hourly grid). Stacks
+ * the tint over `rgba(18, 18, 20, baseAlpha)` and applies the standard
+ * 28px blur / 1.3 saturation backdrop-filter.
+ */
+export function frostedBadgeStyleFromBg(
+  tint: string,
+  baseAlpha: number = 0.78
+): {
+  background: string;
+  backdropFilter: string;
+  WebkitBackdropFilter: string;
+} {
+  const base = `rgba(18, 18, 20, ${baseAlpha})`;
+  return {
+    background: `linear-gradient(${tint}, ${tint}), ${base}`,
+    backdropFilter: "blur(28px) saturate(1.3)",
+    WebkitBackdropFilter: "blur(28px) saturate(1.3)",
+  };
+}
+
 // ─── Status Derivation ──────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Nightly batch fix sweep — 10/10 bug reports landed on this branch. All fixes type-check and build clean. Each commit is a single-bug fix with the bug short-id in the subject; full root-cause + edge-case notes are on each `bug_reports` row in the triage DB.

## Bugs fixed

- [ ] **bug-7424ea4f** `bug_reports` — Calendar event badges paint over a busy canvas with frosted-glass-tinted fill; added `frostedBadgeStyle()` helper, applied across Month/Day/Week/Crew bars and the hover popover, and updated `.interface-design/system.md` with the canonical recipe.
- [ ] **bug-cc515384** `bug_reports` — Unscheduled tray is now a dnd-kit droppable; dropping a calendar event on the tray clears `startDate`/`endDate`/`startTime`/`endTime` (recurrence-aware).
- [ ] **bug-a561f726** `bug_reports` — Today cell now uses the same frosted-glass tinted accent (22% alpha over dense glass + backdrop blur) in Month, Week, Crew row, and Crew header — no more invisible 0.06 alpha.
- [ ] **bug-ab3ace6e** `bug_reports` — Universal search palette projects/clients/tasks rows had `value` strings prefixed with the entity UUID, which dropped the cmdk match score below the visibility threshold; switched to user-meaningful searchable text only.
- [ ] **bug-c971a658** `bug_reports` — `/projects` `Add task` was a `toast.info("coming soon")` stub; wired it to `useWindowStore.openWindow({ type: 'create-task', metadata: { projectId } })` and threaded `initialProjectId` through `<CreateTaskForm>`.
- [ ] **bug-1f76cbac** `bug_reports` — Logo loader iframe rendered blank while React+Babel CDN bootstrapped; layered the static `OpsLockup` behind the iframe and fade it out on `iframe.onLoad`. Removed `loading="lazy"` to guarantee an immediate fetch.
- [ ] **bug-1b2942d5** `bug_reports` `[COMPLEX]` — CrewGrid mounted its own nested `<DndContext>` so the unscheduled-tray drag never reached crew rows; introduced `CalendarDragBridgeContext` so descendants register aux handlers, removed the inner DndContext, and switched the unscheduled-task → crew-row branch in `useCrewDnd` from `createMutation` (which produced a duplicate task) to `updateMutation` that sets startDate/endDate/teamMemberIds.
- [ ] **bug-5c267a5e** `bug_reports` — `useUpdateTask`'s `onMutate` updated only the single-task detail cache; calendar/list caches stayed stale until refetch, which is what produced the "badge jumps back, then jumps forward" glitch. Extended `onMutate` to patch every cached `tasks.list`, `tasks.projectTasks`, and `calendar.scheduled` query in place, with full rollback on error.
- [ ] **bug-8620c037** `bug_reports` — Unscheduled tray now docks on the right in every view (was left in Day, right in Week/Month/Crew).
- [ ] **bug-e06445fe** `bug_reports` — Unscheduled tray's Group: Client option resolves the actual client name via `useClients()` and a `clientId -> name` lookup, instead of falling back to `project.title`.

## Test plan

- [ ] Open `/calendar` in any view — calendar event chips/bars/badges render with the new frosted-glass tinted fill; today cell reads as a clear primary-accent highlight without bleeding.
- [ ] Drag a Month event onto the unscheduled rail (left or right collapse state) — event disappears from the calendar and shows up in the tray.
- [ ] Drag an unscheduled task into Crew view onto Jake's row, drop on Wednesday — task gets assigned to Jake and scheduled for Wednesday; the source row in the tray is removed (no duplicate created).
- [ ] Drag any event to a new day — badge stays at the drop target through the server round-trip; no flash to original cell.
- [ ] Switch between Day, Week, Month, Crew — unscheduled tray stays docked on the right in every view.
- [ ] Open `/calendar`, switch the tray's Group dropdown to "Client" — group headings show client names (not project titles).
- [ ] Topbar search → type a project / client / task name — the entity row appears under the matching group.
- [ ] `/projects` spreadsheet → click `Add task` on any row — the create-task floating window opens with that project preselected.
- [ ] `/projects/{id}` (or any first-paint dashboard route while data loads) — logo loader area is never blank; static `OpsLockup` shows immediately, animated chevron fades in once the iframe is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)