### PR TITLE
Nightly Bug Sweep — web — 2026-05-02 — Batch 01

### DIFF
--- a/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
+++ b/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
@@ -463,6 +463,9 @@ export function MonthEventBar({
   }
 
   // ── Level 2: Standard — short bar with single-line title ──
+  // Bug-5c19dc85: bumped from 14px height / 11px font to 16px / 12px so
+  // titles read cleanly on 13–15" laptop viewports without overflowing
+  // adjacent calendar columns.
   if (displayLevel === "standard") {
     const showStripe = !isPersonal && (span.isFirstSegment || span.isSingleDay);
     return (
@@ -471,7 +474,7 @@ export function MonthEventBar({
           ref={barRef}
           className="cursor-pointer truncate relative"
           style={{
-            height: 14,
+            height: 16,
             background: barBg,
             border: `1px solid ${barBorder}`,
             borderRadius,
@@ -498,7 +501,7 @@ export function MonthEventBar({
           {StripeAccent(showStripe)}
           {isPersonal && (
             <Star
-              size={9}
+              size={10}
               strokeWidth={1.5}
               style={{ color: PERSONAL_TEXT, fill: PERSONAL_TEXT, flexShrink: 0 }}
               aria-hidden="true"
@@ -506,12 +509,12 @@ export function MonthEventBar({
           )}
           <span
             className="font-mohave truncate"
-            style={{ fontSize: 11, lineHeight: "14px", color: barText }}
+            style={{ fontSize: 12, lineHeight: "16px", color: barText }}
           >
             {event.projectTitle ?? event.taskTitle}
           </span>
-          {showLeftHandle && <Handle edge="left" height={14} />}
-          {showRightHandle && <Handle edge="right" height={14} />}
+          {showLeftHandle && <Handle edge="left" height={16} />}
+          {showRightHandle && <Handle edge="right" height={16} />}
           {renderEdgePreview("left")}
           {renderEdgePreview("right")}
         </div>
@@ -521,7 +524,8 @@ export function MonthEventBar({
 
   // ── Level 3: Expanded ──
 
-  // Multi-day events stay 14px even at expanded level
+  // Multi-day events stay slim even at expanded level — bumped to 16px
+  // (bug-5c19dc85) for laptop legibility, matching standard-tier bars.
   if (!span.isSingleDay) {
     const showStripe = !isPersonal && span.isFirstSegment;
     const showStarLead = isPersonal && span.isFirstSegment;
@@ -531,7 +535,7 @@ export function MonthEventBar({
           ref={barRef}
           className="cursor-pointer truncate relative"
           style={{
-            height: 14,
+            height: 16,
             background: barBg,
             border: `1px solid ${barBorder}`,
             borderRadius,
@@ -558,7 +562,7 @@ export function MonthEventBar({
           {StripeAccent(showStripe)}
           {showStarLead && (
             <Star
-              size={9}
+              size={10}
               strokeWidth={1.5}
               style={{ color: PERSONAL_TEXT, fill: PERSONAL_TEXT, flexShrink: 0 }}
               aria-hidden="true"
@@ -566,12 +570,12 @@ export function MonthEventBar({
           )}
           <span
             className="font-mohave truncate"
-            style={{ fontSize: 11, lineHeight: "14px", color: barText }}
+            style={{ fontSize: 12, lineHeight: "16px", color: barText }}
           >
             {event.projectTitle ?? event.taskTitle}
           </span>
-          {showLeftHandle && <Handle edge="left" height={14} />}
-          {showRightHandle && <Handle edge="right" height={14} />}
+          {showLeftHandle && <Handle edge="left" height={16} />}
+          {showRightHandle && <Handle edge="right" height={16} />}
           {renderEdgePreview("left")}
           {renderEdgePreview("right")}
         </div>

--- a/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
+++ b/src/app/(dashboard)/calendar/_components/month/month-event-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import { format } from "date-fns";
+import { addDays, differenceInCalendarDays, format, parseISO } from "date-fns";
 import { Star } from "lucide-react";
 import { type InternalCalendarEvent } from "@/lib/utils/calendar-utils";
 import { useCalendarStore } from "@/stores/calendar-store";
@@ -73,7 +73,9 @@ function useEdgeResize(
   const [resize, setResize] = useState<{
     edge: "left" | "right";
     initialX: number;
-    deltaPx: number;
+    initialY: number;
+    clientX: number;
+    clientY: number;
   } | null>(null);
   const resizeRef = useRef(resize);
   resizeRef.current = resize;
@@ -88,11 +90,88 @@ function useEdgeResize(
     return rect.width / 7;
   }, [barRef]);
 
+  // Find the calendar day under a (clientX, clientY) cursor position by
+  // hit-testing every rendered week row in the document. Returns the date
+  // representing the day cell directly under the cursor, or null when the
+  // cursor sits outside any week row (e.g. above/below the calendar).
+  //
+  // This is what enables vertical-row crossing during resize: the user can
+  // drag the right edge down into the next week's row and the bar will
+  // extend by a full week (or more), instead of only tracking horizontal
+  // pixel delta on the original row.
+  const resolveDayUnderCursor = useCallback(
+    (clientX: number, clientY: number): Date | null => {
+      const el = barRef.current;
+      if (!el) return null;
+      const ownerDoc = el.ownerDocument ?? document;
+      const rows = Array.from(
+        ownerDoc.querySelectorAll<HTMLElement>("[data-month-week-row]")
+      );
+      if (rows.length === 0) return null;
+
+      // 1) Find the row whose vertical bounds contain clientY. If the cursor
+      //    sits above the top row or below the bottom row, snap to the
+      //    nearest row so an aggressive drag past the calendar still lands.
+      let chosenRow: HTMLElement | null = null;
+      let chosenRect: DOMRect | null = null;
+      for (const row of rows) {
+        const r = row.getBoundingClientRect();
+        if (clientY >= r.top && clientY <= r.bottom) {
+          chosenRow = row;
+          chosenRect = r;
+          break;
+        }
+      }
+      if (!chosenRow || !chosenRect) {
+        // Snap to closest by vertical distance.
+        let bestDist = Infinity;
+        for (const row of rows) {
+          const r = row.getBoundingClientRect();
+          const center = (r.top + r.bottom) / 2;
+          const dist = Math.abs(clientY - center);
+          if (dist < bestDist) {
+            bestDist = dist;
+            chosenRow = row;
+            chosenRect = r;
+          }
+        }
+      }
+      if (!chosenRow || !chosenRect) return null;
+
+      const weekStartAttr = chosenRow.getAttribute("data-week-start");
+      if (!weekStartAttr) return null;
+      let weekStart: Date;
+      try {
+        weekStart = parseISO(weekStartAttr);
+        if (Number.isNaN(weekStart.getTime())) return null;
+      } catch {
+        return null;
+      }
+
+      // 2) Within the chosen row, compute column index 0..6 from clientX.
+      const colWidth = chosenRect.width / 7;
+      if (!colWidth || colWidth <= 0) return null;
+      const offsetX = Math.max(
+        0,
+        Math.min(chosenRect.width - 1, clientX - chosenRect.left)
+      );
+      const colIdx = Math.max(0, Math.min(6, Math.floor(offsetX / colWidth)));
+      return addDays(weekStart, colIdx);
+    },
+    [barRef]
+  );
+
   const handleResizeStart = useCallback(
     (edge: "left" | "right") => (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      setResize({ edge, initialX: e.clientX, deltaPx: 0 });
+      setResize({
+        edge,
+        initialX: e.clientX,
+        initialY: e.clientY,
+        clientX: e.clientX,
+        clientY: e.clientY,
+      });
     },
     []
   );
@@ -102,7 +181,7 @@ function useEdgeResize(
 
     const onMouseMove = (mv: MouseEvent) => {
       setResize((prev) =>
-        prev ? { ...prev, deltaPx: mv.clientX - prev.initialX } : null
+        prev ? { ...prev, clientX: mv.clientX, clientY: mv.clientY } : null
       );
     };
     const onMouseUp = () => {
@@ -111,9 +190,30 @@ function useEdgeResize(
       window.removeEventListener("mouseup", onMouseUp);
       setResize(null);
       if (!state) return;
+
+      // Two-pass commit:
+      // 1) Preferred path — locate the day cell directly under the cursor
+      //    and compute dayDelta as the absolute calendar difference between
+      //    that target day and the edge being dragged. This is what makes
+      //    vertical row-crossing work (extend +1 week by dragging into the
+      //    row below).
+      // 2) Fallback — if the cursor is somehow outside any rendered week
+      //    row, fall back to the legacy horizontal pixel-to-day calculation
+      //    so a single-row resize still commits.
+      const targetDay = resolveDayUnderCursor(state.clientX, state.clientY);
+      if (targetDay) {
+        const anchor =
+          state.edge === "right" ? event.endDate : event.startDate;
+        const dayDelta = differenceInCalendarDays(targetDay, anchor);
+        if (dayDelta === 0) return;
+        onResize?.(event, state.edge, dayDelta);
+        return;
+      }
+
       const colWidth = resolveDayColumnWidth();
       if (!colWidth || colWidth <= 0) return;
-      const dayDelta = Math.round(state.deltaPx / colWidth);
+      const deltaPx = state.clientX - state.initialX;
+      const dayDelta = Math.round(deltaPx / colWidth);
       if (dayDelta === 0) return;
       onResize?.(event, state.edge, dayDelta);
     };
@@ -123,14 +223,21 @@ function useEdgeResize(
       window.removeEventListener("mousemove", onMouseMove);
       window.removeEventListener("mouseup", onMouseUp);
     };
-  }, [resize, resolveDayColumnWidth, onResize, event]);
+  }, [resize, resolveDayColumnWidth, resolveDayUnderCursor, onResize, event]);
 
-  // Live preview: snap the deltaPx to integer day units for visual feedback.
+  // Live preview: derive integer day delta from the cursor's position in the
+  // calendar. Mirrors the commit logic so the dashed overlay matches what
+  // will land on mouse-up — including row-crossing extensions.
   const previewDayDelta = (() => {
     if (!resize) return 0;
+    const targetDay = resolveDayUnderCursor(resize.clientX, resize.clientY);
+    if (targetDay) {
+      const anchor = resize.edge === "right" ? event.endDate : event.startDate;
+      return differenceInCalendarDays(targetDay, anchor);
+    }
     const colWidth = resolveDayColumnWidth();
     if (!colWidth || colWidth <= 0) return 0;
-    return Math.round(resize.deltaPx / colWidth);
+    return Math.round((resize.clientX - resize.initialX) / colWidth);
   })();
 
   return {

--- a/src/app/(dashboard)/calendar/_components/month/month-scroll-container.tsx
+++ b/src/app/(dashboard)/calendar/_components/month/month-scroll-container.tsx
@@ -831,6 +831,7 @@ export function MonthScrollContainer({
                 <div
                   key={weekKey}
                   data-month-week-row
+                  data-week-start={weekKey}
                   className="grid grid-cols-7 relative"
                   style={{
                     height: cellHeight,

--- a/src/app/(dashboard)/calendar/_components/month/month-scroll-container.tsx
+++ b/src/app/(dashboard)/calendar/_components/month/month-scroll-container.tsx
@@ -59,7 +59,12 @@ const EXTEND_STEP_MONTHS = 6;
 
 const MIN_CELL_HEIGHT = 80;
 const MAX_CELL_HEIGHT = 320;
-const DEFAULT_CELL_HEIGHT = 120;
+// Spec V2 (2026-05-02 / bug-5c19dc85): default density is too compressed on
+// laptop viewports (13–15", typically 1280–1470 wide × 700–900 tall). Bumped
+// from 120 → 140 so the default cell lands cleanly in the "standard" tier
+// with breathing room for 16px bars and 12px titles. Cmd-wheel zoom still
+// scales freely between MIN_CELL_HEIGHT and MAX_CELL_HEIGHT.
+const DEFAULT_CELL_HEIGHT = 140;
 const DAY_NUMBER_HEIGHT = 24;
 const SLOT_GAP = 2;
 const MORE_ROW_HEIGHT = 14;
@@ -107,14 +112,19 @@ function getDisplayLevel(cellHeight: number): DisplayLevel {
 
 function getSlotHeight(level: DisplayLevel, isSingleDay: boolean): number {
   if (level === "compact") return 10;
-  if (level === "standard") return 14;
-  return isSingleDay ? 42 : 14;
+  // Spec V2 (bug-5c19dc85): 14 → 16 in standard tier so 12px titles get
+  // proper line height on laptop viewports. Multi-day expanded bars match
+  // the standard slot height.
+  if (level === "standard") return 16;
+  return isSingleDay ? 42 : 16;
 }
 
 function getMaxSlots(cellHeight: number, level: DisplayLevel): number {
   const available = cellHeight - DAY_NUMBER_HEIGHT - MORE_ROW_HEIGHT;
   if (available <= 0) return 0;
-  const baseHeight = level === "compact" ? 10 : 14;
+  // Standard / expanded use the same multi-day base height (16) for slot
+  // packing math.
+  const baseHeight = level === "compact" ? 10 : 16;
   return Math.max(1, Math.floor((available + SLOT_GAP) / (baseHeight + SLOT_GAP)));
 }
 
@@ -719,7 +729,9 @@ export function MonthScrollContainer({
     }
   }, []);
 
-  const baseSlotHeight = displayLevel === "compact" ? 10 : 14;
+  // Mirrors getSlotHeight for placement math. 14 → 16 in standard/expanded
+  // (bug-5c19dc85).
+  const baseSlotHeight = displayLevel === "compact" ? 10 : 16;
 
   // Held for parity with week / day views; this view doesn't snap.
   useCalendarDragState();

--- a/src/components/layouts/dashboard-layout.tsx
+++ b/src/components/layouts/dashboard-layout.tsx
@@ -15,6 +15,7 @@ import { NotificationsDrawer } from "@/components/layouts/notifications-drawer";
 import { NotificationsTab } from "@/components/layouts/notifications-tab";
 import { QuickActionsDrawer } from "@/components/layouts/quick-actions-drawer";
 import { QuickActionsTab } from "@/components/layouts/quick-actions-tab";
+import { EdgeTabOutsideDismiss } from "@/components/layouts/edge-tab-outside-dismiss";
 import { DuplicateReviewSheet } from "@/components/ops/duplicate-review-sheet";
 import { useActionPrompts } from "@/hooks/useActionPrompts";
 import { useWindowStore } from "@/stores/window-store";
@@ -246,6 +247,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
       <NotificationsTab />
       <QuickActionsDrawer />
       <QuickActionsTab />
+      <EdgeTabOutsideDismiss />
       <DuplicateReviewSheet />
       <WindowDock />
 

--- a/src/components/layouts/edge-tab-outside-dismiss.tsx
+++ b/src/components/layouts/edge-tab-outside-dismiss.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect } from "react";
+import { useEdgeTabStore } from "@/stores/edge-tab-store";
+
+/**
+ * Global outside-click dismiss for the right-rail edge-tab system
+ * (Notifications, Quick Actions, Bug Report).
+ *
+ * Bug-5b653c30: drawers stayed open until the user explicitly clicked their
+ * close button or pressed Escape. Mounting this once in DashboardLayout
+ * gives all three drawers a single, consistent dismiss-on-outside-click
+ * behavior.
+ *
+ * Rules:
+ *   - Only fires while a tab is active (no work on every page click).
+ *   - mousedown is the canonical outside-click trigger — fires before any
+ *     inner click handlers, so a click inside a popover/menu opened from
+ *     a drawer still counts as inside-the-drawer (because that menu is
+ *     portaled OR contained within data-edge-tab-drawer).
+ *   - "Inside" means: anywhere within a `[data-edge-tab]` (the tab itself),
+ *     `[data-edge-tab-anchor]` (its rail wrapper), or
+ *     `[data-edge-tab-drawer]` (the drawer/panel root).
+ *   - Portaled overlays from drawer content (e.g. Radix popovers, the
+ *     SetupInterceptionModal opened from Quick Actions) live OUTSIDE the
+ *     DOM subtree of the drawer. To avoid dismissing the drawer when the
+ *     user interacts with one of those, we also treat clicks inside any
+ *     `[role="dialog"]` / `[role="menu"]` / `[role="listbox"]` as inside.
+ *     That keeps the user's mental model intact: only clicking the page
+ *     canvas itself dismisses.
+ */
+export function EdgeTabOutsideDismiss() {
+  const activeTab = useEdgeTabStore((s) => s.activeTab);
+  const closeAll = useEdgeTabStore((s) => s.closeAll);
+
+  useEffect(() => {
+    if (!activeTab) return;
+
+    function handleMouseDown(e: MouseEvent) {
+      const target = e.target as Element | null;
+      if (!target || !(target instanceof Element)) return;
+
+      // Click landed inside the active edge-tab system or any portaled
+      // overlay launched from it — keep the drawer open.
+      if (
+        target.closest("[data-edge-tab]") ||
+        target.closest("[data-edge-tab-anchor]") ||
+        target.closest("[data-edge-tab-drawer]") ||
+        target.closest('[role="dialog"]') ||
+        target.closest('[role="menu"]') ||
+        target.closest('[role="listbox"]') ||
+        target.closest("[data-radix-popper-content-wrapper]")
+      ) {
+        return;
+      }
+
+      closeAll();
+    }
+
+    // mousedown beats click — close before any nested click handler runs.
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [activeTab, closeAll]);
+
+  return null;
+}

--- a/src/components/layouts/notifications-drawer.tsx
+++ b/src/components/layouts/notifications-drawer.tsx
@@ -199,6 +199,7 @@ export function NotificationsDrawer() {
           exit="exit"
           role="complementary"
           aria-label={t("drawer.ariaLabel")}
+          data-edge-tab-drawer="notifications"
           style={{
             position: "fixed",
             top: 72,

--- a/src/components/layouts/quick-actions-drawer.tsx
+++ b/src/components/layouts/quick-actions-drawer.tsx
@@ -131,6 +131,7 @@ export function QuickActionsDrawer() {
               exit="exit"
               role="complementary"
               aria-label={t("drawer.ariaLabel")}
+              data-edge-tab-drawer="quick-actions"
               style={{
                 position: "absolute",
                 top: `calc(50% + ${STACK_OFFSET_QA - PANEL_H / 2}px)`,

--- a/src/components/ops/bug-report-button.tsx
+++ b/src/components/ops/bug-report-button.tsx
@@ -359,6 +359,7 @@ export function BugReportButton() {
               transition={{ duration: prefersReducedMotion ? 0.15 : 0.26, ease: [0.22, 1, 0.36, 1] }}
               role="dialog"
               aria-label={t("bugReport.title")}
+              data-edge-tab-drawer="bug-report"
               style={{
                 position: "absolute",
                 top: `calc(50% + ${STACK_OFFSET_BUG - PANEL_H / 2}px)`,

--- a/src/components/ops/bug-report-button.tsx
+++ b/src/components/ops/bug-report-button.tsx
@@ -7,6 +7,8 @@ import { Bug, X, Send, CheckCircle2, Loader2, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 
 import { useAuthStore } from "@/lib/store/auth-store";
+import { useEdgeTabStore } from "@/stores/edge-tab-store";
+import { EdgeTab } from "@/components/ui/edge-tab";
 import {
   BugReportService,
   type BugReportCategory,
@@ -45,9 +47,31 @@ const SEVERITY_TO_PRIORITY: Record<Severity, BugReportPriority> = {
   minor: "low",
 };
 
+// EdgeTab integration (bug-b842f0ff): the report trigger is now a right-rail
+// edge tab that mirrors NotificationsTab + QuickActionsTab. Stack math:
+//   Notifications (180px) sits above center at -94.
+//   Quick Actions (132px) sits below center at +94.
+//   Bug Report tab sits BELOW Quick Actions: top edge = +160, +8px gap, our
+//   own restHeight = 64 (icon-only square-ish) → tab center = +200.
+//
+// Form panel reuses Quick Actions' panel-anchored geometry (308×420) so the
+// tab + panel read as one shape when expanded.
+const EDGE_TAB_ID = "bug-report";
+const STACK_OFFSET_BUG = 200;
+const REST_HEIGHT_BUG = 64;
+const PANEL_W = 308;
+const PANEL_H = 420;
+const RAIL_TOP = 72;
+const RAIL_BOTTOM = 16;
+
 export function BugReportButton() {
   const { t } = useDictionary("common");
-  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+  const open = useEdgeTabStore((s) => s.activeTab === EDGE_TAB_ID);
+  const anyActive = useEdgeTabStore((s) => s.activeTab !== null);
+  const toggle = useEdgeTabStore((s) => s.toggle);
+  const close = useEdgeTabStore((s) => s.close);
+
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [category, setCategory] = useState<BugReportCategory>("bug");
@@ -58,11 +82,8 @@ export function BugReportButton() {
   const [screenshotBlob, setScreenshotBlob] = useState<Blob | null>(null);
   const [includeScreenshot, setIncludeScreenshot] = useState(true);
   const [capturingScreenshot, setCapturingScreenshot] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
   const prefersReducedMotion = useReducedMotion();
-  const pathname = usePathname();
   const { currentUser, company } = useAuthStore();
-  const sidebarWidth = 72;
 
   // Minimal-form gate. Trades business owners get one textarea + submit;
   // power user (the developer) gets full triage controls. Defaults applied
@@ -79,12 +100,11 @@ export function BugReportButton() {
    * shows what the user was actually looking at when they hit the bug button.
    * modern-screenshot handles backdrop-filter / custom fonts better than
    * html2canvas, which is important for this app's frosted-glass surfaces.
+   *
+   * Capture runs only on the OPEN transition — not on close — so toggling
+   * closed doesn't burn a second screenshot.
    */
-  const handleOpen = useCallback(async () => {
-    if (open) {
-      setOpen(false);
-      return;
-    }
+  const captureScreenshot = useCallback(async () => {
     setCapturingScreenshot(true);
     try {
       const { domToBlob } = await import("modern-screenshot");
@@ -95,7 +115,7 @@ export function BugReportButton() {
         backgroundColor: "#0A0A0A",
         filter: (node) => {
           if (!(node instanceof HTMLElement)) return true;
-          // Skip the bug report button itself and anything that opts out
+          // Skip the bug report tab/panel itself and anything that opts out
           if (node.dataset?.bugReportIgnore === "true") return false;
           return true;
         },
@@ -107,40 +127,35 @@ export function BugReportButton() {
       setScreenshotBlob(null);
     } finally {
       setCapturingScreenshot(false);
-      setOpen(true);
     }
-  }, [open]);
+  }, []);
 
-  // Close on outside click
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
-        handleClose();
-      }
+  const handleToggle = useCallback(() => {
+    // If we're about to OPEN the panel, capture the screenshot first so the
+    // panel itself isn't in frame.
+    if (!open) {
+      void captureScreenshot();
     }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
+    toggle(EDGE_TAB_ID);
+  }, [open, toggle, captureScreenshot]);
 
-  // Close on Escape
+  // Close on Escape — duplicates the EdgeTab behavior but adds form reset.
   useEffect(() => {
     if (!open) return;
     function handleKey(e: KeyboardEvent) {
-      if (e.key === "Escape") handleClose();
+      if (e.key === "Escape") {
+        if (formState === "submitting") return;
+        close(EDGE_TAB_ID);
+      }
     }
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [open]);
+  }, [open, formState, close]);
 
-  function handleClose() {
-    if (formState === "submitting") return;
-    setOpen(false);
-    // Reset after animation
-    setTimeout(() => {
+  // Reset form a beat after closing so the exit animation has time to play.
+  useEffect(() => {
+    if (open) return;
+    const t = setTimeout(() => {
       setTitle("");
       setDescription("");
       setCategory("bug");
@@ -150,8 +165,9 @@ export function BugReportButton() {
       setErrorMessage(null);
       setScreenshotBlob(null);
       setIncludeScreenshot(true);
-    }, 200);
-  }
+    }, 220);
+    return () => clearTimeout(t);
+  }, [open]);
 
   const handleSubmit = useCallback(async () => {
     if (!title.trim() || formState === "submitting") return;
@@ -274,7 +290,7 @@ export function BugReportButton() {
 
       setFormState("success");
       setTimeout(() => {
-        handleClose();
+        close(EDGE_TAB_ID);
       }, 1200);
     } catch (err) {
       console.error("Bug report submission failed:", err);
@@ -283,140 +299,201 @@ export function BugReportButton() {
         err instanceof Error ? err.message : "Failed to submit bug report."
       );
     }
-  }, [title, description, category, severity, requiresMyInput, formState, currentUser, company, screenshotBlob, includeScreenshot]);
+  }, [title, description, category, severity, requiresMyInput, formState, currentUser, company, screenshotBlob, includeScreenshot, close]);
 
   // Don't render on dashboard (map filter rail occupies bottom-left)
   // Don't render on intel (full-bleed canvas, overlaps cluster legend)
   if (pathname === "/dashboard" || pathname === "/intel") return null;
 
   return (
-    <div
-      ref={containerRef}
-      className="fixed z-[90]"
-      style={{ bottom: 16, left: sidebarWidth + 12 }}
-      data-bug-report-ignore="true"
-    >
-      {/* Popover form */}
-      <AnimatePresence>
+    <>
+      {/* Right-rail edge tab — icon only at rest, "BUG REPORT" wordmark on
+          hover/open. Mirrors NotificationsTab + QuickActionsTab. */}
+      <EdgeTab
+        id={EDGE_TAB_ID}
+        open={open}
+        onToggle={handleToggle}
+        accent="ambient"
+        restHeight={REST_HEIGHT_BUG}
+        expandedHeight={PANEL_H}
+        drawerWidth={PANEL_W}
+        stackOffset={STACK_OFFSET_BUG}
+        canHoverExpand={!anyActive || open}
+        wordmark={t("bugReport.label")}
+        wordmarkOpen="CLOSE"
+        ariaLabel={t("bugReport.title")}
+        tooltipTitle={t("bugReport.title")}
+        renderGlyph={(isOpen) =>
+          capturingScreenshot ? (
+            <Loader2 className="w-[14px] h-[14px] animate-spin" />
+          ) : isOpen ? (
+            <X className="w-[14px] h-[14px]" />
+          ) : (
+            <Bug className="w-[14px] h-[14px]" />
+          )
+        }
+      />
+
+      {/* Panel-anchored drawer — same geometry as Quick Actions so the
+          tab + panel read as one shape (308×420 centered on stackOffset). */}
+      <AnimatePresence mode="wait">
         {open && (
-          <motion.div
-            initial={{ opacity: 0, y: 8, scale: 0.96 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 8, scale: 0.96 }}
-            transition={
-              prefersReducedMotion
-                ? { duration: 0 }
-                : { duration: 0.2, ease: [0.22, 1, 0.36, 1] }
-            }
-            className="absolute bottom-[44px] left-0 w-[320px] rounded-sm overflow-hidden"
+          <div
+            data-bug-report-ignore="true"
+            aria-hidden={false}
             style={{
-              background: "var(--surface-glass)",
-              backdropFilter: "blur(28px) saturate(1.3)",
-              WebkitBackdropFilter: "blur(28px) saturate(1.3)",
-              border: "1px solid rgba(255, 255, 255, 0.08)",
+              position: "fixed",
+              top: RAIL_TOP,
+              right: 0,
+              bottom: RAIL_BOTTOM,
+              width: PANEL_W,
+              pointerEvents: "none",
+              zIndex: 1500,
             }}
           >
-            {/* Header */}
-            <div className="flex items-center justify-between px-3 py-2.5 border-b border-[rgba(255,255,255,0.08)]">
-              <span className="font-mono text-micro uppercase tracking-wider text-text-2">
-                {t("bugReport.title")}
-              </span>
-              <button
-                onClick={handleClose}
-                className="p-1 text-text-mute hover:text-text-2 transition-colors duration-150"
-              >
-                <X className="w-3 h-3" />
-              </button>
-            </div>
+            <motion.div
+              key="bug-report-panel"
+              initial={prefersReducedMotion ? { opacity: 0 } : { x: PANEL_W, opacity: 0 }}
+              animate={prefersReducedMotion ? { opacity: 1 } : { x: 0, opacity: 1 }}
+              exit={prefersReducedMotion ? { opacity: 0 } : { x: PANEL_W, opacity: 0 }}
+              transition={{ duration: prefersReducedMotion ? 0.15 : 0.26, ease: [0.22, 1, 0.36, 1] }}
+              role="dialog"
+              aria-label={t("bugReport.title")}
+              style={{
+                position: "absolute",
+                top: `calc(50% + ${STACK_OFFSET_BUG - PANEL_H / 2}px)`,
+                right: 0,
+                width: PANEL_W,
+                height: PANEL_H,
+                background: "var(--glass)",
+                backdropFilter: "blur(28px) saturate(1.3)",
+                WebkitBackdropFilter: "blur(28px) saturate(1.3)",
+                border: "1px solid var(--glass-border)",
+                borderRight: "none",
+                borderRadius: "10px 0 0 10px",
+                pointerEvents: "auto",
+                display: "flex",
+                flexDirection: "column",
+                overflow: "hidden",
+              }}
+            >
+              {/* Header */}
+              <div className="flex items-center justify-between px-3 py-2.5 border-b border-[rgba(255,255,255,0.08)]">
+                <span className="font-mono text-micro uppercase tracking-wider text-text-2">
+                  {t("bugReport.title")}
+                </span>
+                <button
+                  onClick={() => close(EDGE_TAB_ID)}
+                  className="p-1 text-text-mute hover:text-text-2 transition-colors duration-150"
+                  aria-label="Close"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </div>
 
-            {/* Body */}
-            <div className="p-3 space-y-2.5">
-              {formState === "success" ? (
-                <div className="flex flex-col items-center justify-center py-4 gap-2">
-                  <CheckCircle2 className="w-5 h-5 text-ops-accent" />
-                  <p className="font-mohave text-body-sm text-text-2 text-left">
-                    {t("bugReport.submitted")}
-                  </p>
-                </div>
-              ) : (
-                <>
-                  {isPowerUser && (
-                    /* Category — required. Chip grid wraps to handle longer
-                        localizations (e.g. Spanish "FEATURE REQUEST"). */
-                    <div>
-                      <label className="font-mono text-micro uppercase tracking-wider text-text-3 mb-1 block">
-                        {t("bugReport.category")}
-                      </label>
-                      <div
-                        role="radiogroup"
-                        aria-label={t("bugReport.category")}
-                        className="flex flex-wrap gap-1"
-                      >
-                        {CATEGORY_OPTIONS.map((opt) => {
-                          const isActive = category === opt.value;
-                          return (
-                            <button
-                              key={opt.value}
-                              type="button"
-                              role="radio"
-                              aria-checked={isActive}
-                              onClick={() => setCategory(opt.value)}
-                              className={cn(
-                                "px-2 py-1 rounded-[4px] border transition-colors duration-150",
-                                "font-mono text-[10px] uppercase tracking-wider",
-                                isActive
-                                  ? "border-[rgba(255,255,255,0.18)] bg-[rgba(255,255,255,0.08)] text-text"
-                                  : "border-[rgba(255,255,255,0.08)] bg-transparent text-text-mute hover:text-text-2 hover:bg-[rgba(255,255,255,0.03)]"
-                              )}
-                            >
-                              {t(opt.labelKey)}
-                            </button>
-                          );
-                        })}
+              {/* Body */}
+              <div className="flex-1 overflow-y-auto scrollbar-hide p-3 space-y-2.5">
+                {formState === "success" ? (
+                  <div className="flex flex-col items-center justify-center py-4 gap-2">
+                    <CheckCircle2 className="w-5 h-5 text-ops-accent" />
+                    <p className="font-mohave text-body-sm text-text-2 text-left">
+                      {t("bugReport.submitted")}
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    {isPowerUser && (
+                      <div>
+                        <label className="font-mono text-micro uppercase tracking-wider text-text-3 mb-1 block">
+                          {t("bugReport.category")}
+                        </label>
+                        <div
+                          role="radiogroup"
+                          aria-label={t("bugReport.category")}
+                          className="flex flex-wrap gap-1"
+                        >
+                          {CATEGORY_OPTIONS.map((opt) => {
+                            const isActive = category === opt.value;
+                            return (
+                              <button
+                                key={opt.value}
+                                type="button"
+                                role="radio"
+                                aria-checked={isActive}
+                                onClick={() => setCategory(opt.value)}
+                                className={cn(
+                                  "px-2 py-1 rounded-[4px] border transition-colors duration-150",
+                                  "font-mono text-[10px] uppercase tracking-wider",
+                                  isActive
+                                    ? "border-[rgba(255,255,255,0.18)] bg-[rgba(255,255,255,0.08)] text-text"
+                                    : "border-[rgba(255,255,255,0.08)] bg-transparent text-text-mute hover:text-text-2 hover:bg-[rgba(255,255,255,0.03)]"
+                                )}
+                              >
+                                {t(opt.labelKey)}
+                              </button>
+                            );
+                          })}
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    )}
 
-                  {/* Primary input — single field for minimal users
-                      (their text becomes the full report), title+description
-                      pair for the power user. */}
-                  {isPowerUser ? (
-                    <>
+                    {isPowerUser ? (
+                      <>
+                        <div>
+                          <label className="font-mono text-micro uppercase tracking-wider text-text-3 mb-1 block">
+                            {t("bugReport.whatHappened")}
+                          </label>
+                          <input
+                            type="text"
+                            value={title}
+                            onChange={(e) => setTitle(e.target.value)}
+                            placeholder={t("bugReport.titlePlaceholder")}
+                            className={cn(
+                              "w-full px-2.5 py-2 rounded-sm font-mohave text-body-sm text-text",
+                              "bg-[rgba(255,255,255,0.04)] border border-[rgba(255,255,255,0.08)]",
+                              "placeholder:text-text-mute",
+                              "focus:outline-none focus:border-[rgba(255,255,255,0.20)]/40",
+                              "transition-colors duration-150"
+                            )}
+                            autoFocus
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter" && !e.shiftKey) {
+                                e.preventDefault();
+                                handleSubmit();
+                              }
+                            }}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="font-mono text-micro uppercase tracking-wider text-text-3 mb-1 block">
+                            {t("bugReport.details")}
+                          </label>
+                          <textarea
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            placeholder={t("bugReport.detailsPlaceholder")}
+                            rows={3}
+                            className={cn(
+                              "w-full px-2.5 py-2 rounded-sm font-mohave text-body-sm text-text resize-none",
+                              "bg-[rgba(255,255,255,0.04)] border border-[rgba(255,255,255,0.08)]",
+                              "placeholder:text-text-mute",
+                              "focus:outline-none focus:border-[rgba(255,255,255,0.20)]/40",
+                              "transition-colors duration-150"
+                            )}
+                          />
+                        </div>
+                      </>
+                    ) : (
                       <div>
                         <label className="font-mono text-micro uppercase tracking-wider text-text-3 mb-1 block">
                           {t("bugReport.whatHappened")}
                         </label>
-                        <input
-                          type="text"
+                        <textarea
                           value={title}
                           onChange={(e) => setTitle(e.target.value)}
                           placeholder={t("bugReport.titlePlaceholder")}
-                          className={cn(
-                            "w-full px-2.5 py-2 rounded-sm font-mohave text-body-sm text-text",
-                            "bg-[rgba(255,255,255,0.04)] border border-[rgba(255,255,255,0.08)]",
-                            "placeholder:text-text-mute",
-                            "focus:outline-none focus:border-[rgba(255,255,255,0.20)]/40",
-                            "transition-colors duration-150"
-                          )}
-                          autoFocus
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter" && !e.shiftKey) {
-                              e.preventDefault();
-                              handleSubmit();
-                            }
-                          }}
-                        />
-                      </div>
-
-                      <div>
-                        <label className="font-mono text-micro uppercase tracking-wider text-text-3 mb-1 block">
-                          {t("bugReport.details")}
-                        </label>
-                        <textarea
-                          value={description}
-                          onChange={(e) => setDescription(e.target.value)}
-                          placeholder={t("bugReport.detailsPlaceholder")}
-                          rows={3}
+                          rows={4}
                           className={cn(
                             "w-full px-2.5 py-2 rounded-sm font-mohave text-body-sm text-text resize-none",
                             "bg-[rgba(255,255,255,0.04)] border border-[rgba(255,255,255,0.08)]",
@@ -424,194 +501,136 @@ export function BugReportButton() {
                             "focus:outline-none focus:border-[rgba(255,255,255,0.20)]/40",
                             "transition-colors duration-150"
                           )}
+                          autoFocus
                         />
                       </div>
-                    </>
-                  ) : (
-                    <div>
-                      <label className="font-mono text-micro uppercase tracking-wider text-text-3 mb-1 block">
-                        {t("bugReport.whatHappened")}
-                      </label>
-                      <textarea
-                        value={title}
-                        onChange={(e) => setTitle(e.target.value)}
-                        placeholder={t("bugReport.titlePlaceholder")}
-                        rows={4}
-                        className={cn(
-                          "w-full px-2.5 py-2 rounded-sm font-mohave text-body-sm text-text resize-none",
-                          "bg-[rgba(255,255,255,0.04)] border border-[rgba(255,255,255,0.08)]",
-                          "placeholder:text-text-mute",
-                          "focus:outline-none focus:border-[rgba(255,255,255,0.20)]/40",
-                          "transition-colors duration-150"
-                        )}
-                        autoFocus
-                      />
-                    </div>
-                  )}
+                    )}
 
-                  {isPowerUser && (
-                    /* Severity — optional. Writes to `priority` as a hint; admin
-                        can override during triage. Click active chip to clear. */
-                    <div>
-                      <label className="font-mono text-micro uppercase tracking-wider text-text-3 mb-1 block">
-                        {t("bugReport.severity")}
-                      </label>
-                      <div role="radiogroup" aria-label={t("bugReport.severity")} className="flex gap-1">
-                        {SEVERITY_OPTIONS.map((opt) => {
-                          const isActive = severity === opt.value;
-                          return (
-                            <button
-                              key={opt.value}
-                              type="button"
-                              role="radio"
-                              aria-checked={isActive}
-                              onClick={() => setSeverity(isActive ? null : opt.value)}
-                              className={cn(
-                                "flex-1 px-2 py-1.5 rounded-[4px] border transition-colors duration-150",
-                                "font-mono text-[10px] uppercase tracking-wider",
-                                isActive
-                                  ? "border-[rgba(255,255,255,0.18)] bg-[rgba(255,255,255,0.08)] text-text"
-                                  : "border-[rgba(255,255,255,0.08)] bg-transparent text-text-mute hover:text-text-2 hover:bg-[rgba(255,255,255,0.03)]"
-                              )}
-                            >
-                              {t(opt.labelKey)}
-                            </button>
-                          );
-                        })}
+                    {isPowerUser && (
+                      <div>
+                        <label className="font-mono text-micro uppercase tracking-wider text-text-3 mb-1 block">
+                          {t("bugReport.severity")}
+                        </label>
+                        <div role="radiogroup" aria-label={t("bugReport.severity")} className="flex gap-1">
+                          {SEVERITY_OPTIONS.map((opt) => {
+                            const isActive = severity === opt.value;
+                            return (
+                              <button
+                                key={opt.value}
+                                type="button"
+                                role="radio"
+                                aria-checked={isActive}
+                                onClick={() => setSeverity(isActive ? null : opt.value)}
+                                className={cn(
+                                  "flex-1 px-2 py-1.5 rounded-[4px] border transition-colors duration-150",
+                                  "font-mono text-[10px] uppercase tracking-wider",
+                                  isActive
+                                    ? "border-[rgba(255,255,255,0.18)] bg-[rgba(255,255,255,0.08)] text-text"
+                                    : "border-[rgba(255,255,255,0.08)] bg-transparent text-text-mute hover:text-text-2 hover:bg-[rgba(255,255,255,0.03)]"
+                                )}
+                              >
+                                {t(opt.labelKey)}
+                              </button>
+                            );
+                          })}
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    )}
 
-                  {isPowerUser && (
-                    /* Requires-my-input toggle. When on, the nightly triage
-                        agent skips this report (written to requires_human_review). */
-                    <label
-                      className={cn(
-                        "w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-[4px] border transition-colors cursor-pointer",
-                        requiresMyInput
-                          ? "border-[rgba(255,255,255,0.18)] bg-[rgba(255,255,255,0.06)]"
-                          : "border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)] hover:border-[rgba(255,255,255,0.14)]"
-                      )}
-                    >
-                      <span
-                        className={cn(
-                          "font-mono text-[10px] uppercase tracking-wider text-left",
-                          requiresMyInput ? "text-text-2" : "text-text-mute"
-                        )}
-                      >
-                        {requiresMyInput
-                          ? `[${t("bugReport.requiresInputOn")}]`
-                          : t("bugReport.requiresInputOff")}
-                      </span>
-                      <Switch
-                        checked={requiresMyInput}
-                        onCheckedChange={setRequiresMyInput}
-                      />
-                    </label>
-                  )}
-
-                  {/* Auto-captured context. Power user gets a screenshot toggle;
-                      minimal users get the screenshot attached silently. */}
-                  <div className="space-y-1.5">
-                    <p className="font-mono text-micro text-text-mute tracking-wider">
-                      {t("bugReport.autoCapture")}
-                    </p>
-                    {isPowerUser && screenshotBlob && (
+                    {isPowerUser && (
                       <label
                         className={cn(
-                          "w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-sm border transition-colors cursor-pointer",
-                          includeScreenshot
-                            ? "border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.05)]"
-                            : "border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)]"
+                          "w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-[4px] border transition-colors cursor-pointer",
+                          requiresMyInput
+                            ? "border-[rgba(255,255,255,0.18)] bg-[rgba(255,255,255,0.06)]"
+                            : "border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)] hover:border-[rgba(255,255,255,0.14)]"
                         )}
                       >
                         <span
                           className={cn(
-                            "font-mono text-micro tracking-wider uppercase text-left",
-                            includeScreenshot ? "text-ops-accent" : "text-text-mute"
+                            "font-mono text-[10px] uppercase tracking-wider text-left",
+                            requiresMyInput ? "text-text-2" : "text-text-mute"
                           )}
                         >
-                          {includeScreenshot
-                            ? `[ATTACH SCREENSHOT · ${Math.round(screenshotBlob.size / 1024)}KB]`
-                            : "[SCREENSHOT OFF]"}
+                          {requiresMyInput
+                            ? `[${t("bugReport.requiresInputOn")}]`
+                            : t("bugReport.requiresInputOff")}
                         </span>
                         <Switch
-                          checked={includeScreenshot}
-                          onCheckedChange={setIncludeScreenshot}
+                          checked={requiresMyInput}
+                          onCheckedChange={setRequiresMyInput}
                         />
                       </label>
                     )}
-                  </div>
 
-                  {/* Error state */}
-                  {formState === "error" && errorMessage && (
-                    <div className="flex items-start gap-1.5 px-2 py-1.5 rounded-sm border border-[rgba(220,80,80,0.3)] bg-[rgba(220,80,80,0.08)]">
-                      <AlertCircle className="w-3 h-3 text-[#E57373] mt-[2px] flex-shrink-0" />
-                      <p className="font-mono text-micro tracking-wider text-[#E57373] break-words">
-                        {errorMessage}
+                    <div className="space-y-1.5">
+                      <p className="font-mono text-micro text-text-mute tracking-wider">
+                        {t("bugReport.autoCapture")}
                       </p>
+                      {isPowerUser && screenshotBlob && (
+                        <label
+                          className={cn(
+                            "w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-sm border transition-colors cursor-pointer",
+                            includeScreenshot
+                              ? "border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.05)]"
+                              : "border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)]"
+                          )}
+                        >
+                          <span
+                            className={cn(
+                              "font-mono text-micro tracking-wider uppercase text-left",
+                              includeScreenshot ? "text-ops-accent" : "text-text-mute"
+                            )}
+                          >
+                            {includeScreenshot
+                              ? `[ATTACH SCREENSHOT · ${Math.round(screenshotBlob.size / 1024)}KB]`
+                              : "[SCREENSHOT OFF]"}
+                          </span>
+                          <Switch
+                            checked={includeScreenshot}
+                            onCheckedChange={setIncludeScreenshot}
+                          />
+                        </label>
+                      )}
                     </div>
-                  )}
 
-                  {/* Submit */}
-                  <button
-                    onClick={handleSubmit}
-                    disabled={!title.trim() || formState === "submitting"}
-                    className={cn(
-                      "w-full flex items-center justify-center gap-1.5 px-3 py-2 rounded-sm",
-                      "font-mono text-micro uppercase tracking-wider",
-                      "transition-all duration-150",
-                      title.trim() && formState !== "submitting"
-                        ? "bg-[rgba(255,255,255,0.08)] text-ops-accent border border-[rgba(255,255,255,0.15)] hover:bg-ops-accent/30"
-                        : "bg-[rgba(255,255,255,0.04)] text-text-mute border border-[rgba(255,255,255,0.06)] cursor-not-allowed"
+                    {formState === "error" && errorMessage && (
+                      <div className="flex items-start gap-1.5 px-2 py-1.5 rounded-sm border border-[rgba(220,80,80,0.3)] bg-[rgba(220,80,80,0.08)]">
+                        <AlertCircle className="w-3 h-3 text-[#E57373] mt-[2px] flex-shrink-0" />
+                        <p className="font-mono text-micro tracking-wider text-[#E57373] break-words">
+                          {errorMessage}
+                        </p>
+                      </div>
                     )}
-                  >
-                    {formState === "submitting" ? (
-                      <Loader2 className="w-3 h-3 animate-spin" />
-                    ) : (
-                      <Send className="w-3 h-3" />
-                    )}
-                    {formState === "submitting"
-                      ? t("bugReport.sending")
-                      : t("bugReport.submit")}
-                  </button>
-                </>
-              )}
-            </div>
-          </motion.div>
+
+                    <button
+                      onClick={handleSubmit}
+                      disabled={!title.trim() || formState === "submitting"}
+                      className={cn(
+                        "w-full flex items-center justify-center gap-1.5 px-3 py-2 rounded-sm",
+                        "font-mono text-micro uppercase tracking-wider",
+                        "transition-all duration-150",
+                        title.trim() && formState !== "submitting"
+                          ? "bg-[rgba(255,255,255,0.08)] text-ops-accent border border-[rgba(255,255,255,0.15)] hover:bg-ops-accent/30"
+                          : "bg-[rgba(255,255,255,0.04)] text-text-mute border border-[rgba(255,255,255,0.06)] cursor-not-allowed"
+                      )}
+                    >
+                      {formState === "submitting" ? (
+                        <Loader2 className="w-3 h-3 animate-spin" />
+                      ) : (
+                        <Send className="w-3 h-3" />
+                      )}
+                      {formState === "submitting"
+                        ? t("bugReport.sending")
+                        : t("bugReport.submit")}
+                    </button>
+                  </>
+                )}
+              </div>
+            </motion.div>
+          </div>
         )}
       </AnimatePresence>
-
-      {/* Bug button */}
-      <motion.button
-        onClick={handleOpen}
-        disabled={capturingScreenshot}
-        initial={{ opacity: 0, scale: 0.9 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={
-          prefersReducedMotion
-            ? { duration: 0 }
-            : { duration: 0.3, ease: [0.22, 1, 0.36, 1] }
-        }
-        className={cn(
-          "flex items-center gap-1.5 px-2 py-1.5 rounded-[5px]",
-          "glass-surface",
-          "hover:border-[rgba(255,255,255,0.18)]",
-          "transition-colors duration-150",
-          open && "!border-[rgba(255,255,255,0.20)]",
-          capturingScreenshot && "opacity-60 cursor-wait"
-        )}
-        title={t("bugReport.title")}
-      >
-        {capturingScreenshot ? (
-          <Loader2 className="w-[13px] h-[13px] text-text-mute animate-spin" />
-        ) : (
-          <Bug className="w-[13px] h-[13px] text-text-mute" />
-        )}
-        <span className="font-mono text-micro text-text-mute tracking-wider uppercase select-none">
-          {t("bugReport.label")}
-        </span>
-      </motion.button>
-    </div>
+    </>
   );
 }

--- a/src/components/ui/edge-tab.tsx
+++ b/src/components/ui/edge-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useReducedMotion } from "framer-motion";
 import type { EdgeTabProps, EdgeTabAccent } from "./edge-tab.types";
 
@@ -44,6 +44,30 @@ export function EdgeTab({
   const [hovered, setHovered] = useState(false);
   const reducedMotion = useReducedMotion();
 
+  // Live viewport height — drives the rail-height clamp so the expanded tab
+  // never grows beyond the visible rail on shorter screens (13" laptops in
+  // particular tend to land below 720px). SSR-safe default 0 means "no clamp"
+  // until first client measurement.
+  const [viewportH, setViewportH] = useState<number>(() =>
+    typeof window === "undefined" ? 0 : window.innerHeight
+  );
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onResize = () => setViewportH(window.innerHeight);
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  // Maximum tab height we'll allow. The wrapper occupies the rail bounded by
+  // railTop / railBottom from the viewport, so the rail height is
+  // `vh - railTop - railBottom`. We never let the tab exceed that.
+  const railHeight = viewportH > 0 ? viewportH - railTop - railBottom : null;
+  const clampToRail = (h: number): number => {
+    if (railHeight == null || railHeight <= 0) return h;
+    return Math.min(h, railHeight);
+  };
+
   const expanded = open || (hovered && canHoverExpand);
 
   // ─── Tab vertical positioning ──────────────────────────────────────────────
@@ -76,6 +100,11 @@ export function EdgeTab({
   //   HOVER without expandedHeight → stay at rest height. Better than
   //     bursting full-rail and covering the sibling tab.
 
+  // Fit-to-rail helpers. Once we know rail height, recompute every
+  // expanded-state tabTop using the clamped tabHeight (instead of the raw
+  // requested height). This keeps the expanded tab anchored to the same
+  // visual edge it was supposed to anchor to (drawer center / sibling-tab
+  // boundary) but never extends beyond the rail on short viewports.
   let tabTop: string;
   let tabHeight: string | number;
   if (!expanded) {
@@ -83,27 +112,51 @@ export function EdgeTab({
     tabHeight = restHeight;
   } else if (open && typeof expandedHeight === "number") {
     // Open + panel clamp → align with the panel-anchored drawer.
-    tabTop = `calc(50% + ${stackOffset - expandedHeight / 2}px)`;
-    tabHeight = expandedHeight;
+    const h = clampToRail(expandedHeight);
+    tabTop = `calc(50% + ${stackOffset - h / 2}px)`;
+    tabHeight = h;
   } else if (open) {
-    // Open + no clamp → legacy full-rail expansion.
+    // Open + no clamp → legacy full-rail expansion. railHeight already
+    // matches wrapper height, so "100%" stays correct here.
     tabTop = "0";
     tabHeight = "100%";
   } else if (typeof expandedHeight === "number") {
     // Hover only → grow outward from the near edge, never crossing the
-    // rail midpoint into the sibling tab's half.
+    // rail midpoint into the sibling tab's half. Clamp height to rail so
+    // short viewports don't push the tab past the rail's far edge.
+    const h = clampToRail(expandedHeight);
     if (stackOffset >= 0) {
       // Below center: anchor TOP edge of rest position, grow down.
       tabTop = `calc(50% + ${stackOffset - restHeight / 2}px)`;
     } else {
       // Above center: anchor BOTTOM edge of rest position, grow up.
-      tabTop = `calc(50% + ${stackOffset + restHeight / 2 - expandedHeight}px)`;
+      tabTop = `calc(50% + ${stackOffset + restHeight / 2 - h}px)`;
     }
-    tabHeight = expandedHeight;
+    tabHeight = h;
   } else {
     // Hover only without `expandedHeight` → stay at rest.
     tabTop = `calc(50% + ${stackOffset - restHeight / 2}px)`;
     tabHeight = restHeight;
+  }
+
+  // Final safety: cap absolute placement so the tab never spills below the
+  // rail bottom (or above the rail top) on any viewport. Apply only when
+  // we've measured the viewport (railHeight known) AND tabTop is a calc()
+  // we can parse — the legacy "0" / "100%" full-rail expansion already
+  // fits by construction.
+  let tabTopCap: number | undefined;
+  if (railHeight != null && typeof tabHeight === "number") {
+    const offsetMatch =
+      typeof tabTop === "string"
+        ? tabTop.match(/^calc\(50%\s*\+\s*(-?\d+(?:\.\d+)?)px\)$/)
+        : null;
+    if (offsetMatch) {
+      const offset = parseFloat(offsetMatch[1]);
+      const rawTop = railHeight / 2 + offset;
+      const maxTop = railHeight - tabHeight;
+      const clampedTop = Math.max(0, Math.min(rawTop, maxTop));
+      tabTopCap = clampedTop;
+    }
   }
 
   return (
@@ -139,7 +192,7 @@ export function EdgeTab({
         onBlur={() => setHovered(false)}
         style={{
           position: "absolute",
-          top: tabTop,
+          top: tabTopCap != null ? `${tabTopCap}px` : tabTop,
           right: open ? drawerWidth : 0,
           width: TAB_WIDTH,
           height: tabHeight,


### PR DESCRIPTION
## Summary

Automated nightly bug sweep — Batch 01 of 02 (web). 5 fixes, 5 escalations.

## Fixed

- [x] **da6204e1** · `bug` · Cannot drag right edge of task across rows in month view. Hook tracked horizontal pixel delta only. Now hit-tests `[data-month-week-row]` under cursor + computes dayDelta from absolute target day, supporting +N week extensions.
- [x] **edfdd057** · `bug` · Quick Actions / Notifications tab hover animation extending beyond screen bounds on laptops. EdgeTab now measures viewport, clamps expanded height to rail height, and clamps tab top so it never overflows the rail.
- [x] **5c19dc85** · `bug` (high) · Calendar event cards too condensed at laptop screen size. Bumped `DEFAULT_CELL_HEIGHT` 120→140 and standard / multi-day-expanded month bars from 14px/11px to 16px/12px (height/font). Layout math updated in lockstep.
- [x] **b842f0ff** · `bug` (low) · Bug-report button now a right-rail edge tab below Quick Actions (icon-only at rest, "BUG" wordmark on hover). Form panel mirrors Quick Actions geometry. Uses `useEdgeTabStore` so all three tabs are mutually exclusive.
- [x] **5b653c30** · `bug` (high) · Edge-tab drawers (Notifications, Quick Actions, Bug Report) now dismiss when the user clicks outside. New `EdgeTabOutsideDismiss` mounted once in DashboardLayout; drawers tagged with `data-edge-tab-drawer`.

## Escalated (`requires_human_review = true`)

- **8d06d3a9** · Requests Supabase→S3 image migration. Out of nightly sweep scope.
- **71b6f2e6** · Reporter clarification (not a bug). 90863dc2 confirmed correct behavior.
- **90863dc2** · Per follow-up `71b6f2e6`, this is correct behavior. Not a bug.
- **b48d8f69** · Cross-repo task — needs changes in `ops-site` / `try-ops` / `ops-learn`, not OPS-Web.
- **d5da3d51** · No photo-limit notification surface exists in `ops-web`. Likely iOS-only or backend-originated. Needs cross-repo investigation.

## Test plan

- [ ] Month view: drag right edge of a 1-day event downward into the next week's row → bar extends by ≥7 days.
- [ ] On a 13" / 14" laptop (viewport ≤ 720px tall), open Quick Actions and Notifications. Hover/expand stays inside the visible rail.
- [ ] Default month view: event cards read more legibly with 16px bars and 12px titles. Cmd+wheel zoom still works between MIN and MAX cell heights.
- [ ] Right rail shows three stacked tabs: Notifications (top), Quick Actions (middle), Bug (bottom). Bug tab is icon-only at rest, "BUG" wordmark on hover. Clicking opens the form panel.
- [ ] With any drawer open, clicking on the page canvas closes the drawer. Clicks inside dropdowns / dialogs portaled from drawer content keep the drawer open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)