### PR TITLE
feat(products): write category_id and unit_id FKs alongside legacy text

### DIFF
--- a/src/app/(dashboard)/products/page.tsx
+++ b/src/app/(dashboard)/products/page.tsx
@@ -27,6 +27,9 @@ import {
   useDeleteProduct,
   useTaskTypes,
   useProductMetrics,
+  useCatalogLookups,
+  resolveCategoryId,
+  resolveUnitId,
 } from "@/lib/hooks";
 import { MetricsHeader } from "@/components/metrics";
 import {
@@ -328,6 +331,12 @@ function ProductFormModal({
   const { t } = useDictionary("dashboard");
   const isEditing = !!product;
   const { data: taskTypes = [] } = useTaskTypes();
+  // Best-effort name -> FK resolution. Stopgap for P0; replaced by real
+  // pickers in P0-2. When the typed value matches an existing catalog row
+  // (case-insensitive, trimmed) we write the FK alongside the legacy text;
+  // otherwise the FK is left NULL and only the legacy column is written.
+  const { categories: catalogCategories, units: catalogUnits } =
+    useCatalogLookups();
 
   const [name, setName] = useState(product?.name ?? "");
   const [description, setDescription] = useState(product?.description ?? "");
@@ -367,13 +376,22 @@ function ProductFormModal({
   const handleSubmit = () => {
     if (!name.trim()) return;
 
+    const trimmedCategory = category.trim() || null;
+    const resolvedCategoryId = resolveCategoryId(
+      trimmedCategory,
+      catalogCategories
+    );
+    const resolvedUnitId = resolveUnitId(unit, catalogUnits);
+
     const data = {
       name: name.trim(),
       description: description.trim() || null,
       defaultPrice,
       unitCost: unitCost || null,
       unit,
-      category: category.trim() || null,
+      unitId: resolvedUnitId,
+      category: trimmedCategory,
+      categoryId: resolvedCategoryId,
       taskTypeId: taskTypeId || null,
       isTaxable,
       isActive,

--- a/src/lib/api/services/product-service.ts
+++ b/src/lib/api/services/product-service.ts
@@ -24,7 +24,9 @@ function mapProductFromDb(row: Record<string, unknown>): Product {
     defaultPrice: Number(row.default_price ?? 0),
     unitCost: row.unit_cost != null ? Number(row.unit_cost) : null,
     unit: (row.unit as string) ?? "each",
+    unitId: (row.unit_id as string) ?? null,
     category: (row.category as string) ?? null,
+    categoryId: (row.category_id as string) ?? null,
     isTaxable: (row.is_taxable as boolean) ?? false,
     isActive: (row.is_active as boolean) ?? true,
     type: ((row.type as string) ?? "LABOR") as LineItemType,
@@ -46,7 +48,9 @@ function mapProductToDb(
   if (data.defaultPrice !== undefined) row.default_price = data.defaultPrice;
   if (data.unitCost !== undefined) row.unit_cost = data.unitCost;
   if (data.unit !== undefined) row.unit = data.unit;
+  if (data.unitId !== undefined) row.unit_id = data.unitId ?? null;
   if (data.category !== undefined) row.category = data.category;
+  if (data.categoryId !== undefined) row.category_id = data.categoryId ?? null;
   if (data.isTaxable !== undefined) row.is_taxable = data.isTaxable;
   if (data.isActive !== undefined) row.is_active = data.isActive;
   if (data.type !== undefined) row.type = data.type;

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -126,6 +126,17 @@ export {
   useDeleteProduct,
 } from "./use-products";
 
+// Catalog lookups (categories + units; read-only)
+export {
+  useCatalogLookups,
+  resolveCategoryId,
+  resolveUnitId,
+} from "./use-catalog-lookups";
+export type {
+  CatalogCategoryLookup,
+  CatalogUnitLookup,
+} from "./use-catalog-lookups";
+
 // Estimates
 export {
   useEstimates,

--- a/src/lib/hooks/use-catalog-lookups.ts
+++ b/src/lib/hooks/use-catalog-lookups.ts
@@ -1,0 +1,122 @@
+/**
+ * OPS Web - Catalog Lookups Hook
+ *
+ * Lightweight read-only fetcher for `catalog_categories` and `catalog_units`
+ * scoped to the active company. Used by the products form to resolve a
+ * user-typed `category` / `unit` string into its FK id when an exact match
+ * exists in the catalog (case-insensitive, trimmed). When no match, the
+ * caller leaves the FK NULL and writes only the legacy free-text column.
+ *
+ * This is a stopgap for the P0 FK-write parity with iOS. Replace with real
+ * pickers (Menu/Combobox over both tables) in P0-2.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { requireSupabase } from "@/lib/supabase/helpers";
+import { useAuthStore } from "@/lib/store/auth-store";
+
+export interface CatalogCategoryLookup {
+  id: string;
+  name: string;
+}
+
+export interface CatalogUnitLookup {
+  id: string;
+  display: string;
+  abbreviation: string | null;
+}
+
+async function fetchCatalogCategories(
+  companyId: string
+): Promise<CatalogCategoryLookup[]> {
+  const supabase = requireSupabase();
+  const { data, error } = await supabase
+    .from("catalog_categories")
+    .select("id, name")
+    .eq("company_id", companyId)
+    .is("deleted_at", null);
+
+  if (error) {
+    throw new Error(`Failed to fetch catalog categories: ${error.message}`);
+  }
+  return (data ?? []) as CatalogCategoryLookup[];
+}
+
+async function fetchCatalogUnits(
+  companyId: string
+): Promise<CatalogUnitLookup[]> {
+  const supabase = requireSupabase();
+  const { data, error } = await supabase
+    .from("catalog_units")
+    .select("id, display, abbreviation")
+    .eq("company_id", companyId)
+    .is("deleted_at", null);
+
+  if (error) {
+    throw new Error(`Failed to fetch catalog units: ${error.message}`);
+  }
+  return (data ?? []) as CatalogUnitLookup[];
+}
+
+export function useCatalogLookups() {
+  const { company } = useAuthStore();
+  const companyId = company?.id ?? "";
+
+  const categoriesQuery = useQuery({
+    queryKey: ["catalog-categories", companyId],
+    queryFn: () => fetchCatalogCategories(companyId),
+    enabled: !!companyId,
+  });
+
+  const unitsQuery = useQuery({
+    queryKey: ["catalog-units", companyId],
+    queryFn: () => fetchCatalogUnits(companyId),
+    enabled: !!companyId,
+  });
+
+  return {
+    categories: categoriesQuery.data ?? [],
+    units: unitsQuery.data ?? [],
+    isLoading: categoriesQuery.isLoading || unitsQuery.isLoading,
+  };
+}
+
+/**
+ * Resolve a user-typed category string to a `catalog_categories.id`.
+ * Returns null if no exact match (case-insensitive, trimmed) is found —
+ * callers should leave the FK NULL in that case and continue to write
+ * the legacy free-text `category` column.
+ */
+export function resolveCategoryId(
+  raw: string | null | undefined,
+  categories: ReadonlyArray<CatalogCategoryLookup>
+): string | null {
+  const trimmed = (raw ?? "").trim().toLowerCase();
+  if (!trimmed) return null;
+  const match = categories.find(
+    (c) => c.name.trim().toLowerCase() === trimmed
+  );
+  return match?.id ?? null;
+}
+
+/**
+ * Resolve a user-typed unit string to a `catalog_units.id`. Matches against
+ * `display` first, then falls back to `abbreviation`. Returns null if no
+ * exact match (case-insensitive, trimmed) — same NULL-FK fallback policy
+ * as `resolveCategoryId`.
+ */
+export function resolveUnitId(
+  raw: string | null | undefined,
+  units: ReadonlyArray<CatalogUnitLookup>
+): string | null {
+  const trimmed = (raw ?? "").trim().toLowerCase();
+  if (!trimmed) return null;
+  const byDisplay = units.find(
+    (u) => u.display.trim().toLowerCase() === trimmed
+  );
+  if (byDisplay) return byDisplay.id;
+  const byAbbrev = units.find(
+    (u) => (u.abbreviation ?? "").trim().toLowerCase() === trimmed
+  );
+  return byAbbrev?.id ?? null;
+}

--- a/src/lib/types/pipeline.ts
+++ b/src/lib/types/pipeline.ts
@@ -483,7 +483,9 @@ export interface Product {
   defaultPrice: number;
   unitCost: number | null;
   unit: string;
+  unitId?: string | null;      // FK to catalog_units.id; nullable for legacy rows
   category: string | null;
+  categoryId?: string | null;  // FK to catalog_categories.id; nullable for legacy rows
   type: LineItemType;
   taskTypeId: string | null;
   isTaxable: boolean;


### PR DESCRIPTION
## Summary

The iOS catalog UI now writes `category_id` (FK to `catalog_categories`) and `unit_id` (FK to `catalog_units`) on every product create + edit. The web `/products` flow did not — every product authored on web shipped with both FKs `NULL`, diverging from iOS rows in the same table.

This PR is the minimum-viable closure of that data divergence: when the user types a category/unit string that already matches a `catalog_categories` / `catalog_units` row by exact name (case-insensitive), the FK is written alongside the legacy text. When no match exists, the FK is left `NULL` (same fallback iOS produces). Real FK-backed pickers + inline "+ NEW…" creation are P0-2 / P0-3 — separate sessions.

## Scope

- 4 atomic commits (see commit list)
- TypeScript clean (`npm run type-check` exit 0)
- Lint clean on changed files (pre-existing warnings unrelated)
- 886 tests pass / 5 skipped — no regressions

## Test plan

- [ ] Create a product on web with category="Hardware" (assuming a CatalogCategory row named "Hardware" exists for your company) → confirm `category_id` populated in DB
- [ ] Create a product with category="asdf" (no match) → confirm `category_id` is NULL but legacy `category` says "asdf"
- [ ] Same two scenarios for unit
- [ ] Edit an existing product, change category in the form, save → confirm `category_id` updates lockstep with `category`
- [ ] After deploy, run the verification SQL queries below

## Verification SQL (run after deploy)

\`\`\`sql
-- How many products have FK populated vs not (per company)
SELECT
  company_id,
  COUNT(*) AS total,
  COUNT(*) FILTER (WHERE category_id IS NOT NULL) AS with_category_fk,
  COUNT(*) FILTER (WHERE unit_id IS NOT NULL) AS with_unit_fk
FROM products
WHERE deleted_at IS NULL
GROUP BY company_id;

-- Recently created: did the FK write?
SELECT id, name, category, category_id, unit, unit_id, created_at
FROM products
WHERE deleted_at IS NULL AND created_at > now() - interval '24 hours'
ORDER BY created_at DESC;

-- Distribution of which category names matched vs didn't
SELECT category, COUNT(*) AS total, COUNT(*) FILTER (WHERE category_id IS NOT NULL) AS resolved
FROM products WHERE deleted_at IS NULL AND category IS NOT NULL
GROUP BY category ORDER BY total DESC LIMIT 30;
\`\`\`

## What's deferred

- **P0-2** — real FK-backed pickers (Menu/Combobox over `catalog_categories` / `catalog_units`)
- **P0-3** — inline "+ NEW CATEGORY…" / "+ NEW UNIT…" affordances mirroring iOS
- **P1-1** — kind/type pickers + the rest of the iOS DTO field-set drift
- **P1-2** — options + modifiers authoring on web dashboard (closes the iOS "edit on web" footer-note loop)

Each is its own follow-up.

## Audit reference

`docs/audit-2026-05-08-products.md` — full P0/P1/P2 list with file refs.