### PR TITLE
Nightly Bug Sweep — web — 2026-04-30 — Batch 03

### DIFF
--- a/src/components/layouts/quick-actions-tab.tsx
+++ b/src/components/layouts/quick-actions-tab.tsx
@@ -12,6 +12,11 @@ const EDGE_TAB_ID = "quick-actions";
 const STACK_OFFSET_QA = 94;
 const REST_HEIGHT = 132;
 const DRAWER_WIDTH = 308;
+// Match the panel-anchored drawer (`PANEL_H`) in quick-actions-drawer.tsx so
+// the tab + panel read as one shape when expanded, and the tab never towers
+// above its drawer or overlaps the Notifications tab. (See bugs dd5659ed +
+// 85da1e52.)
+const EXPANDED_HEIGHT_QA = 452;
 
 export function QuickActionsTab() {
   const { t } = useDictionary("quick-actions");
@@ -44,6 +49,7 @@ export function QuickActionsTab() {
       onToggle={() => toggle(EDGE_TAB_ID)}
       accent="accent"
       restHeight={REST_HEIGHT}
+      expandedHeight={EXPANDED_HEIGHT_QA}
       drawerWidth={DRAWER_WIDTH}
       stackOffset={STACK_OFFSET_QA}
       canHoverExpand={!anyActive || open}

--- a/src/components/ops/inbox/category-chip.tsx
+++ b/src/components/ops/inbox/category-chip.tsx
@@ -41,12 +41,32 @@ const CATEGORY_STYLES: Record<EmailThreadCategory, CategoryStyle> = {
   OTHER:        { border: "#4a4a4a", label: "OTHER",        dotColor: "#4a4a4a" },
 };
 
+// Fallback used when a thread arrives with a `primaryCategory` that isn't
+// in CATEGORY_STYLES — e.g. a legacy row, a server-side enum extension, or
+// a malformed payload. We render OTHER's style and the raw value (if any)
+// rather than crashing the whole inbox route. (See bug a8ece79d.)
+const FALLBACK_STYLE: CategoryStyle = CATEGORY_STYLES.OTHER;
+
+function resolveCategoryStyle(
+  category: EmailThreadCategory | null | undefined
+): CategoryStyle {
+  if (!category) return FALLBACK_STYLE;
+  return CATEGORY_STYLES[category] ?? FALLBACK_STYLE;
+}
+
 export function categoryLabel(category: EmailThreadCategory): string {
-  return CATEGORY_STYLES[category].label;
+  const style = CATEGORY_STYLES[category];
+  if (style) return style.label;
+  // For unmapped categories, surface the raw token (uppercased) so the
+  // operator can still see what came back from the server.
+  if (typeof category === "string" && category.length > 0) {
+    return category.replace(/_/g, " ").toUpperCase();
+  }
+  return FALLBACK_STYLE.label;
 }
 
 export function categoryDotColor(category: EmailThreadCategory): string {
-  return CATEGORY_STYLES[category].dotColor;
+  return (CATEGORY_STYLES[category] ?? FALLBACK_STYLE).dotColor;
 }
 
 // ─── Chip props ──────────────────────────────────────────────────────────────
@@ -78,8 +98,8 @@ export const CategoryChip = forwardRef<HTMLButtonElement | HTMLSpanElement, Cate
     { category, size = "sm", interactive = false, onClick, label, leading, manual, className, title },
     ref
   ) {
-    const style = CATEGORY_STYLES[category];
-    const display = label ?? style.label;
+    const style = resolveCategoryStyle(category);
+    const display = label ?? categoryLabel(category);
 
     const sizeClasses =
       size === "md"

--- a/src/components/ui/edge-tab.tsx
+++ b/src/components/ui/edge-tab.tsx
@@ -25,6 +25,7 @@ export function EdgeTab({
   count,
   accent = "accent",
   restHeight = DEFAULT_REST_HEIGHT,
+  expandedHeight,
   drawerWidth = DEFAULT_DRAWER_WIDTH,
   railTop = DEFAULT_RAIL_TOP,
   railBottom = DEFAULT_RAIL_BOTTOM,
@@ -44,6 +45,66 @@ export function EdgeTab({
   const reducedMotion = useReducedMotion();
 
   const expanded = open || (hovered && canHoverExpand);
+
+  // ─── Tab vertical positioning ──────────────────────────────────────────────
+  //
+  // Two stacked tabs share the right rail, separated by an 8px gap and offset
+  // from the rail's vertical midpoint via `stackOffset` (negative = above
+  // center, positive = below).
+  //
+  // Rest center: `50% + stackOffset`.
+  // Rest top:    `50% + stackOffset - restHeight/2`.
+  // Rest bottom: `50% + stackOffset + restHeight/2`.
+  //
+  // Behavior (bug dd5659ed / 85da1e52):
+  //
+  //   OPEN with expandedHeight  → centered on `stackOffset`, height
+  //     `expandedHeight`. Aligns with a panel-anchored drawer (which is
+  //     also centered on `stackOffset`). The active drawer covers the
+  //     sibling-tab area anyway, so crossing the rail midpoint here is
+  //     fine.
+  //
+  //   OPEN without expandedHeight → fill the entire rail (legacy behavior
+  //     for full-rail drawers like Notifications).
+  //
+  //   HOVER with expandedHeight → grow ONLY toward the rail extremity (away
+  //     from the rail midpoint), capping at `expandedHeight`. This stops
+  //     the tab from bursting across the midpoint and covering the sibling
+  //     tab while no drawer is yet open. The drawer hasn't mounted, so we
+  //     don't need to align with it perfectly.
+  //
+  //   HOVER without expandedHeight → stay at rest height. Better than
+  //     bursting full-rail and covering the sibling tab.
+
+  let tabTop: string;
+  let tabHeight: string | number;
+  if (!expanded) {
+    tabTop = `calc(50% + ${stackOffset - restHeight / 2}px)`;
+    tabHeight = restHeight;
+  } else if (open && typeof expandedHeight === "number") {
+    // Open + panel clamp → align with the panel-anchored drawer.
+    tabTop = `calc(50% + ${stackOffset - expandedHeight / 2}px)`;
+    tabHeight = expandedHeight;
+  } else if (open) {
+    // Open + no clamp → legacy full-rail expansion.
+    tabTop = "0";
+    tabHeight = "100%";
+  } else if (typeof expandedHeight === "number") {
+    // Hover only → grow outward from the near edge, never crossing the
+    // rail midpoint into the sibling tab's half.
+    if (stackOffset >= 0) {
+      // Below center: anchor TOP edge of rest position, grow down.
+      tabTop = `calc(50% + ${stackOffset - restHeight / 2}px)`;
+    } else {
+      // Above center: anchor BOTTOM edge of rest position, grow up.
+      tabTop = `calc(50% + ${stackOffset + restHeight / 2 - expandedHeight}px)`;
+    }
+    tabHeight = expandedHeight;
+  } else {
+    // Hover only without `expandedHeight` → stay at rest.
+    tabTop = `calc(50% + ${stackOffset - restHeight / 2}px)`;
+    tabHeight = restHeight;
+  }
 
   return (
     <div
@@ -78,12 +139,10 @@ export function EdgeTab({
         onBlur={() => setHovered(false)}
         style={{
           position: "absolute",
-          top: expanded
-            ? 0
-            : `calc(50% + ${stackOffset - restHeight / 2}px)`,
+          top: tabTop,
           right: open ? drawerWidth : 0,
           width: TAB_WIDTH,
-          height: expanded ? "100%" : restHeight,
+          height: tabHeight,
           boxSizing: "border-box",
           background: fill,
           backdropFilter: "blur(28px) saturate(1.3)",

--- a/src/components/ui/edge-tab.types.ts
+++ b/src/components/ui/edge-tab.types.ts
@@ -22,6 +22,18 @@ export interface EdgeTabProps {
   /** Rest height in px. Default 180. FAB uses 132 for its shorter wordmark. */
   restHeight?: number;
 
+  /**
+   * Height (px) the tab grows to when hovered or open. Should match the paired
+   * drawer's height so the tab + drawer read as one shape.
+   *
+   * When omitted, the tab fills the full rail (`100%`) — keep this as the
+   * default for tabs paired with a full-rail drawer (e.g. Notifications).
+   * Tabs paired with a panel-anchored drawer (e.g. Quick Actions, panel
+   * 308×452) MUST pass the panel's height here so the tab doesn't tower
+   * above its drawer and overlap a sibling tab. (See bug dd5659ed / 85da1e52.)
+   */
+  expandedHeight?: number;
+
   /** Drawer width in px — the tab slides this far when opening. Default 360. */
   drawerWidth?: number;
 


### PR DESCRIPTION
Final batch (3 of 3) of the nightly web bug sweep for 2026-04-30. All three bugs fixed; one is a high-priority crash recovery for the inbox route.

## Fixed

### a8ece79d — bug — urgent — Inbox crashed with `Cannot read properties of undefined (reading 'label')` (86 errors) `[COMPLEX]`
The `CategoryChip` lookup `CATEGORY_STYLES[category].label` blew up whenever a thread row arrived with a `primaryCategory` outside the hardcoded enum (legacy rows, server-side enum extension, or malformed payload). Hardened the read site in `src/components/ops/inbox/category-chip.tsx` with a `resolveCategoryStyle()` helper that falls back to OTHER's style, and a `categoryLabel()` helper that surfaces the raw token (uppercased) when present so the operator can still see what came back. The whole inbox route no longer hard-stops on a single unmapped category.

S3 CORS errors on `ops-app-files-prod.s3.us-west-2.amazonaws.com` for profile avatars are a separate concern (S3 bucket policy, not in this repo) — noted in `fix_notes` but not fixed here.

### dd5659ed — ui_issue — high — Quick Actions tab much too tall
The Quick Actions tab is paired with a panel-anchored drawer (308×452), not a full-rail drawer. EdgeTab's legacy expansion (`top:0; height:100%`) made the tab much taller than its menu. Passed `expandedHeight={452}` (matching `PANEL_H` in `quick-actions-drawer.tsx`) so the tab now grows only as tall as the panel. Builds on the EdgeTab overhaul below.

### 85da1e52 — ui_issue — high — Hovering one tab covered the other
The right-edge action tabs (Notifications + Quick Actions) shared a single expand path that set `top:0; height:100%` on hover OR open. On hover alone, the hovered tab burst across the rail midpoint and covered the sibling. Split the behavior in `src/components/ui/edge-tab.tsx`:
- Open with `expandedHeight` → centered on `stackOffset`, height clamped to `expandedHeight` (matches the panel-anchored drawer geometry).
- Open without `expandedHeight` → legacy full-rail (Notifications continues to use this).
- Hover with `expandedHeight` → grow outward from the near edge, capped at `expandedHeight`, never crossing the rail midpoint.
- Hover without `expandedHeight` → stay at rest height, rather than bursting full-rail.

## Test plan

- [ ] Open `/inbox` on a company with threads carrying any (or no) `primaryCategory` and verify the page renders instead of crashing with the route-error fallback.
- [ ] Force a thread to have an unmapped category (e.g. via DB) and confirm the chip shows the raw token uppercased and the rest of the inbox works.
- [ ] Open `/calendar` (or any page where the Quick Actions tab renders) and hover the QA tab — verify it grows only to the height of the menu (452px), not the whole rail.
- [ ] Hover the Notifications tab — it stays at rest height (180px) rather than going full rail; the QA tab below remains visible.
- [ ] Click to open the QA drawer — the tab + drawer share the same vertical span (centered around `+94` from rail midpoint, 452px tall).
- [ ] Click to open the Notifications drawer — full-rail expansion still works as before.
- [ ] `npm run type-check && npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)