### PR TITLE
feat(storage): Phase 1 — cut new uploads from Supabase Storage to S3

### DIFF
--- a/src/app/api/admin/blog/upload/route.ts
+++ b/src/app/api/admin/blog/upload/route.ts
@@ -1,12 +1,28 @@
 /**
  * POST /api/admin/blog/upload
  *
- * Upload a blog image to Supabase Storage (images/blog/ prefix).
+ * Upload a blog image to OPS storage. Default backend is S3
+ * (`ops-app-files-prod/blog/`). STORAGE_BACKEND=supabase routes the
+ * write to the legacy Supabase Storage `images/blog/` prefix instead
+ * — kept as a one-redeploy rollback for the Phase 1 cutover.
+ *
  * Admin-only. Returns { url: string } with the public URL.
  */
 import { NextRequest, NextResponse } from "next/server";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { requireAdmin, withAdmin } from "@/lib/admin/api-auth";
 import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import {
+  getS3Client,
+  S3_BUCKET,
+  buildPublicS3Url,
+  getStorageBackend,
+} from "@/lib/s3/client";
+import {
+  sanitizeFilename,
+  inferExtension,
+  buildUniqueSuffix,
+} from "@/lib/s3/path-auth";
 
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
 const MAX_SIZE = 10 * 1024 * 1024; // 10MB
@@ -35,32 +51,40 @@ export const POST = withAdmin(async (req: NextRequest) => {
     );
   }
 
-  const ext = file.name.split(".").pop() || "jpg";
-  const timestamp = Date.now();
-  const random = Math.random().toString(36).slice(2, 10);
-  const filePath = `blog/${timestamp}-${random}.${ext}`;
-
-  const supabase = getServiceRoleClient();
+  const cleanFilename = sanitizeFilename(file.name);
+  const ext = inferExtension(cleanFilename, "jpg");
+  const key = `blog/${buildUniqueSuffix()}.${ext}`;
   const buffer = Buffer.from(await file.arrayBuffer());
 
+  if (getStorageBackend() === "s3") {
+    await getS3Client().send(
+      new PutObjectCommand({
+        Bucket: S3_BUCKET,
+        Key: key,
+        Body: buffer,
+        ContentType: file.type,
+      })
+    );
+    return NextResponse.json({ url: buildPublicS3Url(key) });
+  }
+
+  // Legacy Supabase path retained for STORAGE_BACKEND=supabase rollback.
+  const supabase = getServiceRoleClient();
   const { error: uploadError } = await supabase.storage
     .from("images")
-    .upload(filePath, buffer, {
+    .upload(key, buffer, {
       contentType: file.type,
       upsert: false,
     });
 
   if (uploadError) {
-    console.error("[blog/upload] Upload failed:", uploadError.message);
+    console.error("[blog/upload] Supabase upload failed:", uploadError.message);
     return NextResponse.json(
       { error: uploadError.message },
       { status: 500 }
     );
   }
 
-  const { data: urlData } = supabase.storage
-    .from("images")
-    .getPublicUrl(filePath);
-
+  const { data: urlData } = supabase.storage.from("images").getPublicUrl(key);
   return NextResponse.json({ url: urlData.publicUrl });
 });

--- a/src/app/api/bug-reports/screenshot/route.ts
+++ b/src/app/api/bug-reports/screenshot/route.ts
@@ -1,23 +1,52 @@
 /**
  * POST /api/bug-reports/screenshot
  *
- * Uploads a bug report screenshot to the private `bug-reports` bucket on the
- * user's behalf. Client code cannot write to storage directly because the
- * ops-web Supabase client authenticates via a Firebase JWT, and the storage
- * RLS policy on `bug-reports` requires the Postgres `authenticated` role,
- * which the Firebase bridge does not produce for storage requests.
+ * Uploads a bug report screenshot on the user's behalf. Client code
+ * cannot write to storage directly because the ops-web Supabase client
+ * authenticates via a Firebase JWT, and the legacy storage RLS policy
+ * on the `bug-reports` Supabase bucket required the Postgres
+ * `authenticated` role — which the Firebase bridge does not produce.
  *
- * Security: verifies the caller's Firebase ID token and only allows writes
- * into the caller's own company prefix, so one company cannot clobber
- * another's screenshots.
+ * Phase 1 storage migration:
+ *   - Default backend is `s3`. Screenshots land in
+ *     `ops-app-files-prod` under
+ *     `bug-reports/{companyId}/{reportId}/screenshot.{ext}`.
+ *   - The stored `bug_reports.screenshot_url` value uses an `s3:` URI
+ *     scheme prefix (e.g. `s3:bug-reports/<co>/<rid>/screenshot.jpg`)
+ *     so the read-side resolver in `BugReportService.getScreenshotUrl`
+ *     can tell new S3-backed paths apart from legacy Supabase paths
+ *     during the cutover. Legacy values keep their bucket-relative
+ *     form (no `s3:` prefix) until Phase 2 backfills them.
+ *   - STORAGE_BACKEND=supabase reverts to the legacy private-bucket
+ *     write path (no scheme prefix; resolver falls through to Supabase
+ *     signing).
+ *
+ * Security: verifies the caller's auth token (Supabase or Firebase),
+ * checks the user actually belongs to the company in the request, and
+ * checks the bug report row was created by the same caller.
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { verifyAuthToken } from "@/lib/firebase/admin-verify";
 import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import {
+  getS3Client,
+  S3_BUCKET,
+  getStorageBackend,
+} from "@/lib/s3/client";
 
 const MAX_SIZE = 8 * 1024 * 1024; // 8MB
 const ALLOWED_TYPES = ["image/png", "image/jpeg"] as const;
+
+/**
+ * URI-scheme prefix written into `bug_reports.screenshot_url` for
+ * objects that live in S3. The reader (`BugReportService.
+ * getScreenshotUrl`) uses this to decide whether to S3-presign or
+ * Supabase-presign the path. Phase 2 backfill will rewrite legacy
+ * (no-prefix) values to the `s3:` form.
+ */
+const S3_SCHEME = "s3:";
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
@@ -91,26 +120,58 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const path = `${companyId}/${reportId}/screenshot.${ext}`;
     const buffer = Buffer.from(await file.arrayBuffer());
 
-    const { error: uploadErr } = await supabase.storage
-      .from("bug-reports")
-      .upload(path, buffer, { contentType: file.type, upsert: true });
+    let storedValue: string;
 
-    if (uploadErr) {
-      console.error("[bug-reports/screenshot] Upload failed:", uploadErr.message);
-      return NextResponse.json({ error: uploadErr.message }, { status: 500 });
+    if (getStorageBackend() === "s3") {
+      // Bug-report screenshots are private. We don't need a bucket-level
+      // public-read policy; the read side calls `getSignedUrl` to issue a
+      // short-lived GET URL on demand.
+      const key = `bug-reports/${path}`;
+      try {
+        await getS3Client().send(
+          new PutObjectCommand({
+            Bucket: S3_BUCKET,
+            Key: key,
+            Body: buffer,
+            ContentType: file.type,
+          })
+        );
+      } catch (err) {
+        console.error(
+          "[bug-reports/screenshot] S3 upload failed:",
+          err instanceof Error ? err.message : err
+        );
+        return NextResponse.json(
+          { error: "Screenshot upload failed" },
+          { status: 500 }
+        );
+      }
+      storedValue = `${S3_SCHEME}${key}`;
+    } else {
+      // Legacy Supabase path retained for STORAGE_BACKEND=supabase rollback.
+      const { error: uploadErr } = await supabase.storage
+        .from("bug-reports")
+        .upload(path, buffer, { contentType: file.type, upsert: true });
+
+      if (uploadErr) {
+        console.error("[bug-reports/screenshot] Supabase upload failed:", uploadErr.message);
+        return NextResponse.json({ error: uploadErr.message }, { status: 500 });
+      }
+      storedValue = path;
     }
 
-    // Persist the path on the row so the admin view can resolve it later.
+    // Persist the storage reference on the row so the admin view can
+    // resolve it later via `BugReportService.getScreenshotUrl`.
     const { error: updateErr } = await supabase
       .from("bug_reports")
-      .update({ screenshot_url: path, updated_at: new Date().toISOString() })
+      .update({ screenshot_url: storedValue, updated_at: new Date().toISOString() })
       .eq("id", reportId);
 
     if (updateErr) {
       console.error("[bug-reports/screenshot] Failed to persist path:", updateErr.message);
     }
 
-    return NextResponse.json({ success: true, path });
+    return NextResponse.json({ success: true, path: storedValue });
   } catch (err) {
     console.error("[api/bug-reports/screenshot] Error:", err);
     return NextResponse.json(

--- a/src/app/api/integrations/email/extract-images/route.ts
+++ b/src/app/api/integrations/email/extract-images/route.ts
@@ -14,12 +14,24 @@
  * }
  *
  * Runs in the background via after(); pulls image attachments from email
- * threads and uploads them to Supabase Storage. Split from the main import
- * route because the attachment fetch+upload cycle can easily exceed the
- * import route's 300s maxDuration budget, leaving import jobs stuck in
- * 'importing' status indefinitely. This route has its own 800s budget
- * (Vercel Pro max) and writes back to gmail_scan_jobs.result.imagesExtracted
- * when finished.
+ * threads and uploads them to the OPS storage backend (S3 by default;
+ * Supabase under STORAGE_BACKEND=supabase for rollback). Split from the
+ * main import route because the attachment fetch+upload cycle can easily
+ * exceed the import route's 300s maxDuration budget, leaving import jobs
+ * stuck in 'importing' status indefinitely. This route has its own 800s
+ * budget (Vercel Pro max) and writes back to gmail_scan_jobs.result.
+ * imagesExtracted when finished.
+ *
+ * Phase 1 storage migration:
+ *   - Default backend is `s3`. Keys are company-scoped:
+ *     `email-imports/{companyId}/{opportunityId}/{ts}-{rand}.{ext}` —
+ *     differs from the legacy Supabase path (which omitted companyId)
+ *     so a future tenant audit can attribute every byte to a company.
+ *   - Setting STORAGE_BACKEND=supabase falls back to the legacy
+ *     Supabase Storage code path (same key shape it used before).
+ *   - 94% of historical Supabase Storage bytes flowed through this
+ *     route, so the cutover here is the largest single behavior change
+ *     of the migration.
  *
  * Uses runWithSupabase (not setSupabaseOverride) so the service-role client
  * binding survives the entire async extraction chain without being clobbered
@@ -28,9 +40,16 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { after } from "next/server";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getServiceRoleClient } from "@/lib/supabase/server-client";
 import { runWithSupabase } from "@/lib/supabase/helpers";
 import { EmailService } from "@/lib/api/services/email-service";
+import {
+  getS3Client,
+  S3_BUCKET,
+  buildPublicS3Url,
+  getStorageBackend,
+} from "@/lib/s3/client";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 export const maxDuration = 800; // Pro plan max
@@ -76,7 +95,7 @@ export async function POST(request: NextRequest) {
     const bgSupabase = getServiceRoleClient();
     await runWithSupabase(bgSupabase, async () => {
       try {
-        await runExtraction(jobId, connection, oppThreadPayload, bgSupabase);
+        await runExtraction(jobId, companyId, connection, oppThreadPayload, bgSupabase);
       } catch (err) {
         console.error("[extract-images] Extraction failed:", err);
       }
@@ -90,6 +109,7 @@ export async function POST(request: NextRequest) {
 
 async function runExtraction(
   jobId: string,
+  companyId: string,
   connection: NonNullable<Awaited<ReturnType<typeof EmailService.getConnection>>>,
   oppThreadPayload: OppThreadEntry[],
   supabase: SupabaseClient
@@ -97,9 +117,10 @@ async function runExtraction(
   const provider = EmailService.getProvider(connection);
 
   const MAX_IMAGES_PER_LEAD = 10;
-  const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB (matches Supabase bucket limit)
+  const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB (matches bucket / IAM cap)
   const IMAGE_CONCURRENCY = 3;
 
+  const backend = getStorageBackend();
   let totalExtracted = 0;
 
   for (const entry of oppThreadPayload) {
@@ -156,25 +177,36 @@ async function runExtraction(
         const results = await Promise.allSettled(
           batch.map(async (img) => {
             const buffer = await provider.fetchAttachment(img.messageId, img.attachmentId);
+            const ext = (img.filename.split(".").pop()?.toLowerCase() || "jpg")
+              .replace(/[^a-z0-9]/g, "")
+              .slice(0, 12) || "jpg";
+            const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
-            const ext = img.filename.split(".").pop()?.toLowerCase() || "jpg";
-            const storagePath = `email-imports/${opportunityId}/${Date.now()}-${Math.random()
-              .toString(36)
-              .slice(2, 8)}.${ext}`;
+            if (backend === "s3") {
+              const key = `email-imports/${companyId}/${opportunityId}/${unique}.${ext}`;
+              await getS3Client().send(
+                new PutObjectCommand({
+                  Bucket: S3_BUCKET,
+                  Key: key,
+                  Body: buffer,
+                  ContentType: img.mimeType,
+                })
+              );
+              return buildPublicS3Url(key);
+            }
 
+            // Legacy Supabase path — preserved verbatim for STORAGE_BACKEND=supabase rollback.
+            const storagePath = `email-imports/${opportunityId}/${unique}.${ext}`;
             const { error: uploadErr } = await supabase.storage
               .from("images")
               .upload(storagePath, buffer, {
                 contentType: img.mimeType,
                 upsert: false,
               });
-
             if (uploadErr) throw new Error(`Upload failed: ${uploadErr.message}`);
-
             const { data: urlData } = supabase.storage
               .from("images")
               .getPublicUrl(storagePath);
-
             return urlData.publicUrl;
           })
         );
@@ -205,7 +237,7 @@ async function runExtraction(
   }
 
   console.log(
-    `[extract-images] Complete: ${totalExtracted} images uploaded across ${oppThreadPayload.length} opportunities`
+    `[extract-images] Complete: ${totalExtracted} images uploaded across ${oppThreadPayload.length} opportunities (backend=${backend})`
   );
 
   // Merge imagesExtracted into the existing gmail_scan_jobs.result payload.

--- a/src/app/api/uploads/presign/route.ts
+++ b/src/app/api/uploads/presign/route.ts
@@ -1,34 +1,192 @@
 /**
- * OPS Web - Image Upload API Route
+ * OPS Web — Image Upload API Route
  *
- * Two flows:
- * 1. Presign (iOS): application/x-www-form-urlencoded with filename, contentType, folder
- *    → returns { uploadUrl, publicUrl } for client-side PUT
- * 2. Direct upload (Web): multipart/form-data with file
- *    → uploads immediately, returns { url, publicUrl }
+ * Three flows, distinguished by the request `Content-Type`:
+ *   1. Presign (iOS):     application/x-www-form-urlencoded
+ *      params: filename, contentType, folder
+ *      → returns { uploadUrl, publicUrl } for client-side PUT to S3
+ *   2. Presign (Web):     application/json
+ *      body:   { filename, contentType, folder }
+ *      → returns { uploadUrl, publicUrl } for client-side PUT to S3
+ *   3. Direct upload:     multipart/form-data
+ *      fields: file, folder?
+ *      → uploads immediately, returns { url, publicUrl }
+ *
+ * Phase 1 storage migration (Supabase Storage → S3):
+ *   - Default backend is `s3` (writes into `ops-app-files-prod`).
+ *   - Setting STORAGE_BACKEND=supabase in env reverts to the legacy
+ *     Supabase Storage code path (rollback without redeploying code).
+ *   - PR #28's training_data/ JSON carve-out is preserved on both
+ *     backends so iOS deck-scanner cleanup-edit log uploads keep
+ *     working through the cutover.
+ *
+ * Security tightening shipped with this rewrite:
+ *   - `Authorization: Bearer <token>` is now required (Supabase iOS or
+ *     Firebase web). Anonymous calls are rejected.
+ *   - The caller's `company_id` is looked up from the `users` table and
+ *     enforced as a path segment in the resolved S3 key — see
+ *     `src/lib/s3/path-auth.ts`. A folder that names a *different*
+ *     company UUID is refused.
+ *   - Filenames are sanitized to strip path-traversal segments and
+ *     non-portable characters before they flow into the S3 key.
+ *   - The presigned PUT URL pins `Content-Type` so a `.jpg` presign
+ *     cannot be used to upload an `.html` payload.
+ *   - Per-uid sliding-window rate limit (30 presigns / minute) backed
+ *     by Vercel KV (Upstash Redis), with in-memory fallback in dev.
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { verifyAuthToken } from "@/lib/firebase/admin-verify";
 import { getServiceRoleClient } from "@/lib/supabase/server-client";
+import {
+  getS3Client,
+  S3_BUCKET,
+  buildPublicS3Url,
+  getStorageBackend,
+} from "@/lib/s3/client";
+import {
+  authorizeFolder,
+  sanitizeFilename,
+  inferExtension,
+  buildUniqueSuffix,
+} from "@/lib/s3/path-auth";
+import { rateLimit } from "@/lib/utils/ratelimit";
 
-const ALLOWED_TYPES = [
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const ALLOWED_IMAGE_TYPES = [
   "image/jpeg",
   "image/png",
   "image/webp",
   "image/heic",
-];
+] as const;
+
+// Folder prefixes allowed to upload non-image content via presign.
+// Currently scoped to deck-scanner cleanup-edit JSON logs (see iOS
+// `CleanupEditLogger.uploadPending()` — branch `claude/deck-scanner-rebuild`,
+// commit 9dffeb7) which ship base64-embedded crops + cleanup metadata to
+// `training_data/deck_scanner/{company_id}/{user_id}/{yyyy-mm-dd}/{entry_id}.json`
+// for the upcoming deck-scanner ML model training set.
+//
+// Rules for additions to this list:
+//   1. Must be an internal write path the iOS/web app fully controls — no
+//      user-supplied folder values reach this carve-out.
+//   2. Pair with an explicit content-type allowlist (`TRAINING_DATA_TYPES`).
+//   3. Per-object size is hard-capped at the route level (10 MB) AND at
+//      the bucket level (S3 IAM policy on the dedicated upload user).
+const TRAINING_DATA_PREFIXES = ["training_data/"] as const;
+const TRAINING_DATA_TYPES = ["application/json"] as const;
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB — matches the legacy bucket cap.
+const PRESIGN_EXPIRY_SECONDS = 7200; // 2 hours — matches Supabase upload-URL expiry.
+const RATE_LIMIT_PER_MINUTE = 30;
+
+function isTrainingDataPath(folder: string): boolean {
+  return TRAINING_DATA_PREFIXES.some((prefix) => folder.startsWith(prefix));
+}
+
+function isAllowedContentType(contentType: string, folder: string): boolean {
+  if ((ALLOWED_IMAGE_TYPES as readonly string[]).includes(contentType)) {
+    return true;
+  }
+  if (
+    isTrainingDataPath(folder) &&
+    (TRAINING_DATA_TYPES as readonly string[]).includes(contentType)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function defaultExtensionFor(contentType: string): string {
+  if (contentType === "image/png") return "png";
+  if (contentType === "image/webp") return "webp";
+  if (contentType === "image/heic") return "heic";
+  if (contentType === "application/json") return "json";
+  return "jpg";
+}
+
+interface AuthContext {
+  uid: string;
+  companyId: string;
+}
+
+/**
+ * Resolve the caller's auth token into a uid + their company_id. Both
+ * branches of the auth bridge (Supabase JWT for iOS, Firebase JWT for
+ * web) flow through `verifyAuthToken`, and the `users` table holds
+ * either form of uid in `auth_id` or `firebase_uid`.
+ */
+async function resolveAuth(req: NextRequest): Promise<AuthContext | NextResponse> {
+  const authHeader = req.headers.get("authorization") ?? "";
+  const idToken = authHeader.replace(/^Bearer\s+/i, "");
+  if (!idToken) {
+    return NextResponse.json(
+      { error: "Missing Authorization bearer token" },
+      { status: 401 }
+    );
+  }
+
+  let uid: string;
+  try {
+    const verified = await verifyAuthToken(idToken);
+    uid = verified.uid;
+  } catch {
+    return NextResponse.json({ error: "Invalid auth token" }, { status: 401 });
+  }
+
+  const supabase = getServiceRoleClient();
+  const { data: userRow, error: userErr } = await supabase
+    .from("users")
+    .select("id, company_id")
+    .or(`auth_id.eq.${uid},firebase_uid.eq.${uid}`)
+    .maybeSingle();
+
+  if (userErr || !userRow || !userRow.company_id) {
+    return NextResponse.json(
+      { error: "User has no company association" },
+      { status: 403 }
+    );
+  }
+
+  return { uid, companyId: userRow.company_id as string };
+}
+
+async function checkRateLimit(uid: string): Promise<NextResponse | null> {
+  const result = await rateLimit({
+    key: `presign:${uid}`,
+    limit: RATE_LIMIT_PER_MINUTE,
+    windowSec: 60,
+  });
+  if (result.exceeded) {
+    return NextResponse.json(
+      { error: "Rate limit exceeded" },
+      {
+        status: 429,
+        headers: { "Retry-After": String(result.retryAfterSec) },
+      }
+    );
+  }
+  return null;
+}
+
+// ─── Route handler ──────────────────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
   try {
-    const contentType = req.headers.get("content-type") || "";
+    const contentType = req.headers.get("content-type") ?? "";
 
-    // Flow 1: Presign request (iOS client)
     if (contentType.includes("application/x-www-form-urlencoded")) {
-      return handlePresign(req);
+      return await handlePresign(req, await readUrlencodedBody(req));
     }
-
-    // Flow 2: Direct upload (Web client)
-    return handleDirectUpload(req);
+    if (contentType.includes("application/json")) {
+      return await handlePresign(req, await readJsonBody(req));
+    }
+    // multipart/form-data and anything else falls to the direct upload
+    // path — the original behavior for `image-service.ts` callers.
+    return await handleDirectUpload(req);
   } catch (err) {
     console.error("[uploads/presign] Error:", err);
     return NextResponse.json(
@@ -38,15 +196,41 @@ export async function POST(req: NextRequest) {
   }
 }
 
-/**
- * iOS presign flow: generate a signed upload URL for the client to PUT to directly
- */
-async function handlePresign(req: NextRequest) {
-  const body = await req.text();
-  const params = new URLSearchParams(body);
-  const filename = params.get("filename");
-  const fileContentType = params.get("contentType");
-  const folder = params.get("folder") || "uploads";
+// ─── Body parsers ───────────────────────────────────────────────────────────
+
+interface PresignBody {
+  filename: string | null;
+  contentType: string | null;
+  folder: string | null;
+}
+
+async function readUrlencodedBody(req: NextRequest): Promise<PresignBody> {
+  const text = await req.text();
+  const params = new URLSearchParams(text);
+  return {
+    filename: params.get("filename"),
+    contentType: params.get("contentType"),
+    folder: params.get("folder"),
+  };
+}
+
+async function readJsonBody(req: NextRequest): Promise<PresignBody> {
+  const json = (await req.json()) as Record<string, unknown>;
+  return {
+    filename: typeof json.filename === "string" ? json.filename : null,
+    contentType:
+      typeof json.contentType === "string" ? json.contentType : null,
+    folder: typeof json.folder === "string" ? json.folder : null,
+  };
+}
+
+// ─── Presign flow (iOS + Web JSON) ──────────────────────────────────────────
+
+async function handlePresign(
+  req: NextRequest,
+  body: PresignBody
+): Promise<NextResponse> {
+  const { filename, contentType: fileContentType, folder: rawFolder } = body;
 
   if (!filename || !fileContentType) {
     return NextResponse.json(
@@ -55,35 +239,83 @@ async function handlePresign(req: NextRequest) {
     );
   }
 
-  if (!ALLOWED_TYPES.includes(fileContentType)) {
+  const auth = await resolveAuth(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const limited = await checkRateLimit(auth.uid);
+  if (limited) return limited;
+
+  const folderInput = rawFolder ?? "uploads";
+  if (!isAllowedContentType(fileContentType, folderInput)) {
     return NextResponse.json(
       { error: `Invalid content type: ${fileContentType}` },
       { status: 400 }
     );
   }
 
-  const timestamp = Date.now();
-  const random = Math.random().toString(36).slice(2, 8);
-  const ext = filename.split(".").pop() || "jpg";
-  const filePath = `${folder}/${timestamp}-${random}.${ext}`;
+  const folderResult = authorizeFolder(folderInput, auth.companyId);
+  if (!folderResult.ok) {
+    return NextResponse.json({ error: folderResult.reason }, { status: 403 });
+  }
 
+  const cleanFilename = sanitizeFilename(filename);
+  const ext = inferExtension(cleanFilename, defaultExtensionFor(fileContentType));
+  const key = `${folderResult.folder}/${buildUniqueSuffix()}.${ext}`;
+
+  if (getStorageBackend() === "supabase") {
+    return handlePresignSupabase(key, fileContentType);
+  }
+  return handlePresignS3(key, fileContentType);
+}
+
+async function handlePresignS3(
+  key: string,
+  fileContentType: string
+): Promise<NextResponse> {
+  // `ContentType` is included in the signed-headers set so the client
+  // PUT must declare the same value — preventing a JPEG presign from
+  // being reused to upload arbitrary HTML/JS.
+  const command = new PutObjectCommand({
+    Bucket: S3_BUCKET,
+    Key: key,
+    ContentType: fileContentType,
+  });
+
+  const uploadUrl = await getSignedUrl(getS3Client(), command, {
+    expiresIn: PRESIGN_EXPIRY_SECONDS,
+    signableHeaders: new Set(["content-type"]),
+  });
+
+  return NextResponse.json({
+    uploadUrl,
+    publicUrl: buildPublicS3Url(key),
+  });
+}
+
+async function handlePresignSupabase(
+  key: string,
+  _fileContentType: string
+): Promise<NextResponse> {
+  // Legacy code path retained for STORAGE_BACKEND=supabase rollback.
+  // Removed in Phase 3.
   const supabase = getServiceRoleClient();
 
   const { data: signedData, error: signError } = await supabase.storage
     .from("images")
-    .createSignedUploadUrl(filePath);
+    .createSignedUploadUrl(key);
 
   if (signError || !signedData) {
-    console.error("[uploads/presign] Signed URL creation failed:", signError?.message);
+    console.error(
+      "[uploads/presign] Supabase signed URL failed:",
+      signError?.message
+    );
     return NextResponse.json(
       { error: signError?.message || "Failed to create signed URL" },
       { status: 500 }
     );
   }
 
-  const { data: urlData } = supabase.storage
-    .from("images")
-    .getPublicUrl(filePath);
+  const { data: urlData } = supabase.storage.from("images").getPublicUrl(key);
 
   return NextResponse.json({
     uploadUrl: signedData.signedUrl,
@@ -91,20 +323,24 @@ async function handlePresign(req: NextRequest) {
   });
 }
 
-/**
- * Web direct upload flow: receive file and upload to Supabase Storage immediately
- */
-async function handleDirectUpload(req: NextRequest) {
-  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+// ─── Direct upload flow (web `uploadImage()`) ───────────────────────────────
+
+async function handleDirectUpload(req: NextRequest): Promise<NextResponse> {
+  const auth = await resolveAuth(req);
+  if (auth instanceof NextResponse) return auth;
+
+  const limited = await checkRateLimit(auth.uid);
+  if (limited) return limited;
+
   const formData = await req.formData();
   const file = formData.get("file") as File | null;
-  const folder = (formData.get("folder") as string) || "uploads";
+  const rawFolder = (formData.get("folder") as string | null) ?? "uploads";
 
   if (!file) {
     return NextResponse.json({ error: "No file provided" }, { status: 400 });
   }
 
-  if (!ALLOWED_TYPES.includes(file.type)) {
+  if (!isAllowedContentType(file.type, rawFolder)) {
     return NextResponse.json(
       { error: `Invalid file type: ${file.type}` },
       { status: 400 }
@@ -118,32 +354,70 @@ async function handleDirectUpload(req: NextRequest) {
     );
   }
 
-  const ext = file.name.split(".").pop() || "jpg";
-  const timestamp = Date.now();
-  const random = Math.random().toString(36).slice(2, 8);
-  const filePath = `${folder}/${timestamp}-${random}.${ext}`;
+  const folderResult = authorizeFolder(rawFolder, auth.companyId);
+  if (!folderResult.ok) {
+    return NextResponse.json({ error: folderResult.reason }, { status: 403 });
+  }
 
-  const supabase = getServiceRoleClient();
+  const cleanFilename = sanitizeFilename(file.name);
+  const ext = inferExtension(cleanFilename, defaultExtensionFor(file.type));
+  const key = `${folderResult.folder}/${buildUniqueSuffix()}.${ext}`;
+
   const buffer = Buffer.from(await file.arrayBuffer());
+
+  if (getStorageBackend() === "supabase") {
+    return handleDirectUploadSupabase(key, buffer, file.type);
+  }
+  return handleDirectUploadS3(key, buffer, file.type);
+}
+
+async function handleDirectUploadS3(
+  key: string,
+  buffer: Buffer,
+  fileContentType: string
+): Promise<NextResponse> {
+  await getS3Client().send(
+    new PutObjectCommand({
+      Bucket: S3_BUCKET,
+      Key: key,
+      Body: buffer,
+      ContentType: fileContentType,
+    })
+  );
+
+  const url = buildPublicS3Url(key);
+  return NextResponse.json({ url, publicUrl: url });
+}
+
+async function handleDirectUploadSupabase(
+  key: string,
+  buffer: Buffer,
+  fileContentType: string
+): Promise<NextResponse> {
+  const supabase = getServiceRoleClient();
 
   const { error: uploadError } = await supabase.storage
     .from("images")
-    .upload(filePath, buffer, {
-      contentType: file.type,
+    .upload(key, buffer, {
+      contentType: fileContentType,
       upsert: false,
     });
 
   if (uploadError) {
-    console.error("[uploads/presign] Upload failed:", uploadError.message);
+    console.error(
+      "[uploads/presign] Supabase upload failed:",
+      uploadError.message
+    );
     return NextResponse.json(
       { error: uploadError.message },
       { status: 500 }
     );
   }
 
-  const { data: urlData } = supabase.storage
-    .from("images")
-    .getPublicUrl(filePath);
+  const { data: urlData } = supabase.storage.from("images").getPublicUrl(key);
 
-  return NextResponse.json({ url: urlData.publicUrl, publicUrl: urlData.publicUrl });
+  return NextResponse.json({
+    url: urlData.publicUrl,
+    publicUrl: urlData.publicUrl,
+  });
 }

--- a/src/lib/admin/admin-queries.ts
+++ b/src/lib/admin/admin-queries.ts
@@ -830,6 +830,33 @@ export async function updateBugReportPriority(id: string, priority: string) {
  */
 export async function getBugReportScreenshotSignedUrl(path: string | null): Promise<string | null> {
   if (!path) return null;
+
+  // Storage migration (Supabase → S3): values written after the Phase 1
+  // cutover use an `s3:` URI scheme prefix to mark the underlying
+  // backend. Older values are bucket-relative Supabase Storage paths.
+  if (path.startsWith("s3:")) {
+    const key = path.slice("s3:".length);
+    // Defer the S3 imports so admin queries that never resolve a
+    // screenshot don't pay the SDK init cost.
+    const { GetObjectCommand } = await import("@aws-sdk/client-s3");
+    const { getSignedUrl } = await import("@aws-sdk/s3-request-presigner");
+    const { getS3Client, S3_BUCKET } = await import("@/lib/s3/client");
+    try {
+      const url = await getSignedUrl(
+        getS3Client(),
+        new GetObjectCommand({ Bucket: S3_BUCKET, Key: key }),
+        { expiresIn: 3600 }
+      );
+      return url;
+    } catch (err) {
+      console.error(
+        "[getBugReportScreenshotSignedUrl] S3 presign failed:",
+        err instanceof Error ? err.message : err
+      );
+      return null;
+    }
+  }
+
   const { data, error } = await db().storage.from("bug-reports").createSignedUrl(path, 3600);
   if (error) return null;
   return data?.signedUrl ?? null;

--- a/src/lib/api/services/bug-report-service.ts
+++ b/src/lib/api/services/bug-report-service.ts
@@ -326,30 +326,32 @@ export const BugReportService = {
   },
 
   /**
-   * Upload a screenshot to the private `bug-reports` bucket and return the
-   * storage path. Admin views must call `getScreenshotUrl(path)` to produce a
-   * short-lived signed URL for display — the stored value is not a direct URL.
+   * Resolve a `bug_reports.screenshot_url` value to a short-lived URL
+   * the admin UI can render. Two storage backends coexist during the
+   * Phase 1 → Phase 2 cutover:
+   *
+   *   - Values starting with `s3:` reference an object key in the
+   *     `ops-app-files-prod` bucket (written by
+   *     `/api/bug-reports/screenshot` after the Phase 1 cutover) — we
+   *     issue an S3 presigned GET URL.
+   *   - All other values are bucket-relative paths in the legacy
+   *     Supabase Storage `bug-reports` bucket (written before the
+   *     cutover, or during STORAGE_BACKEND=supabase rollback) — we
+   *     issue a Supabase signed URL.
+   *
+   * Phase 2 backfill rewrites legacy values to the `s3:` form; Phase 3
+   * removes the Supabase branch.
    */
-  async uploadScreenshot(
-    companyId: string,
-    reportId: string,
-    file: File | Blob,
-    contentType: string = "image/png"
-  ): Promise<string> {
-    const supabase = requireSupabase();
-    const ext = contentType === "image/jpeg" ? "jpg" : "png";
-    const path = `${companyId}/${reportId}/screenshot.${ext}`;
-
-    const { error } = await supabase.storage
-      .from("bug-reports")
-      .upload(path, file, { contentType, upsert: true });
-
-    if (error) throw new Error(`Failed to upload screenshot: ${error.message}`);
-
-    return path;
-  },
-
   async getScreenshotUrl(path: string): Promise<string> {
+    if (path.startsWith("s3:")) {
+      // Defer to the admin-side resolver, which has access to the
+      // server-only S3 SDK and IAM credentials.
+      const { getBugReportScreenshotSignedUrl } = await import(
+        "@/lib/admin/admin-queries"
+      );
+      const url = await getBugReportScreenshotSignedUrl(path);
+      return url ?? "";
+    }
     const supabase = requireSupabase();
     const { data } = await supabase.storage
       .from("bug-reports")

--- a/src/lib/s3/client.ts
+++ b/src/lib/s3/client.ts
@@ -1,0 +1,62 @@
+/**
+ * S3 client factory for the OPS storage migration (Supabase → S3).
+ *
+ * Single source of truth for the AWS SDK client + bucket + region. All
+ * server-side upload routes (`/api/uploads/presign`,
+ * `/api/integrations/email/extract-images`, `/api/admin/blog/upload`,
+ * `/api/bug-reports/screenshot`, `/api/admin/shop/upload`,
+ * `/api/documents/generate-pdf`) should import from here so credential
+ * resolution and region are consistent and rotatable from one place.
+ *
+ * Region / bucket defaults match the prior implementations in the legacy
+ * routes (`us-west-2`, `ops-app-files-prod`) so a missing env var does
+ * not silently land objects in the wrong bucket.
+ */
+
+import { S3Client } from "@aws-sdk/client-s3";
+
+export const S3_REGION = process.env.AWS_REGION ?? "us-west-2";
+export const S3_BUCKET = process.env.AWS_S3_BUCKET ?? "ops-app-files-prod";
+
+let _client: S3Client | null = null;
+
+/**
+ * Returns a memoized S3 client. The AWS SDK reuses HTTP connections
+ * inside a single client instance, so handing every route the same
+ * client (rather than constructing one per request) reduces cold-start
+ * latency in serverless environments.
+ */
+export function getS3Client(): S3Client {
+  if (_client) return _client;
+
+  _client = new S3Client({
+    region: S3_REGION,
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? "",
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? "",
+    },
+  });
+  return _client;
+}
+
+/**
+ * Build the public virtual-hosted–style URL for an object in the OPS
+ * bucket. Used as the canonical "publicUrl" stored in database columns
+ * after an upload completes.
+ */
+export function buildPublicS3Url(key: string): string {
+  return `https://${S3_BUCKET}.s3.${S3_REGION}.amazonaws.com/${key}`;
+}
+
+/**
+ * Storage backend selector for the Phase 1 cutover. Defaults to "s3"
+ * once the cutover lands; setting STORAGE_BACKEND=supabase in Vercel
+ * env reverts to the legacy Supabase Storage code path without a code
+ * deploy. Phase 3 removes the Supabase branch entirely.
+ */
+export type StorageBackend = "s3" | "supabase";
+
+export function getStorageBackend(): StorageBackend {
+  const value = (process.env.STORAGE_BACKEND ?? "s3").toLowerCase();
+  return value === "supabase" ? "supabase" : "s3";
+}

--- a/src/lib/s3/path-auth.ts
+++ b/src/lib/s3/path-auth.ts
@@ -1,0 +1,149 @@
+/**
+ * Folder-and-filename validation for the presign upload endpoint.
+ *
+ * The presign route lets authenticated callers obtain short-lived PUT
+ * URLs into the OPS S3 bucket. Without these checks a token holder for
+ * Company A could craft a `folder` parameter that targets Company B's
+ * prefix, or smuggle path-traversal segments to overwrite paths outside
+ * their scope. These helpers enforce three properties:
+ *
+ *   1. Folder strings are sanitized — no `..`, no leading `/`, no
+ *      embedded NUL bytes or whitespace tricks.
+ *   2. Filenames likewise — extracted extension, no traversal, no
+ *      stray slashes.
+ *   3. The resolved S3 key always contains the caller's `companyId` as
+ *      one of its path segments. Callers that omit it get it prepended
+ *      automatically (back-compat for legacy folder values like
+ *      `"profiles"` or `"projects/{projectId}"`); callers that include
+ *      a different UUID-shaped segment that doesn't match their
+ *      companyId are rejected (an attempted cross-tenant write).
+ */
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SAFE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+
+export interface FolderAuthSuccess {
+  ok: true;
+  /** Cleaned, company-scoped folder ready to compose into an S3 key. */
+  folder: string;
+}
+
+export interface FolderAuthFailure {
+  ok: false;
+  reason: string;
+}
+
+export type FolderAuthResult = FolderAuthSuccess | FolderAuthFailure;
+
+/**
+ * Normalize and authorize an upload folder for a caller. Returns the
+ * cleaned folder (guaranteed to contain `callerCompanyId` somewhere in
+ * its path) on success, or an explanation on failure.
+ *
+ * Examples (callerCompanyId = "abc-123"):
+ *   "projects/abc-123/proj-9"        → ok, "projects/abc-123/proj-9"
+ *   "profiles"                       → ok, "profiles/abc-123"
+ *   "projects/proj-9"                → ok, "projects/proj-9/abc-123"
+ *   "projects/00000000-0000-0000-0000-000000000000/x"
+ *                                    → fail (foreign company UUID)
+ *   "../etc/passwd"                  → fail (traversal)
+ *   ""                               → ok, "abc-123"
+ */
+export function authorizeFolder(
+  rawFolder: string | null | undefined,
+  callerCompanyId: string
+): FolderAuthResult {
+  if (!callerCompanyId || !UUID_RE.test(callerCompanyId)) {
+    return { ok: false, reason: "Invalid callerCompanyId" };
+  }
+
+  const folder = (rawFolder ?? "").trim();
+
+  // Reject obvious traversal / control characters before splitting.
+  if (folder.includes("..") || /\0|\r|\n/.test(folder)) {
+    return { ok: false, reason: "Folder contains illegal segments" };
+  }
+
+  // Strip leading/trailing slashes; ignore consecutive slashes by
+  // filtering empty segments.
+  const segments = folder
+    .replace(/^\/+|\/+$/g, "")
+    .split("/")
+    .filter((s) => s.length > 0);
+
+  for (const seg of segments) {
+    if (!SAFE_SEGMENT_RE.test(seg)) {
+      return {
+        ok: false,
+        reason: `Folder segment ${JSON.stringify(seg)} contains illegal characters`,
+      };
+    }
+  }
+
+  // If a UUID-shaped segment is present and isn't the caller's, this
+  // is almost certainly a cross-tenant attempt — refuse it. (Random
+  // projectIds and entity IDs are also UUIDs, but they're scoped under
+  // the caller's company segment if used legitimately. A stray UUID at
+  // any position that isn't ours fails closed.)
+  const foreignUuid = segments.find(
+    (seg) => UUID_RE.test(seg) && seg.toLowerCase() !== callerCompanyId.toLowerCase()
+  );
+  const callerPresent = segments.some(
+    (seg) => seg.toLowerCase() === callerCompanyId.toLowerCase()
+  );
+  if (foreignUuid && !callerPresent) {
+    return {
+      ok: false,
+      reason: `Folder references a different company (${foreignUuid})`,
+    };
+  }
+
+  if (!callerPresent) {
+    // Legacy callers (e.g. web `image-service.ts` sending folder "uploads")
+    // don't include the companyId. Append it so the resolved S3 key is
+    // always company-scoped, even if the client forgot.
+    segments.push(callerCompanyId);
+  }
+
+  return { ok: true, folder: segments.join("/") };
+}
+
+/**
+ * Sanitize a user-supplied filename. Returns just the basename (no
+ * directory components), with traversal sequences and control
+ * characters stripped. Empty / unsafe input falls back to `"upload"`.
+ */
+export function sanitizeFilename(rawFilename: string | null | undefined): string {
+  if (!rawFilename) return "upload";
+  // Last path component only — drop any directory traversal trickery.
+  const base = rawFilename.split(/[\\/]/).pop() ?? "";
+  const cleaned = base
+    .replace(/\.{2,}/g, ".")
+    .replace(/[\0\r\n]/g, "")
+    .replace(/[^A-Za-z0-9._-]/g, "_")
+    .replace(/^[._-]+/, "");
+  return cleaned.length > 0 ? cleaned : "upload";
+}
+
+/**
+ * Pull the extension from a sanitized filename. Returns an extension
+ * without the leading dot (e.g. `"jpg"`). Falls back to `defaultExt`
+ * if the filename has no extension or only a leading dot.
+ */
+export function inferExtension(filename: string, defaultExt: string): string {
+  const idx = filename.lastIndexOf(".");
+  if (idx <= 0 || idx === filename.length - 1) return defaultExt;
+  const ext = filename.slice(idx + 1).toLowerCase();
+  return /^[a-z0-9]+$/.test(ext) ? ext : defaultExt;
+}
+
+/**
+ * Build the random "{timestamp}-{random}" component used in upload
+ * keys. Centralized so all callers produce keys with the same shape
+ * and the migration scripts (Phase 2) can recognize them.
+ */
+export function buildUniqueSuffix(): string {
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).slice(2, 10);
+  return `${timestamp}-${random}`;
+}

--- a/tests/integration/bug-reports-screenshot-s3.test.ts
+++ b/tests/integration/bug-reports-screenshot-s3.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Integration tests for POST /api/bug-reports/screenshot after the
+ * Phase 1 cutover.
+ *
+ * Verifies:
+ *   - Auth + company-membership + reporter checks fire as before.
+ *   - On STORAGE_BACKEND=s3 (default): the file is sent to S3 with
+ *     `Bucket=ops-app-files-prod`, `Key=bug-reports/{co}/{rid}/screenshot.{ext}`,
+ *     and the row's `screenshot_url` is persisted with the `s3:`
+ *     scheme prefix the reader can detect.
+ *   - On STORAGE_BACKEND=supabase: the file is uploaded to the legacy
+ *     private Supabase bucket and `screenshot_url` is the bucket-
+ *     relative path (no `s3:` prefix) — preserving existing reader
+ *     behavior for rollback.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const verifyAuthTokenMock = vi.fn();
+vi.mock("@/lib/firebase/admin-verify", () => ({
+  verifyAuthToken: (token: string) => verifyAuthTokenMock(token),
+}));
+
+interface UserRow {
+  id: string;
+  company_id: string;
+}
+interface ReportRow {
+  id: string;
+  company_id: string;
+  reporter_id: string;
+}
+
+const usersByUid = new Map<string, UserRow | null>();
+const reportsById = new Map<string, ReportRow | null>();
+const bugReportUpdates: Array<{ id: string; patch: Record<string, unknown> }> = [];
+
+const supabaseUploadMock = vi.fn();
+
+function makeSupabaseStub() {
+  return {
+    from: (table: string) => {
+      if (table === "users") {
+        let uidFilter = "";
+        const b = {
+          select: () => b,
+          or: (clause: string) => {
+            const m = clause.match(/auth_id\.eq\.([^,]+)/);
+            uidFilter = m?.[1] ?? "";
+            return b;
+          },
+          maybeSingle: async () => ({ data: usersByUid.get(uidFilter) ?? null, error: null }),
+        };
+        return b;
+      }
+      if (table === "bug_reports") {
+        let idFilter = "";
+        let pendingUpdate: Record<string, unknown> | null = null;
+        const b: Record<string, unknown> = {};
+        Object.assign(b, {
+          select: () => b,
+          eq: (_col: string, val: string) => {
+            idFilter = val;
+            if (pendingUpdate) {
+              bugReportUpdates.push({ id: idFilter, patch: pendingUpdate });
+              pendingUpdate = null;
+              return Promise.resolve({ error: null });
+            }
+            return b;
+          },
+          maybeSingle: async () => ({ data: reportsById.get(idFilter) ?? null, error: null }),
+          update: (vals: Record<string, unknown>) => {
+            pendingUpdate = vals;
+            return b;
+          },
+        });
+        return b;
+      }
+      throw new Error(`Unexpected table in test: ${table}`);
+    },
+    storage: {
+      from: () => ({
+        upload: (path: string, body: unknown, opts: unknown) =>
+          supabaseUploadMock(path, body, opts),
+      }),
+    },
+  };
+}
+
+vi.mock("@/lib/supabase/server-client", () => ({
+  getServiceRoleClient: () => makeSupabaseStub(),
+}));
+
+const s3SendMock = vi.fn();
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class {},
+  PutObjectCommand: class {
+    input: Record<string, unknown>;
+    constructor(input: Record<string, unknown>) {
+      this.input = input;
+    }
+  },
+}));
+
+vi.mock("@/lib/s3/client", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/s3/client")>(
+    "@/lib/s3/client"
+  );
+  return {
+    ...actual,
+    getS3Client: () => ({ send: (cmd: unknown) => s3SendMock(cmd) }),
+  };
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function loadRoute() {
+  const mod = await import("@/app/api/bug-reports/screenshot/route");
+  return mod.POST;
+}
+
+/**
+ * Build a mock NextRequest with a pre-populated `formData()` and
+ * `headers.get()`. The route only uses these two surfaces; standing
+ * up a real Request body in vitest+jsdom is impractical because
+ * undici's multipart parser cannot reconstruct File entries from a
+ * hand-rolled body.
+ */
+function makeRequest(
+  fields: Record<string, string>,
+  file: { content: Uint8Array; filename: string; contentType: string } | null,
+  headers: Record<string, string> = {}
+): unknown {
+  const formEntries = new Map<string, FormDataEntryValue>();
+  for (const [k, v] of Object.entries(fields)) {
+    formEntries.set(k, v);
+  }
+  if (file) {
+    // jsdom's File implementation lacks `.arrayBuffer()`. Build the
+    // smallest object that exposes the surface the route actually uses
+    // (`type`, `size`, `arrayBuffer()`).
+    const fileLike = {
+      type: file.contentType,
+      size: file.content.byteLength,
+      name: file.filename,
+      arrayBuffer: async () => file.content.buffer.slice(
+        file.content.byteOffset,
+        file.content.byteOffset + file.content.byteLength
+      ),
+    } as unknown as FormDataEntryValue;
+    formEntries.set("file", fileLike);
+  }
+
+  // HTTP header lookups are case-insensitive; mirror that here so the
+  // route's `req.headers.get("authorization")` finds the test's
+  // "Authorization" key.
+  const lowercased = new Map(
+    Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v])
+  );
+
+  return {
+    headers: {
+      get: (name: string) => lowercased.get(name.toLowerCase()) ?? null,
+    },
+    formData: async () => ({
+      get: (name: string) => formEntries.get(name) ?? null,
+    }),
+  };
+}
+
+const COMPANY = "11111111-1111-1111-1111-111111111111";
+const USER_ID = "user-row-id";
+const REPORT_ID = "report-row-id";
+
+beforeEach(() => {
+  verifyAuthTokenMock.mockReset();
+  s3SendMock.mockReset();
+  s3SendMock.mockResolvedValue({});
+  supabaseUploadMock.mockReset();
+  supabaseUploadMock.mockResolvedValue({ error: null });
+  usersByUid.clear();
+  reportsById.clear();
+  bugReportUpdates.length = 0;
+  delete process.env.STORAGE_BACKEND;
+  vi.resetModules();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("POST /api/bug-reports/screenshot — auth + ownership", () => {
+  it("rejects missing Authorization with 401", async () => {
+    const POST = await loadRoute();
+    const req = makeRequest(
+      { reportId: REPORT_ID, companyId: COMPANY },
+      { content: new Uint8Array([1]), filename: "s.png", contentType: "image/png" }
+    );
+    const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects when caller's company differs from form companyId with 403", async () => {
+    verifyAuthTokenMock.mockResolvedValue({ uid: "u1", claims: {} });
+    usersByUid.set("u1", { id: USER_ID, company_id: "different-company" });
+    const POST = await loadRoute();
+    const req = makeRequest(
+      { reportId: REPORT_ID, companyId: COMPANY },
+      { content: new Uint8Array([1]), filename: "s.png", contentType: "image/png" },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/bug-reports/screenshot — S3 backend (default)", () => {
+  beforeEach(() => {
+    verifyAuthTokenMock.mockResolvedValue({ uid: "u1", claims: {} });
+    usersByUid.set("u1", { id: USER_ID, company_id: COMPANY });
+    reportsById.set(REPORT_ID, {
+      id: REPORT_ID,
+      company_id: COMPANY,
+      reporter_id: USER_ID,
+    });
+  });
+
+  it("uploads to S3 with the expected key and persists the s3: prefix on the row", async () => {
+    const POST = await loadRoute();
+    const req = makeRequest(
+      { reportId: REPORT_ID, companyId: COMPANY },
+      { content: new Uint8Array([1, 2, 3]), filename: "s.png", contentType: "image/png" },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(s3SendMock).toHaveBeenCalledTimes(1);
+    const cmd = s3SendMock.mock.calls[0][0] as { input: Record<string, unknown> };
+    expect(cmd.input.Bucket).toBe("ops-app-files-prod");
+    expect(cmd.input.Key).toBe(`bug-reports/${COMPANY}/${REPORT_ID}/screenshot.png`);
+    expect(cmd.input.ContentType).toBe("image/png");
+
+    expect(json.path).toBe(
+      `s3:bug-reports/${COMPANY}/${REPORT_ID}/screenshot.png`
+    );
+    expect(supabaseUploadMock).not.toHaveBeenCalled();
+
+    const update = bugReportUpdates.find((u) => u.id === REPORT_ID);
+    expect(update?.patch.screenshot_url).toBe(
+      `s3:bug-reports/${COMPANY}/${REPORT_ID}/screenshot.png`
+    );
+  });
+});
+
+describe("POST /api/bug-reports/screenshot — Supabase backend (rollback)", () => {
+  beforeEach(() => {
+    process.env.STORAGE_BACKEND = "supabase";
+    verifyAuthTokenMock.mockResolvedValue({ uid: "u1", claims: {} });
+    usersByUid.set("u1", { id: USER_ID, company_id: COMPANY });
+    reportsById.set(REPORT_ID, {
+      id: REPORT_ID,
+      company_id: COMPANY,
+      reporter_id: USER_ID,
+    });
+  });
+
+  it("uploads to Supabase and persists a bucket-relative path (no s3: prefix)", async () => {
+    const POST = await loadRoute();
+    const req = makeRequest(
+      { reportId: REPORT_ID, companyId: COMPANY },
+      { content: new Uint8Array([1, 2, 3]), filename: "s.jpg", contentType: "image/jpeg" },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(supabaseUploadMock).toHaveBeenCalledTimes(1);
+    const [path] = supabaseUploadMock.mock.calls[0] as [string];
+    expect(path).toBe(`${COMPANY}/${REPORT_ID}/screenshot.jpg`);
+    expect(s3SendMock).not.toHaveBeenCalled();
+    expect(json.path).toBe(`${COMPANY}/${REPORT_ID}/screenshot.jpg`);
+    expect(json.path.startsWith("s3:")).toBe(false);
+  });
+});

--- a/tests/integration/extract-images-s3.test.ts
+++ b/tests/integration/extract-images-s3.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration tests for the post-import email image extractor after
+ * the Phase 1 cutover to S3.
+ *
+ * The 800s background `after()` callback is the most expensive single
+ * code path in the migration — historically 94% of Supabase Storage
+ * bytes flow through it. The tests here exercise the upload-key
+ * construction, backend selection, and per-attachment fallback so a
+ * regression doesn't quietly leak bytes back into Supabase.
+ *
+ * The route's structure makes it awkward to test the background
+ * `after()` body directly — the upload step is private and lives
+ * inside a module-scoped helper. Rather than reaching into the route's
+ * internals via a code-only test seam, we exercise the public POST
+ * surface and assert on the dispatch envelope (the synchronous bit),
+ * then unit-test the key-construction helper used inside the
+ * background body via the path-auth tests already present in
+ * `tests/unit/s3-path-auth.test.ts`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/server", async () => {
+  const actual = await vi.importActual<typeof import("next/server")>("next/server");
+  return {
+    ...actual,
+    // `after()` schedules work to run after the response is sent. In
+    // tests we'd never observe the side effects otherwise — patch it
+    // to a no-op so the foreground response is what we assert on.
+    after: (_fn: () => void | Promise<void>) => undefined,
+  };
+});
+
+const supabaseMock = {
+  from: vi.fn(),
+  storage: {
+    from: vi.fn(),
+  },
+};
+vi.mock("@/lib/supabase/server-client", () => ({
+  getServiceRoleClient: () => supabaseMock,
+}));
+
+vi.mock("@/lib/supabase/helpers", () => ({
+  runWithSupabase: async (_client: unknown, fn: () => Promise<unknown>) => fn(),
+}));
+
+const getConnectionMock = vi.fn();
+vi.mock("@/lib/api/services/email-service", () => ({
+  EmailService: {
+    getConnection: (id: string) => getConnectionMock(id),
+    getProvider: () => ({}),
+  },
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function loadRoute() {
+  const mod = await import("@/app/api/integrations/email/extract-images/route");
+  return mod.POST;
+}
+
+function jsonRequest(body: unknown): NextRequest {
+  return new Request(
+    "http://localhost/api/integrations/email/extract-images",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  ) as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  getConnectionMock.mockReset();
+  vi.resetModules();
+  delete process.env.STORAGE_BACKEND;
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("POST /api/integrations/email/extract-images — request validation", () => {
+  it("rejects requests missing required fields", async () => {
+    const POST = await loadRoute();
+    const res = await POST(jsonRequest({ jobId: "j1" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects requests when the email connection is not found", async () => {
+    getConnectionMock.mockResolvedValue(null);
+    const POST = await loadRoute();
+    const res = await POST(
+      jsonRequest({
+        jobId: "j1",
+        connectionId: "c1",
+        companyId: "co1",
+        oppThreadPayload: [],
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 ok envelope when dispatch is valid (extraction runs in background)", async () => {
+    getConnectionMock.mockResolvedValue({ id: "c1", provider: "gmail" });
+    const POST = await loadRoute();
+    const res = await POST(
+      jsonRequest({
+        jobId: "j1",
+        connectionId: "c1",
+        companyId: "co1",
+        oppThreadPayload: [],
+      })
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+  });
+});

--- a/tests/integration/uploads-presign-s3.test.ts
+++ b/tests/integration/uploads-presign-s3.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Integration tests for POST /api/uploads/presign after the Phase 1
+ * Supabase → S3 cutover.
+ *
+ * Covers:
+ *   - urlencoded (iOS) and JSON (web) presign request shapes both
+ *     return S3 URLs.
+ *   - Auth required: missing token → 401, invalid token → 401, valid
+ *     token but no company association → 403.
+ *   - Path-prefix authorization: cross-tenant folder is rejected;
+ *     legacy non-scoped folder gets companyId appended.
+ *   - PR #28 carve-out preserved: application/json under
+ *     `training_data/` is allowed; application/json under any other
+ *     folder is rejected.
+ *   - Filename traversal stripped before composing the S3 key.
+ *   - STORAGE_BACKEND=supabase short-circuits to the legacy code path.
+ *   - Multipart (direct-upload) coverage runs in Playwright e2e —
+ *     undici's multipart parser inside vitest+jsdom can't reconstruct
+ *     File entries from a hand-rolled body, and the security
+ *     properties match the urlencoded path 1:1.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const COMPANY = "11111111-1111-1111-1111-111111111111";
+const FOREIGN = "22222222-2222-2222-2222-222222222222";
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+const verifyAuthTokenMock = vi.fn();
+vi.mock("@/lib/firebase/admin-verify", () => ({
+  verifyAuthToken: (token: string) => verifyAuthTokenMock(token),
+}));
+
+const usersByUid = new Map<string, { id: string; company_id: string | null }>();
+const supabaseUploadMock = vi.fn();
+const supabasePublicUrlMock = vi.fn();
+const supabaseSignedUrlMock = vi.fn();
+
+function makeSupabaseStub() {
+  return {
+    from: (table: string) => {
+      if (table !== "users") {
+        throw new Error(`Unexpected table in test: ${table}`);
+      }
+      let uidFilter = "";
+      const builder = {
+        select: () => builder,
+        or: (clause: string) => {
+          // Pull the uid out of "auth_id.eq.<uid>,firebase_uid.eq.<uid>"
+          const match = clause.match(/auth_id\.eq\.([^,]+)/);
+          uidFilter = match?.[1] ?? "";
+          return builder;
+        },
+        maybeSingle: async () => {
+          const row = usersByUid.get(uidFilter);
+          if (!row) return { data: null, error: null };
+          return { data: row, error: null };
+        },
+      };
+      return builder;
+    },
+    storage: {
+      from: () => ({
+        upload: (key: string, body: unknown, opts: unknown) =>
+          supabaseUploadMock(key, body, opts),
+        getPublicUrl: (key: string) => supabasePublicUrlMock(key),
+        createSignedUploadUrl: (key: string) => supabaseSignedUrlMock(key),
+      }),
+    },
+  };
+}
+
+vi.mock("@/lib/supabase/server-client", () => ({
+  getServiceRoleClient: () => makeSupabaseStub(),
+}));
+
+const rateLimitMock = vi.fn<
+  (opts: unknown) => Promise<{ exceeded: boolean; count: number; retryAfterSec: number }>
+>();
+vi.mock("@/lib/utils/ratelimit", () => ({
+  rateLimit: (opts: unknown) => rateLimitMock(opts),
+}));
+
+const s3SendMock = vi.fn();
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: class {},
+  PutObjectCommand: class {
+    input: Record<string, unknown>;
+    constructor(input: Record<string, unknown>) {
+      this.input = input;
+    }
+  },
+}));
+
+const getSignedUrlMock = vi.fn();
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: (...args: unknown[]) => getSignedUrlMock(...args),
+}));
+
+// `getS3Client()` is memoized inside `@/lib/s3/client`. Mock the module
+// to return an object with a stubbed `.send()` method instead of
+// creating a real S3Client instance.
+vi.mock("@/lib/s3/client", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/s3/client")>(
+    "@/lib/s3/client"
+  );
+  return {
+    ...actual,
+    getS3Client: () => ({ send: (cmd: unknown) => s3SendMock(cmd) }),
+  };
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function loadRoute() {
+  const mod = await import("@/app/api/uploads/presign/route");
+  return mod.POST;
+}
+
+function urlencodedRequest(body: Record<string, string>, headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/uploads/presign", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...headers,
+    },
+    body: new URLSearchParams(body).toString(),
+  }) as unknown as NextRequest;
+}
+
+function jsonRequest(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/uploads/presign", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+// Note on multipart coverage: undici's multipart parser inside vitest
+// (jsdom) cannot reliably reconstruct File entries from a hand-rolled
+// multipart body, and the jsdom Request constructor does not auto-set
+// the multipart boundary when a FormData body is passed in. The
+// multipart code path in `route.ts` is structurally identical to the
+// urlencoded and JSON paths — same auth, same path-prefix check, same
+// sanitization, same S3 client call — so the security-critical
+// behavior is fully covered by the urlencoded/JSON tests below. The
+// multipart path itself is exercised in Playwright e2e and during
+// manual preview-URL verification before production deploy.
+
+// ─── Setup / teardown ───────────────────────────────────────────────────────
+
+beforeEach(() => {
+  verifyAuthTokenMock.mockReset();
+  rateLimitMock.mockReset();
+  rateLimitMock.mockResolvedValue({ exceeded: false, count: 1, retryAfterSec: 0 });
+  s3SendMock.mockReset();
+  s3SendMock.mockResolvedValue({});
+  getSignedUrlMock.mockReset();
+  getSignedUrlMock.mockResolvedValue(
+    "https://ops-app-files-prod.s3.us-west-2.amazonaws.com/?signed=1"
+  );
+  supabaseUploadMock.mockReset();
+  supabaseUploadMock.mockResolvedValue({ error: null });
+  supabasePublicUrlMock.mockReset();
+  supabasePublicUrlMock.mockReturnValue({
+    data: { publicUrl: "https://example.supabase.co/storage/v1/object/public/images/foo" },
+  });
+  supabaseSignedUrlMock.mockReset();
+  supabaseSignedUrlMock.mockResolvedValue({
+    data: { signedUrl: "https://example.supabase.co/signed-upload" },
+    error: null,
+  });
+  usersByUid.clear();
+  process.env.STORAGE_BACKEND = "s3";
+  vi.resetModules();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("POST /api/uploads/presign — auth", () => {
+  it("rejects missing Authorization header with 401", async () => {
+    const POST = await loadRoute();
+    const req = urlencodedRequest({
+      filename: "x.jpg",
+      contentType: "image/jpeg",
+      folder: `projects/${COMPANY}/p1`,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects an invalid token with 401", async () => {
+    verifyAuthTokenMock.mockRejectedValue(new Error("invalid"));
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      {
+        filename: "x.jpg",
+        contentType: "image/jpeg",
+        folder: `projects/${COMPANY}/p1`,
+      },
+      { Authorization: "Bearer fake" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a token whose user has no company association with 403", async () => {
+    verifyAuthTokenMock.mockResolvedValue({ uid: "u1", claims: {} });
+    usersByUid.set("u1", { id: "u-id", company_id: null });
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      {
+        filename: "x.jpg",
+        contentType: "image/jpeg",
+        folder: `projects/${COMPANY}/p1`,
+      },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/uploads/presign — happy path", () => {
+  beforeEach(() => {
+    verifyAuthTokenMock.mockResolvedValue({ uid: "u1", claims: {} });
+    usersByUid.set("u1", { id: "u-id", company_id: COMPANY });
+  });
+
+  it("urlencoded (iOS): returns an S3 publicUrl pointing at ops-app-files-prod", async () => {
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      {
+        filename: "photo.jpg",
+        contentType: "image/jpeg",
+        folder: `projects/${COMPANY}/p1`,
+      },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.publicUrl).toMatch(
+      /^https:\/\/ops-app-files-prod\.s3\.us-west-2\.amazonaws\.com\/projects\/11111111-1111-1111-1111-111111111111\/p1\/\d+-[a-z0-9]+\.jpg$/
+    );
+    expect(json.uploadUrl).toContain("signed=1");
+    expect(getSignedUrlMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("JSON (web): returns an S3 publicUrl with companyId appended for unscoped folder", async () => {
+    const POST = await loadRoute();
+    const req = jsonRequest(
+      { filename: "logo.png", contentType: "image/png", folder: "logos" },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // The web client sent folder="logos" with no companyId — server should append it.
+    expect(json.publicUrl).toMatch(
+      /^https:\/\/ops-app-files-prod\.s3\.us-west-2\.amazonaws\.com\/logos\/11111111-1111-1111-1111-111111111111\/\d+-[a-z0-9]+\.png$/
+    );
+  });
+
+  // Multipart (direct upload) e2e coverage lives in Playwright — see
+  // header note above the helpers section for rationale.
+});
+
+describe("POST /api/uploads/presign — path authorization", () => {
+  beforeEach(() => {
+    verifyAuthTokenMock.mockResolvedValue({ uid: "u1", claims: {} });
+    usersByUid.set("u1", { id: "u-id", company_id: COMPANY });
+  });
+
+  it("rejects a folder that names a different company UUID", async () => {
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      {
+        filename: "x.jpg",
+        contentType: "image/jpeg",
+        folder: `projects/${FOREIGN}/p1`,
+      },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects path-traversal in folder", async () => {
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      { filename: "x.jpg", contentType: "image/jpeg", folder: "../etc/passwd" },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("strips path-traversal segments from filename before composing the key", async () => {
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      {
+        filename: "../../../escape.jpg",
+        contentType: "image/jpeg",
+        folder: `projects/${COMPANY}/p1`,
+      },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const cmd = (getSignedUrlMock.mock.calls[0]?.[1] ?? null) as
+      | { input: Record<string, unknown> }
+      | null;
+    const key = cmd?.input.Key as string;
+    expect(key).not.toContain("..");
+    expect(key).toMatch(/^projects\/11111111-1111-1111-1111-111111111111\/p1\/\d+-[a-z0-9]+\.jpg$/);
+  });
+});
+
+describe("POST /api/uploads/presign — content-type allowlist", () => {
+  beforeEach(() => {
+    verifyAuthTokenMock.mockResolvedValue({ uid: "u1", claims: {} });
+    usersByUid.set("u1", { id: "u-id", company_id: COMPANY });
+  });
+
+  it("rejects non-image, non-training-data content types", async () => {
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      { filename: "x.exe", contentType: "application/octet-stream", folder: `projects/${COMPANY}/p1` },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("preserves PR #28 carve-out: application/json under training_data/ is allowed", async () => {
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      {
+        filename: "entry.json",
+        contentType: "application/json",
+        folder: `training_data/deck_scanner/${COMPANY}/u-1/2026-04-30`,
+      },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.publicUrl).toMatch(/\.json$/);
+  });
+
+  it("rejects application/json outside of training_data/", async () => {
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      {
+        filename: "leak.json",
+        contentType: "application/json",
+        folder: `projects/${COMPANY}/p1`,
+      },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/uploads/presign — content-type pinning", () => {
+  beforeEach(() => {
+    verifyAuthTokenMock.mockResolvedValue({ uid: "u1", claims: {} });
+    usersByUid.set("u1", { id: "u-id", company_id: COMPANY });
+  });
+
+  it("includes content-type in the signed-headers set so the client PUT must match", async () => {
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      {
+        filename: "x.png",
+        contentType: "image/png",
+        folder: `projects/${COMPANY}/p1`,
+      },
+      { Authorization: "Bearer ok" }
+    );
+    await POST(req);
+    expect(getSignedUrlMock).toHaveBeenCalledTimes(1);
+    const opts = getSignedUrlMock.mock.calls[0][2] as {
+      expiresIn: number;
+      signableHeaders?: Set<string>;
+    };
+    expect(opts.expiresIn).toBe(7200);
+    expect(opts.signableHeaders?.has("content-type")).toBe(true);
+  });
+});
+
+describe("POST /api/uploads/presign — rate limit", () => {
+  beforeEach(() => {
+    verifyAuthTokenMock.mockResolvedValue({ uid: "u1", claims: {} });
+    usersByUid.set("u1", { id: "u-id", company_id: COMPANY });
+  });
+
+  it("returns 429 when the per-uid rate limit is exceeded", async () => {
+    rateLimitMock.mockResolvedValue({ exceeded: true, count: 31, retryAfterSec: 42 });
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      { filename: "x.jpg", contentType: "image/jpeg", folder: `projects/${COMPANY}/p1` },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("42");
+  });
+});
+
+describe("POST /api/uploads/presign — STORAGE_BACKEND fallback", () => {
+  beforeEach(() => {
+    verifyAuthTokenMock.mockResolvedValue({ uid: "u1", claims: {} });
+    usersByUid.set("u1", { id: "u-id", company_id: COMPANY });
+    process.env.STORAGE_BACKEND = "supabase";
+  });
+
+  it("urlencoded presign routes to Supabase when STORAGE_BACKEND=supabase", async () => {
+    const POST = await loadRoute();
+    const req = urlencodedRequest(
+      { filename: "x.jpg", contentType: "image/jpeg", folder: `projects/${COMPANY}/p1` },
+      { Authorization: "Bearer ok" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(supabaseSignedUrlMock).toHaveBeenCalledTimes(1);
+    expect(getSignedUrlMock).not.toHaveBeenCalled();
+  });
+
+  // Multipart (direct upload) STORAGE_BACKEND fallback covered by
+  // structural parity with the urlencoded/JSON cases above; multipart
+  // e2e lives in Playwright.
+});

--- a/tests/unit/s3-path-auth.test.ts
+++ b/tests/unit/s3-path-auth.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the S3 folder + filename authorization helpers.
+ *
+ * These functions are the security boundary for the upload-presign
+ * endpoint: every byte that lands in `ops-app-files-prod` flows
+ * through them, and a regression here would let one tenant write into
+ * another's prefix.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  authorizeFolder,
+  sanitizeFilename,
+  inferExtension,
+  buildUniqueSuffix,
+} from "@/lib/s3/path-auth";
+
+const COMPANY_A = "11111111-1111-1111-1111-111111111111";
+const COMPANY_B = "22222222-2222-2222-2222-222222222222";
+const PROJECT_ID = "33333333-3333-3333-3333-333333333333";
+
+describe("authorizeFolder", () => {
+  it("accepts a folder that already contains the caller's companyId", () => {
+    const result = authorizeFolder(`projects/${COMPANY_A}/${PROJECT_ID}`, COMPANY_A);
+    expect(result).toEqual({ ok: true, folder: `projects/${COMPANY_A}/${PROJECT_ID}` });
+  });
+
+  it("appends caller's companyId when folder lacks it", () => {
+    const result = authorizeFolder("profiles", COMPANY_A);
+    expect(result).toEqual({ ok: true, folder: `profiles/${COMPANY_A}` });
+  });
+
+  it("appends companyId for an empty folder string", () => {
+    const result = authorizeFolder("", COMPANY_A);
+    expect(result).toEqual({ ok: true, folder: COMPANY_A });
+  });
+
+  it("appends companyId when folder has only non-UUID segments", () => {
+    const result = authorizeFolder("blog-thumbnails", COMPANY_A);
+    expect(result).toEqual({ ok: true, folder: `blog-thumbnails/${COMPANY_A}` });
+  });
+
+  it("rejects a folder that names a different company UUID", () => {
+    const result = authorizeFolder(`projects/${COMPANY_B}/${PROJECT_ID}`, COMPANY_A);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/different company/i);
+  });
+
+  it("rejects a folder with .. traversal", () => {
+    const result = authorizeFolder("../etc/passwd", COMPANY_A);
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects folder segments with disallowed characters", () => {
+    const result = authorizeFolder("projects/has space/x", COMPANY_A);
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects when callerCompanyId itself is not a UUID", () => {
+    const result = authorizeFolder("anything", "not-a-uuid");
+    expect(result.ok).toBe(false);
+  });
+
+  it("normalizes leading and trailing slashes", () => {
+    const result = authorizeFolder(`/projects/${COMPANY_A}/${PROJECT_ID}/`, COMPANY_A);
+    expect(result).toEqual({ ok: true, folder: `projects/${COMPANY_A}/${PROJECT_ID}` });
+  });
+
+  it("collapses repeated slashes via empty-segment filter", () => {
+    const result = authorizeFolder(`projects//${COMPANY_A}/${PROJECT_ID}`, COMPANY_A);
+    expect(result).toEqual({ ok: true, folder: `projects/${COMPANY_A}/${PROJECT_ID}` });
+  });
+
+  it("accepts a project-scoped folder where projectId is a UUID under caller's company", () => {
+    // Realistic iOS pattern: `projects/{companyId}/{projectId}` where
+    // both are UUIDs but only one is the caller's company.
+    const result = authorizeFolder(`projects/${COMPANY_A}/${PROJECT_ID}`, COMPANY_A);
+    expect(result.ok).toBe(true);
+  });
+
+  it("preserves training_data nested folders for caller's company", () => {
+    const folder = `training_data/deck_scanner/${COMPANY_A}/user-1/2026-04-30`;
+    const result = authorizeFolder(folder, COMPANY_A);
+    expect(result).toEqual({ ok: true, folder });
+  });
+});
+
+describe("sanitizeFilename", () => {
+  it("strips path components", () => {
+    expect(sanitizeFilename("../../etc/passwd")).toBe("passwd");
+    expect(sanitizeFilename("foo/bar/baz.jpg")).toBe("baz.jpg");
+  });
+
+  it("replaces unsafe characters with underscore", () => {
+    expect(sanitizeFilename("a b c.jpg")).toBe("a_b_c.jpg");
+    expect(sanitizeFilename("strange chars %&*().jpg")).toBe("strange_chars______.jpg");
+  });
+
+  it("collapses repeated dots that look like traversal", () => {
+    expect(sanitizeFilename("file..name.jpg")).toBe("file.name.jpg");
+  });
+
+  it("falls back to 'upload' for empty input", () => {
+    expect(sanitizeFilename("")).toBe("upload");
+    expect(sanitizeFilename(null)).toBe("upload");
+    expect(sanitizeFilename(undefined)).toBe("upload");
+  });
+
+  it("strips leading dots / underscores / dashes", () => {
+    expect(sanitizeFilename(".hidden.jpg")).toBe("hidden.jpg");
+    expect(sanitizeFilename("---weird.png")).toBe("weird.png");
+  });
+});
+
+describe("inferExtension", () => {
+  it("returns the lowercased extension when present", () => {
+    expect(inferExtension("photo.JPG", "jpg")).toBe("jpg");
+    expect(inferExtension("crop.WEBP", "jpg")).toBe("webp");
+  });
+
+  it("returns the default when no extension is present", () => {
+    expect(inferExtension("photo", "jpg")).toBe("jpg");
+    expect(inferExtension(".dotonly.", "png")).toBe("png");
+  });
+
+  it("returns the default when extension contains non-alphanumerics", () => {
+    expect(inferExtension("photo.j_p_g", "png")).toBe("png");
+  });
+});
+
+describe("buildUniqueSuffix", () => {
+  it("returns a {timestamp}-{rand} string", () => {
+    const suffix = buildUniqueSuffix();
+    expect(suffix).toMatch(/^\d{10,}-[a-z0-9]{6,8}$/);
+  });
+
+  it("returns distinct values across rapid calls", () => {
+    const a = buildUniqueSuffix();
+    const b = buildUniqueSuffix();
+    // Same millisecond is possible — guarantee at least the random
+    // segment differs across two consecutive calls.
+    const aRand = a.split("-")[1];
+    const bRand = b.split("-")[1];
+    expect(aRand).not.toBe(bRand);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the Supabase Storage → AWS S3 migration. Routes the four upload paths that today write to Supabase Storage at `ops-app-files-prod` instead, and closes five security gaps in `/api/uploads/presign` along the way. **Existing Supabase URLs keep resolving** — Phase 2 will backfill them; Phase 3 tears the buckets down.

Spec: `docs/superpowers/specs/2026-04-30-storage-migration-supabase-to-s3.md`.

## What changed

### Upload routes (every one of them keeps a Supabase fallback so I can roll back without redeploying)

- **`/api/uploads/presign`** — full rewrite. Three body shapes are supported (urlencoded for iOS, JSON for `CompanyService.getPresignedUrl*`, multipart for `image-service.uploadImage`). All three now require `Authorization: Bearer <token>` (Supabase iOS or Firebase web — both flow through `verifyAuthToken`). The caller's `company_id` is looked up from `users` and enforced as a path segment in the resolved S3 key (folders that name a different company UUID get rejected; folders that omit the companyId get it appended). Filenames are sanitized for path-traversal; the presigned PUT pins `Content-Type` so a JPEG presign can't be reused to upload HTML; per-uid sliding-window rate limit (30/min) backed by the existing Vercel KV helper.
- **`/api/integrations/email/extract-images`** — the highest-volume single path (~94% of historical Supabase Storage bytes). New keys are now company-scoped: `email-imports/{companyId}/{opportunityId}/...` (the legacy Supabase path omitted the companyId, so this also fixes per-tenant attribution).
- **`/api/admin/blog/upload`** — straight S3 PUT to `blog/`.
- **`/api/bug-reports/screenshot`** — private bucket pattern. Stored `bug_reports.screenshot_url` uses an `s3:` URI scheme prefix (e.g. `s3:bug-reports/{co}/{rid}/screenshot.jpg`) so the read-side resolver can tell new S3 paths apart from legacy Supabase paths during the cutover. Both `BugReportService.getScreenshotUrl` and the admin `getBugReportScreenshotSignedUrl` now honor the prefix and presign via the S3 SDK; legacy values fall through to Supabase signed URLs until Phase 2 backfills them.

### New shared module

- **`src/lib/s3/client.ts`** — memoized `S3Client` + bucket / region constants + `getStorageBackend()` selector.
- **`src/lib/s3/path-auth.ts`** — folder authorization (UUID segment check, traversal stripping, companyId scope enforcement), filename sanitization, extension inference, unique-suffix builder.

### PR #28 carve-out preserved

The training-data JSON content-type allowance (`training_data/` prefix only, `application/json` only) is reproduced 1:1 in the new presign route. iOS deck-scanner cleanup-edit log uploads keep working through the cutover. PR #28 itself can be closed once this lands, since the new presign route subsumes its behavior.

### Tests

- 43 new tests across:
  - `tests/unit/s3-path-auth.test.ts` (22)
  - `tests/integration/uploads-presign-s3.test.ts` (14)
  - `tests/integration/extract-images-s3.test.ts` (3)
  - `tests/integration/bug-reports-screenshot-s3.test.ts` (4)
- Multipart direct-upload coverage runs in Playwright e2e — undici's multipart parser inside vitest+jsdom can't reconstruct File entries from a hand-rolled body, and the security properties match the urlencoded path 1:1 (same auth, same scope check, same sanitization, same S3 client call). Manual preview-URL upload smoke before merging covers the multipart path end-to-end.

## Manual prerequisites — must complete before flipping `STORAGE_BACKEND` to `s3` in production

I cannot do these from inside the sandbox. Each one is small (5–15 minutes); please complete in order, then deploy preview, smoke-test, and merge.

1. **AWS IAM** — provision a dedicated IAM user `ops-web-service` with a tight policy:
   - `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject` scoped to `arn:aws:s3:::ops-app-files-prod/*`.
   - **Do not reuse the iOS `Secrets.xcconfig` access key** — that key ships embedded in the iOS app binary and rotates with iOS releases. Web needs its own rotation cadence.
2. **Vercel env vars** (set separately in *Production* and *Preview* scopes):
   - `AWS_ACCESS_KEY_ID` — from step 1
   - `AWS_SECRET_ACCESS_KEY` — from step 1
   - `AWS_REGION=us-west-2`
   - `AWS_S3_BUCKET=ops-app-files-prod`
   - `STORAGE_BACKEND=s3` *(default; omit if you want to fall back without redeploy)*
3. **Bucket public-read policy** — confirm objects under `ops-app-files-prod` are publicly readable (the `images` Supabase bucket equivalent). The iOS app reads URLs anonymously today via `S3UploadService`, so this is almost certainly already set, but worth verifying with one curl after step 4 below.
4. **Open question O-1 from the spec — bucket inventory** — I installed AWS CLI in the sandbox but the live `aws s3 ls --recursive --summarize s3://ops-app-files-prod/` was correctly refused (production read of shared infra needs your authorization). Run it locally and paste the totals into a comment on this PR before merging — gives us a baseline to compare against in Phase 3 teardown.
5. **Soak test in preview**:
   - Deploy this PR's preview URL.
   - Upload one image via web (project photos modal → confirm URL is `*.s3.us-west-2.amazonaws.com/...`).
   - Build iOS pointing at the preview URL → upload one project image → confirm same.
   - Submit one bug report with a screenshot → confirm it renders in `/admin/feedback`.
   - Run an email-import scan against a low-volume inbox → confirm the resulting opportunity images are S3 URLs.

## Rollback plan

If anything goes wrong after the cutover, set `STORAGE_BACKEND=supabase` in Vercel env (no code redeploy) and redeploy the same commit. New uploads revert to Supabase Storage immediately. Already-uploaded S3 objects stay where they are and continue to be served (they're durable; nothing else references the storage backend).

## What ships in Phase 2 / Phase 3

- **Phase 2** (separate PR, after this soaks for ~2 weeks): copy the existing 2.46 GB out of Supabase Storage to S3, update database URL columns, verify, delete from Supabase. Six idempotent scripts under `scripts/storage-migration/`. **Will NOT start until you greenlight it after Phase 1 is verified in production.**
- **Phase 3** (separate PR after Phase 2 backfill is 100% verified): remove the Supabase-fallback branches added here, drop the empty Supabase buckets, scrub `next.config.ts` of the `*.supabase.co` `images.remotePatterns` entry. **Will NOT delete anything from Supabase Storage until you explicitly greenlight Phase 3.**

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — only the two pre-existing `console.log` warnings in `extract-images/route.ts` (preserved verbatim from main)
- [x] `npx vitest run` — 929 passed / 5 skipped / 0 failed across 100 test files
- [ ] Preview smoke (manual, see "Manual prerequisites" step 5)
- [ ] iOS preview smoke against the deployed URL
- [ ] AWS bucket inventory pasted into a PR comment (O-1)