### PR TITLE
Nightly Bug Sweep — web — 2026-04-30 — Batch 02

### DIFF
--- a/src/app/(dashboard)/calendar/_components/calendar-dnd-shell.tsx
+++ b/src/app/(dashboard)/calendar/_components/calendar-dnd-shell.tsx
@@ -327,11 +327,16 @@ export function CalendarDndShell({ children }: CalendarDndShellProps) {
       }
 
       // ── Schedule from unscheduled tray ───────────────────────────────
+      // duration is the inclusive day count (1 = single calendar day,
+      // 2 = two consecutive days, etc). Calendar surfaces treat
+      // endDate === startDate as single-day, so endDate must land
+      // (duration - 1) days after the start, never duration. The earlier
+      // formula scheduled a 1-day task as a 2-day span (May 7 → May 8).
       if (activeData.type === "unscheduled-task" && activeData.task) {
         const task = activeData.task;
         const duration = Math.max(task.duration ?? 1, 1);
         const newStart = targetDay;
-        const newEnd = addDays(newStart, duration);
+        const newEnd = addDays(newStart, Math.max(duration - 1, 0));
         updateTask.mutate(
           { id: task.id, data: { startDate: newStart, endDate: newEnd } },
           {
@@ -349,7 +354,7 @@ export function CalendarDndShell({ children }: CalendarDndShellProps) {
         const task = activeData.task;
         const duration = Math.max(task.duration ?? 1, 1);
         const newStart = targetDay;
-        const newEnd = addDays(newStart, duration);
+        const newEnd = addDays(newStart, Math.max(duration - 1, 0));
         updateTask.mutate(
           { id: task.id, data: { startDate: newStart, endDate: newEnd } },
           {

--- a/src/app/(dashboard)/calendar/_components/calendar-toolbar.tsx
+++ b/src/app/(dashboard)/calendar/_components/calendar-toolbar.tsx
@@ -6,7 +6,7 @@ import {
   type InternalCalendarEvent,
 } from "@/lib/utils/calendar-utils";
 import { useCalendarStore } from "@/stores/calendar-store";
-import { useTasks } from "@/lib/hooks";
+import { useTasks, useTeamMembers } from "@/lib/hooks";
 import { TaskStatus } from "@/lib/types/models";
 import { ChevronDown, X } from "lucide-react";
 
@@ -25,11 +25,16 @@ export function CalendarToolbar({ events, t }: CalendarToolbarProps) {
     unscheduledTrayCollapsed,
     toggleUnscheduledTray,
     setHighlightedTaskType,
+    setHighlightedTeamMemberId,
   } = useCalendarStore();
 
   // Legend dropdown — collapsed by default. Click summary chip to expand.
   const [legendOpen, setLegendOpen] = useState(false);
   const legendWrapRef = useRef<HTMLDivElement | null>(null);
+
+  // Team-member dropdown — same interaction pattern as legend.
+  const [teamOpen, setTeamOpen] = useState(false);
+  const teamWrapRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!legendOpen) {
@@ -48,8 +53,61 @@ export function CalendarToolbar({ events, t }: CalendarToolbarProps) {
     return () => document.removeEventListener("mousedown", onDown);
   }, [legendOpen, setHighlightedTaskType]);
 
+  useEffect(() => {
+    if (!teamOpen) {
+      setHighlightedTeamMemberId(null);
+      return;
+    }
+    const onDown = (e: MouseEvent) => {
+      if (
+        teamWrapRef.current &&
+        !teamWrapRef.current.contains(e.target as Node)
+      ) {
+        setTeamOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [teamOpen, setHighlightedTeamMemberId]);
+
   // Unscheduled count for the toolbar chip (T15)
   const { data: taskData } = useTasks();
+  const { data: teamData } = useTeamMembers();
+  const teamMembers = useMemo(() => teamData?.users ?? [], [teamData]);
+
+  // Per-member event counts (use crewIds from each event so it tracks
+  // multi-assignee tasks; unassigned events naturally fall out).
+  const memberEventCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const e of events) {
+      for (const id of e.crewIds) {
+        counts[id] = (counts[id] ?? 0) + 1;
+      }
+    }
+    return counts;
+  }, [events]);
+
+  // Helper — toggle a member id in the persisted filter list.
+  function toggleMemberFilter(id: string) {
+    const current = filterTeamMemberIds;
+    updateFilters({
+      filterTeamMemberIds: current.includes(id)
+        ? current.filter((x) => x !== id)
+        : [...current, id],
+    });
+  }
+
+  // Helper — toggle a task type in the persisted filter list. Mirrors
+  // FilterSidebar.toggleTaskType so legend click and sidebar checkbox
+  // are kept in sync.
+  function toggleTypeFilter(typeLabel: string) {
+    const current = filterTaskTypes;
+    updateFilters({
+      filterTaskTypes: current.includes(typeLabel)
+        ? current.filter((x) => x !== typeLabel)
+        : [...current, typeLabel],
+    });
+  }
   const unscheduledCount = useMemo(() => {
     const all = taskData?.tasks ?? [];
     return all.filter(
@@ -72,12 +130,17 @@ export function CalendarToolbar({ events, t }: CalendarToolbarProps) {
 
     // Group by real type display ('Vinyl Install', 'Rail Install', etc.) and
     // remember the first effective color we see for each so the legend dot
-    // matches the actual card stripe.
-    const typeStats: Record<string, { count: number; color: string }> = {};
+    // matches the actual card stripe. Also track the underlying taskType key
+    // (e.g. 'installation') so legend clicks can toggle the persisted
+    // filterTaskTypes — which filters on key, not display label.
+    const typeStats: Record<
+      string,
+      { count: number; color: string; key: string }
+    > = {};
     events.forEach((e) => {
       const label = e.typeLabel || "Task";
       if (!typeStats[label]) {
-        typeStats[label] = { count: 0, color: e.color };
+        typeStats[label] = { count: 0, color: e.color, key: e.taskType };
       }
       typeStats[label].count += 1;
     });
@@ -187,10 +250,160 @@ export function CalendarToolbar({ events, t }: CalendarToolbarProps) {
         </div>
       )}
 
+      {/* Team-member dropdown — same interaction pattern as legend.
+          Hover row → dim every non-matching card. Click row → toggle
+          the persisted team-member filter. */}
+      <div ref={teamWrapRef} className="hidden md:block ml-auto relative">
+        <button
+          type="button"
+          onClick={() => setTeamOpen((v) => !v)}
+          aria-expanded={teamOpen}
+          aria-haspopup="true"
+          className="flex items-center gap-[6px] px-2 py-1 cursor-pointer font-mono text-[11px] uppercase tracking-wider tabular-nums"
+          style={{
+            color: teamOpen ? "var(--text)" : "var(--text-2)",
+            background: teamOpen
+              ? "rgba(255, 255, 255, 0.08)"
+              : "rgba(255, 255, 255, 0.04)",
+            border: "1px solid var(--line)",
+            borderRadius: 4,
+            fontFeatureSettings: '"tnum" 1, "zero" 1',
+            transition: "background 0.15s cubic-bezier(0.22, 1, 0.36, 1)",
+          }}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLElement).style.background =
+              "rgba(255, 255, 255, 0.08)";
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLElement).style.background = teamOpen
+              ? "rgba(255, 255, 255, 0.08)"
+              : "rgba(255, 255, 255, 0.04)";
+          }}
+        >
+          <span style={{ color: "var(--text-mute)" }}>{"// TEAM"}</span>
+          <span>{`[${teamMembers.length}]`}</span>
+          {filterTeamMemberIds.length > 0 && (
+            <span style={{ color: "var(--ops-accent)" }}>
+              {`(${filterTeamMemberIds.length})`}
+            </span>
+          )}
+          <ChevronDown
+            className="w-[10px] h-[10px]"
+            style={{
+              transform: teamOpen ? "rotate(180deg)" : "rotate(0deg)",
+              transition: "transform 0.15s cubic-bezier(0.22, 1, 0.36, 1)",
+            }}
+          />
+        </button>
+
+        {teamOpen && (
+          <div
+            className="absolute right-0 mt-1 z-50"
+            onMouseLeave={() => setHighlightedTeamMemberId(null)}
+            style={{
+              minWidth: 240,
+              background: "rgba(18, 18, 20, 0.78)",
+              backdropFilter: "blur(28px) saturate(1.3)",
+              WebkitBackdropFilter: "blur(28px) saturate(1.3)",
+              border: "1px solid rgba(255, 255, 255, 0.09)",
+              borderRadius: 12,
+              padding: "6px 0",
+              maxHeight: 360,
+              overflowY: "auto",
+            }}
+          >
+            {teamMembers.length === 0 ? (
+              <div
+                className="px-3 py-[6px] font-mono text-[10px] uppercase tracking-wider"
+                style={{ color: "var(--text-mute)" }}
+              >
+                {"// NO TEAM MEMBERS"}
+              </div>
+            ) : (
+              teamMembers
+                .slice()
+                .sort((a, b) => {
+                  const an = `${a.firstName ?? ""} ${a.lastName ?? ""}`.trim() || a.email || "";
+                  const bn = `${b.firstName ?? ""} ${b.lastName ?? ""}`.trim() || b.email || "";
+                  return an.localeCompare(bn);
+                })
+                .map((member) => {
+                  const name =
+                    `${member.firstName ?? ""} ${member.lastName ?? ""}`.trim() ||
+                    member.email ||
+                    "Unknown";
+                  const count = memberEventCounts[member.id] ?? 0;
+                  const isFiltered = filterTeamMemberIds.includes(member.id);
+                  return (
+                    <div
+                      key={member.id}
+                      onMouseEnter={() => setHighlightedTeamMemberId(member.id)}
+                      onClick={() => toggleMemberFilter(member.id)}
+                      className="flex items-center gap-[8px] px-3 py-[5px] cursor-pointer"
+                      style={{
+                        background: isFiltered
+                          ? "rgba(111, 148, 176, 0.10)"
+                          : "transparent",
+                        transition:
+                          "background 0.12s cubic-bezier(0.22, 1, 0.36, 1)",
+                      }}
+                      onMouseOver={(e) => {
+                        (e.currentTarget as HTMLElement).style.background =
+                          isFiltered
+                            ? "rgba(111, 148, 176, 0.16)"
+                            : "rgba(255, 255, 255, 0.05)";
+                      }}
+                      onMouseOut={(e) => {
+                        (e.currentTarget as HTMLElement).style.background =
+                          isFiltered
+                            ? "rgba(111, 148, 176, 0.10)"
+                            : "transparent";
+                      }}
+                    >
+                      {member.profileImageURL ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={member.profileImageURL}
+                          alt=""
+                          className="w-[18px] h-[18px] rounded-full object-cover shrink-0"
+                        />
+                      ) : (
+                        <div className="w-[18px] h-[18px] rounded-full bg-fill-neutral-dim shrink-0 flex items-center justify-center">
+                          <span className="font-mono text-[9px] text-text-mute uppercase">
+                            {name.charAt(0)}
+                          </span>
+                        </div>
+                      )}
+                      <span
+                        className="font-mono text-[11px] uppercase tracking-wider flex-1 truncate"
+                        style={{
+                          color: isFiltered ? "var(--text)" : "var(--text-2)",
+                        }}
+                      >
+                        {name}
+                      </span>
+                      <span
+                        className="font-mono text-[11px] tabular-nums"
+                        style={{
+                          color: "var(--text-3)",
+                          fontFeatureSettings: '"tnum" 1, "zero" 1',
+                        }}
+                      >
+                        {count}
+                      </span>
+                    </div>
+                  );
+                })
+            )}
+          </div>
+        )}
+      </div>
+
       {/* Task type legend — collapsed dropdown. Click the summary chip to
           open the panel. Hovering a row dims every non-matching event card
-          across the calendar (highlightedTaskType state). */}
-      <div ref={legendWrapRef} className="hidden md:block ml-auto relative">
+          across the calendar (highlightedTaskType state). Clicking a row
+          toggles the persisted filterTaskTypes filter. */}
+      <div ref={legendWrapRef} className="hidden md:block relative">
         <button
           type="button"
           onClick={() => setLegendOpen((v) => !v)}
@@ -246,36 +459,53 @@ export function CalendarToolbar({ events, t }: CalendarToolbarProps) {
           >
             {Object.entries(stats.typeStats)
               .sort(([, a], [, b]) => b.count - a.count)
-              .map(([type, { count, color }]) => (
-                <div
-                  key={type}
-                  onMouseEnter={() => setHighlightedTaskType(type)}
-                  className="flex items-center gap-[8px] px-3 py-[5px] cursor-default"
-                  style={{
-                    transition:
-                      "background 0.12s cubic-bezier(0.22, 1, 0.36, 1)",
-                  }}
-                  onMouseOver={(e) => {
-                    (e.currentTarget as HTMLElement).style.background =
-                      "rgba(255, 255, 255, 0.05)";
-                  }}
-                  onMouseOut={(e) => {
-                    (e.currentTarget as HTMLElement).style.background =
-                      "transparent";
-                  }}
-                >
+              .map(([type, { count, color, key }]) => {
+                const isFiltered = filterTaskTypes.includes(key);
+                return (
                   <div
-                    className="w-[8px] h-[8px] rounded-full shrink-0"
-                    style={{ backgroundColor: color }}
-                  />
-                  <span className="font-mono text-[11px] text-text-2 uppercase tracking-wider flex-1 truncate">
-                    {type}
-                  </span>
-                  <span className="font-mono text-[11px] text-text-3 tabular-nums">
-                    {count}
-                  </span>
-                </div>
-              ))}
+                    key={type}
+                    onMouseEnter={() => setHighlightedTaskType(type)}
+                    onClick={() => toggleTypeFilter(key)}
+                    className="flex items-center gap-[8px] px-3 py-[5px] cursor-pointer"
+                    role="button"
+                    style={{
+                      background: isFiltered
+                        ? "rgba(111, 148, 176, 0.10)"
+                        : "transparent",
+                      transition:
+                        "background 0.12s cubic-bezier(0.22, 1, 0.36, 1)",
+                    }}
+                    onMouseOver={(e) => {
+                      (e.currentTarget as HTMLElement).style.background =
+                        isFiltered
+                          ? "rgba(111, 148, 176, 0.16)"
+                          : "rgba(255, 255, 255, 0.05)";
+                    }}
+                    onMouseOut={(e) => {
+                      (e.currentTarget as HTMLElement).style.background =
+                        isFiltered
+                          ? "rgba(111, 148, 176, 0.10)"
+                          : "transparent";
+                    }}
+                  >
+                    <div
+                      className="w-[8px] h-[8px] rounded-full shrink-0"
+                      style={{ backgroundColor: color }}
+                    />
+                    <span
+                      className="font-mono text-[11px] uppercase tracking-wider flex-1 truncate"
+                      style={{
+                        color: isFiltered ? "var(--text)" : "var(--text-2)",
+                      }}
+                    >
+                      {type}
+                    </span>
+                    <span className="font-mono text-[11px] text-text-3 tabular-nums">
+                      {count}
+                    </span>
+                  </div>
+                );
+              })}
           </div>
         )}
       </div>

--- a/src/app/(dashboard)/calendar/_components/day/day-hourly-grid.tsx
+++ b/src/app/(dashboard)/calendar/_components/day/day-hourly-grid.tsx
@@ -89,12 +89,21 @@ function TimedBlock({
   const locked =
     event.statusKey === "completed" || event.statusKey === "cancelled";
 
-  // Legend hover-to-highlight integration.
+  // Legend hover-to-highlight integration. Combined logic — match either
+  // the highlighted task type or the highlighted team member.
   const highlightedTaskType = useCalendarStore((s) => s.highlightedTaskType);
-  const dimmedByLegend =
-    highlightedTaskType !== null && event.typeLabel !== highlightedTaskType;
-  const highlightedByLegend =
+  const highlightedTeamMemberId = useCalendarStore(
+    (s) => s.highlightedTeamMemberId
+  );
+  const matchesType =
     highlightedTaskType !== null && event.typeLabel === highlightedTaskType;
+  const matchesMember =
+    highlightedTeamMemberId !== null &&
+    event.crewIds.includes(highlightedTeamMemberId);
+  const dimmedByLegend =
+    (highlightedTaskType !== null && !matchesType) ||
+    (highlightedTeamMemberId !== null && !matchesMember);
+  const highlightedByLegend = matchesType || matchesMember;
 
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({

--- a/src/app/(dashboard)/calendar/_components/day/day-task-card.tsx
+++ b/src/app/(dashboard)/calendar/_components/day/day-task-card.tsx
@@ -77,12 +77,22 @@ export function DayTaskCard({
   const setSidePanelTask = useCalendarStore((s) => s.setSidePanelTask);
   const setInlineEdit = useCalendarStore((s) => s.setInlineEdit);
 
-  // Legend hover-to-highlight integration.
+  // Legend hover-to-highlight integration. Same combined logic as the month
+  // bar — match either the highlighted task type or the highlighted team
+  // member, dim everything that matches neither when one is set.
   const highlightedTaskType = useCalendarStore((s) => s.highlightedTaskType);
-  const dimmedByLegend =
-    highlightedTaskType !== null && event.typeLabel !== highlightedTaskType;
-  const highlightedByLegend =
+  const highlightedTeamMemberId = useCalendarStore(
+    (s) => s.highlightedTeamMemberId
+  );
+  const matchesType =
     highlightedTaskType !== null && event.typeLabel === highlightedTaskType;
+  const matchesMember =
+    highlightedTeamMemberId !== null &&
+    event.crewIds.includes(highlightedTeamMemberId);
+  const dimmedByLegend =
+    (highlightedTaskType !== null && !matchesType) ||
+    (highlightedTeamMemberId !== null && !matchesMember);
+  const highlightedByLegend = matchesType || matchesMember;
 
   // ── Resize state — bottom-edge drag for all-day duration ──────────────
   const [resize, setResize] = useState<{

--- a/src/app/(dashboard)/calendar/_components/day/day-task-card.tsx
+++ b/src/app/(dashboard)/calendar/_components/day/day-task-card.tsx
@@ -92,10 +92,11 @@ export function DayTaskCard({
   const resizeRef = useRef(resize);
   resizeRef.current = resize;
 
-  const baseDurationDays = Math.max(
-    differenceInCalendarDays(event.endDate, event.startDate),
-    1
-  );
+  // Inclusive day count: a bar that runs May 7 → May 8 covers 2 calendar
+  // days (diff = 1 + the start day = 2). Clamp to at least 1 so a same-day
+  // event can never shrink past the start.
+  const baseDurationDays =
+    differenceInCalendarDays(event.endDate, event.startDate) + 1;
 
   // Snap deltaPx → integer dayDelta. Clamp so duration stays >= 1 day.
   const snapDayDelta = useCallback(

--- a/src/app/(dashboard)/calendar/_components/event-hover-popover.tsx
+++ b/src/app/(dashboard)/calendar/_components/event-hover-popover.tsx
@@ -158,8 +158,13 @@ function PopoverBody({ event }: { event: InternalCalendarEvent }) {
             className="px-[6px] py-[2px] font-mono uppercase tracking-wider"
             style={{
               color: "#000",
+              // Completed → olive (positive/success token), cancelled → text-mute
+              // (decorative neutral). Both pulled from CSS custom properties so
+              // any future token shift propagates here automatically.
               background:
-                event.statusKey === "completed" ? "#9DB582" : "#6A6A6A",
+                event.statusKey === "completed"
+                  ? "var(--olive)"
+                  : "var(--text-mute)",
               borderRadius: 4,
               fontSize: 10,
             }}

--- a/src/app/(dashboard)/calendar/_components/filter-sidebar.tsx
+++ b/src/app/(dashboard)/calendar/_components/filter-sidebar.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { X, Search, ChevronDown, ChevronRight } from "lucide-react";
+import { X, ChevronDown, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { TASK_TYPE_COLORS } from "@/lib/utils/calendar-constants";
 import { useCalendarStore } from "@/stores/calendar-store";
 import { useTeamMembers, useProjects } from "@/lib/hooks";
 import { useDictionary } from "@/i18n/client";
+import { SearchInput } from "@/components/ui/search-input";
 
 // ─── Event Status Options ────────────────────────────────────────────────────
 
@@ -282,16 +283,11 @@ export function FilterSidebar() {
           count={filterProjectIds.length}
         >
           <div className="mb-1.5">
-            <div className="relative">
-              <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-mute" />
-              <input
-                type="text"
-                value={projectSearch}
-                onChange={(e) => setProjectSearch(e.target.value)}
-                placeholder={t("filter.searchProjects")}
-                className="w-full pl-[26px] pr-2 py-[5px] bg-fill-neutral-dim/50 border border-border-subtle rounded-sm font-mono text-[11px] text-text placeholder:text-text-mute focus:outline-none focus:border-[rgba(255,255,255,0.20)]/40 transition-colors"
-              />
-            </div>
+            <SearchInput
+              value={projectSearch}
+              onChange={(e) => setProjectSearch(e.target.value)}
+              placeholder={t("filter.searchProjects")}
+            />
           </div>
           <div className="flex flex-col gap-0.5 max-h-[200px] overflow-y-auto">
             {projects.map((project) => (

--- a/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
+++ b/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
@@ -2,9 +2,18 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { format } from "date-fns";
+import { Star } from "lucide-react";
 import { type InternalCalendarEvent } from "@/lib/utils/calendar-utils";
 import { useCalendarStore } from "@/stores/calendar-store";
 import { EventHoverPopover } from "../event-hover-popover";
+
+// Personal events ride on the same color pool as task types, which makes
+// them visually indistinguishable from any task type using the same color.
+// Override their visual treatment: outline-only chip with a star icon and
+// white text/border — distinct from any task-type bar regardless of color.
+const PERSONAL_BG = "rgba(255, 255, 255, 0.04)";
+const PERSONAL_BORDER = "rgba(255, 255, 255, 0.55)";
+const PERSONAL_TEXT = "#FFFFFF";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -142,6 +151,14 @@ export function MonthEventBar({
 }: MonthEventBarProps) {
   const [isHovered, setIsHovered] = useState(false);
   const barRef = useRef<HTMLDivElement | null>(null);
+
+  // Personal events render with a distinct white-outline + star treatment
+  // so they're never confused with task-type bars (which can land on any
+  // color in the palette).
+  const isPersonal = event.kind === "personal";
+  const barBg = isPersonal ? PERSONAL_BG : event.typeColors.bg;
+  const barBorder = isPersonal ? PERSONAL_BORDER : event.typeColors.border;
+  const barText = isPersonal ? PERSONAL_TEXT : event.typeColors.text;
 
   // Legend hover-to-highlight: dim non-matches, brighten matches. The "glow"
   // is brightness + opacity rather than a box-shadow (forbidden on dark
@@ -282,6 +299,32 @@ export function MonthEventBar({
 
   // ── Level 1: Compact — color dot only (no stripe, no handles) ──
   if (displayLevel === "compact") {
+    if (isPersonal) {
+      // White star instead of color dot — keeps the same 10px slot but
+      // signals "personal" at a glance.
+      return (
+        <EventHoverPopover event={event} side="top">
+          <div
+            className="cursor-pointer shrink-0 flex items-center justify-center"
+            style={{
+              width: 10,
+              height: 10,
+              opacity: dimmedByLegend ? 0.18 : 1,
+              filter: highlightedByLegend ? "brightness(1.25)" : "none",
+              transition:
+                "opacity 0.15s cubic-bezier(0.22, 1, 0.36, 1), filter 0.15s cubic-bezier(0.22, 1, 0.36, 1)",
+            }}
+            onClick={handleClick}
+          >
+            <Star
+              size={10}
+              strokeWidth={1.5}
+              style={{ color: PERSONAL_TEXT, fill: PERSONAL_TEXT }}
+            />
+          </div>
+        </EventHoverPopover>
+      );
+    }
     return (
       <EventHoverPopover event={event} side="top">
         <div
@@ -304,7 +347,7 @@ export function MonthEventBar({
 
   // ── Level 2: Standard — short bar with single-line title ──
   if (displayLevel === "standard") {
-    const showStripe = span.isFirstSegment || span.isSingleDay;
+    const showStripe = !isPersonal && (span.isFirstSegment || span.isSingleDay);
     return (
       <EventHoverPopover event={event} side="top" disabled={!!resize}>
         <div
@@ -312,14 +355,15 @@ export function MonthEventBar({
           className="cursor-pointer truncate relative"
           style={{
             height: 14,
-            background: event.typeColors.bg,
-            border: `1px solid ${event.typeColors.border}`,
+            background: barBg,
+            border: `1px solid ${barBorder}`,
             borderRadius,
-            color: event.typeColors.text,
-            paddingLeft: showStripe ? 7 : 4,
+            color: barText,
+            paddingLeft: showStripe ? 7 : isPersonal ? 5 : 4,
             paddingRight: 4,
             display: "flex",
             alignItems: "center",
+            gap: isPersonal ? 4 : 0,
             overflow: "visible",
             transition:
               "filter 0.15s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.15s cubic-bezier(0.22, 1, 0.36, 1)",
@@ -335,9 +379,17 @@ export function MonthEventBar({
           onMouseLeave={() => setIsHovered(false)}
         >
           {StripeAccent(showStripe)}
+          {isPersonal && (
+            <Star
+              size={9}
+              strokeWidth={1.5}
+              style={{ color: PERSONAL_TEXT, fill: PERSONAL_TEXT, flexShrink: 0 }}
+              aria-hidden="true"
+            />
+          )}
           <span
             className="font-mohave truncate"
-            style={{ fontSize: 11, lineHeight: "14px", color: "var(--text)" }}
+            style={{ fontSize: 11, lineHeight: "14px", color: barText }}
           >
             {event.projectTitle ?? event.taskTitle}
           </span>
@@ -354,7 +406,8 @@ export function MonthEventBar({
 
   // Multi-day events stay 14px even at expanded level
   if (!span.isSingleDay) {
-    const showStripe = span.isFirstSegment;
+    const showStripe = !isPersonal && span.isFirstSegment;
+    const showStarLead = isPersonal && span.isFirstSegment;
     return (
       <EventHoverPopover event={event} side="top" disabled={!!resize}>
         <div
@@ -362,14 +415,15 @@ export function MonthEventBar({
           className="cursor-pointer truncate relative"
           style={{
             height: 14,
-            background: event.typeColors.bg,
-            border: `1px solid ${event.typeColors.border}`,
+            background: barBg,
+            border: `1px solid ${barBorder}`,
             borderRadius,
-            color: event.typeColors.text,
-            paddingLeft: showStripe ? 7 : 4,
+            color: barText,
+            paddingLeft: showStripe ? 7 : isPersonal ? 5 : 4,
             paddingRight: 4,
             display: "flex",
             alignItems: "center",
+            gap: showStarLead ? 4 : 0,
             overflow: "visible",
             transition:
               "filter 0.15s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.15s cubic-bezier(0.22, 1, 0.36, 1)",
@@ -385,9 +439,17 @@ export function MonthEventBar({
           onMouseLeave={() => setIsHovered(false)}
         >
           {StripeAccent(showStripe)}
+          {showStarLead && (
+            <Star
+              size={9}
+              strokeWidth={1.5}
+              style={{ color: PERSONAL_TEXT, fill: PERSONAL_TEXT, flexShrink: 0 }}
+              aria-hidden="true"
+            />
+          )}
           <span
             className="font-mohave truncate"
-            style={{ fontSize: 11, lineHeight: "14px", color: "var(--text)" }}
+            style={{ fontSize: 11, lineHeight: "14px", color: barText }}
           >
             {event.projectTitle ?? event.taskTitle}
           </span>
@@ -420,11 +482,11 @@ export function MonthEventBar({
         className="cursor-pointer relative"
         style={{
           height: 42,
-          background: event.typeColors.bg,
-          border: `1px solid ${event.typeColors.border}`,
+          background: barBg,
+          border: `1px solid ${barBorder}`,
           borderRadius: "4px",
-          color: event.typeColors.text,
-          paddingLeft: 9,
+          color: barText,
+          paddingLeft: isPersonal ? 8 : 9,
           paddingRight: 6,
           paddingTop: 4,
           paddingBottom: 4,
@@ -439,7 +501,15 @@ export function MonthEventBar({
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        {StripeAccent(true)}
+        {StripeAccent(!isPersonal)}
+        {isPersonal && (
+          <Star
+            size={12}
+            strokeWidth={1.5}
+            style={{ color: PERSONAL_TEXT, fill: PERSONAL_TEXT, flexShrink: 0 }}
+            aria-hidden="true"
+          />
+        )}
 
         <div className="flex-1 min-w-0 flex flex-col justify-center">
           <span
@@ -447,7 +517,7 @@ export function MonthEventBar({
             style={{
               fontSize: 12,
               lineHeight: "14px",
-              color: "var(--text)",
+              color: barText,
               letterSpacing: 0,
             }}
           >
@@ -459,7 +529,7 @@ export function MonthEventBar({
               style={{
                 fontSize: 10,
                 lineHeight: "12px",
-                color: "var(--text-2)",
+                color: isPersonal ? "rgba(255,255,255,0.65)" : "var(--text-2)",
               }}
             >
               {lineTwo}
@@ -475,7 +545,7 @@ export function MonthEventBar({
               style={{
                 fontSize: 10,
                 lineHeight: "12px",
-                color: "var(--text-3)",
+                color: isPersonal ? "rgba(255,255,255,0.65)" : "var(--text-3)",
                 fontFeatureSettings: '"tnum" 1, "zero" 1',
               }}
             >
@@ -485,9 +555,9 @@ export function MonthEventBar({
           <div
             className="px-[5px] py-[1px] font-cakemono font-light uppercase"
             style={{
-              color: event.typeColors.text,
-              background: event.typeColors.bg,
-              border: `1px solid ${event.typeColors.border}`,
+              color: barText,
+              background: barBg,
+              border: `1px solid ${barBorder}`,
               borderRadius: 4,
               fontSize: 9,
               letterSpacing: "0.04em",

--- a/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
+++ b/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
@@ -162,12 +162,22 @@ export function MonthEventBar({
 
   // Legend hover-to-highlight: dim non-matches, brighten matches. The "glow"
   // is brightness + opacity rather than a box-shadow (forbidden on dark
-  // canvas per the design spec).
+  // canvas per the design spec). Mirrors logic for the team-member dropdown
+  // — when a team member is being hovered, dim every card whose crew does
+  // not include them.
   const highlightedTaskType = useCalendarStore((s) => s.highlightedTaskType);
-  const dimmedByLegend =
-    highlightedTaskType !== null && event.typeLabel !== highlightedTaskType;
-  const highlightedByLegend =
+  const highlightedTeamMemberId = useCalendarStore(
+    (s) => s.highlightedTeamMemberId
+  );
+  const matchesType =
     highlightedTaskType !== null && event.typeLabel === highlightedTaskType;
+  const matchesMember =
+    highlightedTeamMemberId !== null &&
+    event.crewIds.includes(highlightedTeamMemberId);
+  const dimmedByLegend =
+    (highlightedTaskType !== null && !matchesType) ||
+    (highlightedTeamMemberId !== null && !matchesMember);
+  const highlightedByLegend = matchesType || matchesMember;
 
   // Status guard — completed/cancelled events are display-only.
   const locked =

--- a/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
+++ b/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
@@ -186,19 +186,24 @@ export function MonthEventBar({
     canResize && (span.isSingleDay || span.isLastSegment);
 
   // Visual preview during drag — translucent overlay extending or
-  // contracting from the active edge by previewDayDelta day-columns. The
-  // outer absolute container is one day-column wide on the bar's edge,
-  // anchored beyond the bar so growth is visible.
+  // contracting from the active edge by previewDayDelta day-columns.
+  //
+  // The bar's own width spans `barDayCount` calendar columns (1 for
+  // single-day, N for multi-day). A naive `${magnitude * 100}%` is
+  // measured against the bar's width, which means a 1-day extension on
+  // a 2-day bar renders as a 2-column-wide preview overlay (the
+  // user-visible bug). Compute the width as a fraction of a single
+  // day-column so the preview always tracks one calendar day per unit
+  // of dayDelta.
   const renderEdgePreview = (edge: "left" | "right") => {
     if (!resize || resize.edge !== edge || previewDayDelta === 0) return null;
     const grow = previewDayDelta > 0;
     const magnitude = Math.abs(previewDayDelta);
 
-    // For "right" edge: positive grow extends further right (outside the bar);
-    //                    negative shrink overlays the bar from the right.
-    // For "left" edge:  positive grow extends further left;
-    //                    negative shrink overlays from the left.
-    const widthCol = `${magnitude * 100}%`;
+    const barDayCount =
+      span.endDayIndex - span.startDayIndex + 1; // 1 for single-day; N for multi-day
+    const widthPctOfBar = (magnitude / barDayCount) * 100;
+
     const style: React.CSSProperties = {
       position: "absolute",
       top: -2,
@@ -209,7 +214,7 @@ export function MonthEventBar({
         : "rgba(0,0,0,0.45)",
       border: `1px dashed ${event.typeColors.border}`,
       borderRadius: 4,
-      width: widthCol,
+      width: `${widthPctOfBar}%`,
       zIndex: 8,
     };
     if (edge === "right") {

--- a/src/app/(dashboard)/calendar/_components/month/month-scroll-container.tsx
+++ b/src/app/(dashboard)/calendar/_components/month/month-scroll-container.tsx
@@ -678,19 +678,29 @@ export function MonthScrollContainer({
       dayDelta: number
     ) => {
       if (dayDelta === 0) return;
+      // totalDays = how many days between start and end. For a 2-day bar
+      // (May 7 → May 8) this is 1. The minimum allowed bar covers a
+      // single calendar day, i.e. start === end (totalDays === 0).
       const totalDays = differenceInCalendarDays(
         event.endDate,
         event.startDate
       );
       if (edge === "right") {
-        const minDelta = totalDays > 0 ? -(totalDays - 1) : 0;
+        // Pulling the right edge inward shrinks the bar. Allow shrink down
+        // to start === end (single day), so minDelta is -totalDays. The
+        // earlier formula (-(totalDays - 1)) blocked the final click that
+        // would collapse a 2-day bar back to 1 day.
+        const minDelta = -totalDays;
         const clamped = Math.max(dayDelta, minDelta);
         if (clamped === 0) return;
         const newEnd = addDays(event.endDate, clamped);
         commitResize(event, { endDate: newEnd });
         return;
       }
-      const maxDelta = totalDays > 0 ? totalDays - 1 : 0;
+      // Pulling the left edge inward (positive dayDelta) shrinks the bar.
+      // Symmetric clamp: allow up to totalDays so the bar can collapse to
+      // a single day.
+      const maxDelta = totalDays;
       const clamped = Math.min(dayDelta, maxDelta);
       if (clamped === 0) return;
       const newStart = addDays(event.startDate, clamped);

--- a/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
+++ b/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
@@ -137,82 +137,94 @@ export function UnscheduledTray({ view }: UnscheduledTrayProps) {
   const dockSide: "left" | "right" = view === "day" ? "left" : "right";
   const count = allUnscheduled.length;
 
-  // ── Collapsed state ─────────────────────────────────────────────────────
-
-  if (unscheduledTrayCollapsed) {
-    return (
-      <button
-        type="button"
-        onClick={toggleUnscheduledTray}
-        className="shrink-0 h-full flex flex-col items-center justify-start gap-3 cursor-pointer group"
-        style={{
-          width: COLLAPSED_WIDTH,
-          background: "var(--glass-bg)",
-          borderLeft: dockSide === "right" ? "1px solid var(--line)" : "none",
-          borderRight: dockSide === "left" ? "1px solid var(--line)" : "none",
-          padding: "16px 0",
-          transition: "background 0.15s cubic-bezier(0.22, 1, 0.36, 1)",
-        }}
-        onMouseEnter={(e) => {
-          (e.currentTarget as HTMLElement).style.background = "var(--surface-hover)";
-        }}
-        onMouseLeave={(e) => {
-          (e.currentTarget as HTMLElement).style.background = "var(--glass-bg)";
-        }}
-        aria-label={`Show ${count} unscheduled tasks`}
-        title={`// UNSCHEDULED [${count}]`}
-      >
-        {dockSide === "right" ? (
-          <ChevronLeft
-            className="w-[14px] h-[14px]"
-            style={{ color: "var(--text-3)" }}
-          />
-        ) : (
-          <ChevronRight
-            className="w-[14px] h-[14px]"
-            style={{ color: "var(--text-3)" }}
-          />
-        )}
-        <div
-          className="flex-1 flex items-center justify-center"
-          style={{
-            writingMode: "vertical-rl",
-            transform: "rotate(180deg)",
-          }}
-        >
-          <span
-            className="font-mono text-[11px] uppercase tracking-wider tabular-nums"
-            style={{
-              color: "var(--text-3)",
-              fontFeatureSettings: '"tnum" 1, "zero" 1',
-            }}
-          >
-            {`// UNSCHEDULED [${count}]`}
-          </span>
-        </div>
-        <GripVertical
-          className="w-[14px] h-[14px]"
-          style={{ color: "var(--text-mute)" }}
-        />
-      </button>
-    );
-  }
-
-  // ── Expanded state ──────────────────────────────────────────────────────
+  // ── Animated width container ────────────────────────────────────────────
+  // A single motion.div animates between COLLAPSED_WIDTH and EXPANDED_WIDTH
+  // so the rail visibly slides closed / open. Inner contents cross-fade with
+  // AnimatePresence so the collapsed rail (vertical label) and expanded
+  // panel (search + cards) hand off smoothly without an instant swap.
 
   return (
     <motion.div
       initial={false}
-      animate={{ width: EXPANDED_WIDTH }}
-      transition={{ duration: 0.22, ease: EASE_SMOOTH }}
-      className="shrink-0 h-full flex flex-col min-h-0"
+      animate={{
+        width: unscheduledTrayCollapsed ? COLLAPSED_WIDTH : EXPANDED_WIDTH,
+      }}
+      transition={{ duration: 0.24, ease: EASE_SMOOTH }}
+      className="shrink-0 h-full flex flex-col min-h-0 overflow-hidden relative"
       style={{
-        width: EXPANDED_WIDTH,
         background: "var(--glass-bg)",
         borderLeft: dockSide === "right" ? "1px solid var(--line)" : "none",
         borderRight: dockSide === "left" ? "1px solid var(--line)" : "none",
       }}
     >
+      <AnimatePresence initial={false} mode="wait">
+        {unscheduledTrayCollapsed ? (
+          <motion.button
+            key="tray-collapsed"
+            type="button"
+            onClick={toggleUnscheduledTray}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.16, ease: EASE_SMOOTH }}
+            className="absolute inset-0 flex flex-col items-center justify-start gap-3 cursor-pointer group"
+            style={{
+              padding: "16px 0",
+              background: "transparent",
+              transition: "background 0.15s cubic-bezier(0.22, 1, 0.36, 1)",
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLElement).style.background = "var(--surface-hover)";
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLElement).style.background = "transparent";
+            }}
+            aria-label={`Show ${count} unscheduled tasks`}
+            title={`// UNSCHEDULED [${count}]`}
+          >
+            {dockSide === "right" ? (
+              <ChevronLeft
+                className="w-[14px] h-[14px]"
+                style={{ color: "var(--text-3)" }}
+              />
+            ) : (
+              <ChevronRight
+                className="w-[14px] h-[14px]"
+                style={{ color: "var(--text-3)" }}
+              />
+            )}
+            <div
+              className="flex-1 flex items-center justify-center"
+              style={{
+                writingMode: "vertical-rl",
+                transform: "rotate(180deg)",
+              }}
+            >
+              <span
+                className="font-mono text-[11px] uppercase tracking-wider tabular-nums"
+                style={{
+                  color: "var(--text-3)",
+                  fontFeatureSettings: '"tnum" 1, "zero" 1',
+                }}
+              >
+                {`// UNSCHEDULED [${count}]`}
+              </span>
+            </div>
+            <GripVertical
+              className="w-[14px] h-[14px]"
+              style={{ color: "var(--text-mute)" }}
+            />
+          </motion.button>
+        ) : (
+          <motion.div
+            key="tray-expanded"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18, ease: EASE_SMOOTH, delay: 0.04 }}
+            className="absolute inset-0 flex flex-col min-h-0"
+            style={{ width: EXPANDED_WIDTH }}
+          >
       {/* Header row */}
       <div
         className="shrink-0 flex items-center justify-between px-3 py-3"
@@ -354,6 +366,9 @@ export function UnscheduledTray({ view }: UnscheduledTrayProps) {
           </div>
         )}
       </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </motion.div>
   );
 }

--- a/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
+++ b/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
@@ -73,7 +73,8 @@ export function UnscheduledTray({ view }: UnscheduledTrayProps) {
         (t.customTitle ?? "").toLowerCase().includes(q) ||
         (t.taskType?.display ?? "").toLowerCase().includes(q) ||
         (t.project?.title ?? "").toLowerCase().includes(q) ||
-        (t.project?.address ?? "").toLowerCase().includes(q)
+        (t.project?.address ?? "").toLowerCase().includes(q) ||
+        (t.project?.client?.name ?? "").toLowerCase().includes(q)
     );
   }, [allUnscheduled, unscheduledTraySearch]);
 
@@ -112,9 +113,9 @@ export function UnscheduledTray({ view }: UnscheduledTrayProps) {
         case "project":
           return t.project?.title ?? "// NO PROJECT";
         case "client":
-          // ProjectTask doesn't expose client directly; project carries clientId.
-          // Without joining, fall back to project title (best available proxy).
-          return t.project?.title ?? "// NO CLIENT";
+          // task-service eager-loads project.client (see select clause), so
+          // group by the actual client name when present.
+          return t.project?.client?.name ?? "// NO CLIENT";
         case "type":
           return t.taskType?.display?.toUpperCase() ?? "// NO TYPE";
       }
@@ -397,6 +398,7 @@ function UnscheduledTrayCard({ task }: { task: ProjectTask }) {
     "#6F94B0";
 
   const projectName = task.project?.title ?? "Untitled Project";
+  const clientName = task.project?.client?.name ?? null;
   const taskTypeLabel = task.taskType?.display?.toUpperCase() ?? "TASK";
   const customTitle = task.customTitle;
 
@@ -452,6 +454,14 @@ function UnscheduledTrayCard({ task }: { task: ProjectTask }) {
           {taskTypeLabel}
         </span>
       </div>
+      {clientName && (
+        <div
+          className="font-mono text-[10px] uppercase tracking-wider truncate mt-1"
+          style={{ color: "var(--text-2)", letterSpacing: "0.04em" }}
+        >
+          {clientName}
+        </div>
+      )}
       {customTitle && customTitle !== task.taskType?.display && (
         <div
           className="font-mono text-[10px] truncate mt-1"

--- a/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
+++ b/src/app/(dashboard)/calendar/_components/unscheduled-tray.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useMemo } from "react";
-import { Search, ChevronRight, ChevronLeft, GripVertical } from "lucide-react";
+import { ChevronRight, ChevronLeft, GripVertical } from "lucide-react";
+import { SearchInput } from "@/components/ui/search-input";
 import { useDraggable } from "@dnd-kit/core";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTasks } from "@/lib/hooks";
@@ -263,35 +264,10 @@ export function UnscheduledTray({ view }: UnscheduledTrayProps) {
 
       {/* Search */}
       <div className="shrink-0 px-3 pt-3 pb-1">
-        <div className="relative">
-          <Search
-            size={12}
-            className="absolute left-[10px] top-1/2 -translate-y-1/2 pointer-events-none"
-            style={{ color: "var(--text-3)" }}
-          />
-          <input
-            type="text"
-            value={unscheduledTraySearch}
-            onChange={(e) => setUnscheduledTraySearch(e.target.value)}
-            placeholder="SEARCH"
-            className="w-full pl-[30px] pr-2 py-[6px] font-mono text-[11px] uppercase tracking-wider"
-            style={{
-              background: "var(--surface-input)",
-              border: "1px solid var(--line)",
-              borderRadius: 5,
-              color: "var(--text)",
-              outline: "none",
-              letterSpacing: "0.06em",
-            }}
-            onFocus={(e) =>
-              ((e.currentTarget as HTMLElement).style.borderColor =
-                "rgba(255,255,255,0.20)")
-            }
-            onBlur={(e) =>
-              ((e.currentTarget as HTMLElement).style.borderColor = "var(--line)")
-            }
-          />
-        </div>
+        <SearchInput
+          value={unscheduledTraySearch}
+          onChange={(e) => setUnscheduledTraySearch(e.target.value)}
+        />
       </div>
 
       {/* Group / Sort selects */}

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import * as React from "react";
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Universal compact search input — matches the styling first established
+ * in the calendar's unscheduled tray:
+ *
+ *   - 11px font-mono uppercase tracking-wider
+ *   - Search icon at left (12px)
+ *   - surface-input background, hairline border (var(--line))
+ *   - 5px radius
+ *   - Border lifts to rgba(255,255,255,0.20) on focus
+ *
+ * Use this anywhere a calendar / dashboard / drawer needs a tactical
+ * search field. Avoid the heavier `Input` primitive (56px tall) for
+ * inline filter contexts.
+ */
+
+export interface SearchInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type" | "size"> {
+  /** Icon size (px). Defaults to 12 to match the unscheduled tray. */
+  iconSize?: number;
+  /** Wrapper className — applies to the relative container, not the input. */
+  wrapperClassName?: string;
+}
+
+export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
+  (
+    {
+      iconSize = 12,
+      wrapperClassName,
+      className,
+      placeholder = "SEARCH",
+      onFocus,
+      onBlur,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <div className={cn("relative", wrapperClassName)}>
+        <Search
+          size={iconSize}
+          className="absolute left-[10px] top-1/2 -translate-y-1/2 pointer-events-none"
+          style={{ color: "var(--text-3)" }}
+        />
+        <input
+          ref={ref}
+          type="text"
+          placeholder={placeholder}
+          className={cn(
+            "w-full pl-[30px] pr-2 py-[6px] font-mono text-[11px] uppercase tracking-wider",
+            className
+          )}
+          style={{
+            background: "var(--surface-input)",
+            border: "1px solid var(--line)",
+            borderRadius: 5,
+            color: "var(--text)",
+            outline: "none",
+            letterSpacing: "0.06em",
+          }}
+          onFocus={(e) => {
+            (e.currentTarget as HTMLElement).style.borderColor =
+              "rgba(255,255,255,0.20)";
+            onFocus?.(e);
+          }}
+          onBlur={(e) => {
+            (e.currentTarget as HTMLElement).style.borderColor = "var(--line)";
+            onBlur?.(e);
+          }}
+          {...props}
+        />
+      </div>
+    );
+  }
+);
+
+SearchInput.displayName = "SearchInput";

--- a/src/stores/calendar-store.ts
+++ b/src/stores/calendar-store.ts
@@ -61,6 +61,11 @@ interface CalendarStoreState {
   // events and brighten matching ones. UI-ephemeral, never persisted.
   highlightedTaskType: string | null;
 
+  // Team-member hover-to-highlight (parallel to highlightedTaskType, for
+  // the team-member dropdown). When set, event renderers dim cards whose
+  // crew does not include this user id.
+  highlightedTeamMemberId: string | null;
+
   // Cascade / Ghost previews
   ghostPreviews: GhostPreview[];
   isConfirmBarVisible: boolean;
@@ -109,6 +114,7 @@ interface CalendarStoreState {
 
   // Actions — Legend highlight
   setHighlightedTaskType: (type: string | null) => void;
+  setHighlightedTeamMemberId: (id: string | null) => void;
 
   // Actions — Multi-select
   toggleTaskSelection: (taskId: string) => void;
@@ -173,6 +179,7 @@ export const useCalendarStore = create<CalendarStoreState>()(
 
       // Legend highlight
       highlightedTaskType: null,
+      highlightedTeamMemberId: null,
 
       // Cascade / Ghost
       ghostPreviews: [],
@@ -242,6 +249,7 @@ export const useCalendarStore = create<CalendarStoreState>()(
 
       // Actions — Legend highlight
       setHighlightedTaskType: (type) => set({ highlightedTaskType: type }),
+      setHighlightedTeamMemberId: (id) => set({ highlightedTeamMemberId: id }),
 
       // Actions — Multi-select
       toggleTaskSelection: (taskId) =>


### PR DESCRIPTION
## Summary

Calendar-focused bug sweep — 9 fixes, 1 escalation. Touches month-bar resize math, unscheduled tray, status badges, drag-to-schedule defaults, calendar toolbar (new team-member dropdown), and a new shared search input primitive.

## Bugs

- [x] **483cd85c** · ui_issue · animate unscheduled drawer collapse/expand. Single motion.div animates width with cross-faded inner contents.
- [ ] **6197c2e9** · ui_issue · ESCALATED — month-view badge "0 roundness on hover" — could not locate the relevant code with confidence (no hover handler mutates radius). Needs screenshot.
- [x] **0f63663b** · ui_issue · resize preview width corrected to one column per dayDelta (was % of bar width, which overstated for multi-day bars).
- [x] **834200a2** · bug · resize clamps fixed so a 2-day bar can shrink to 1 day (month + day surfaces).
- [x] **1d4505a3** · ui_issue · unscheduled tray cards now show client name; CLIENT group-by and search extended to use it.
- [x] **89a5d774** · ui_issue · personal events get a distinct white-outline + leading star icon across all month-view display levels.
- [x] **06e00bb2** · ui_issue · completed/cancelled status badges in hover popover swapped to var(--olive) / var(--text-mute) tokens.
- [x] **da108fb6** · ui_issue · drag-to-schedule defaults no longer add an extra calendar day (inclusive duration math).
- [x] **324e6520** · ui_issue · added // TEAM dropdown beside // LEGEND with hover-to-highlight + click-to-filter; legend rows are now clickable too.
- [x] **e8175e88** · ui_issue · created src/components/ui/search-input.tsx universal primitive; migrated unscheduled tray and filter sidebar to it.

## Test plan

- [ ] Calendar / Month view: drag right edge of a 2-day bar inward — should shrink to 1 day.
- [ ] Calendar / Month view: drag right edge of a 2-day bar outward by 1 day — preview overlay should be exactly one column wide.
- [ ] Calendar / Month view: hover a personal event — bar shows white outline + star icon.
- [ ] Calendar / Month view: hover any event with completed status — popover badge background should be olive.
- [ ] Calendar toolbar: open // TEAM dropdown, hover a member → other cards dim. Click a member → filter activates (chip count appears).
- [ ] Calendar toolbar: open // LEGEND, click a row → toggles task-type filter; FilterSidebar reflects same state.
- [ ] Calendar / Unscheduled tray: collapse / expand the rail — should slide smoothly, not snap.
- [ ] Calendar / Unscheduled tray: card shows project + client name on a card with both.
- [ ] Calendar / Filter sidebar: project search input visually matches the unscheduled tray search.
- [ ] Drag a 1-day task from the unscheduled tray onto a calendar day — should land as a single-day event (not span two days).

🤖 Generated with [Claude Code](https://claude.com/claude-code)