### PR TITLE
feat(products): FK-backed category + unit pickers with inline create

### DIFF
--- a/src/app/(dashboard)/products/page.tsx
+++ b/src/app/(dashboard)/products/page.tsx
@@ -20,6 +20,10 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { EmptyState } from "@/components/ops/empty-state";
 import { ProductBomEditor } from "@/components/ops/product-bom-editor";
+import { CategoryPicker } from "@/components/ops/category-picker";
+import { UnitPicker } from "@/components/ops/unit-picker";
+import { InlineCreateCategoryDialog } from "@/components/ops/inline-create-category-dialog";
+import { InlineCreateUnitDialog } from "@/components/ops/inline-create-unit-dialog";
 import {
   useProducts,
   useCreateProduct,
@@ -28,14 +32,11 @@ import {
   useTaskTypes,
   useProductMetrics,
   useCatalogLookups,
-  resolveCategoryId,
-  resolveUnitId,
 } from "@/lib/hooks";
 import { MetricsHeader } from "@/components/metrics";
 import {
   formatCurrency,
   calculateMargin,
-  UNIT_OPTIONS,
 } from "@/lib/types/pipeline";
 import type { Product, CreateProduct } from "@/lib/types/pipeline";
 import { useAuthStore } from "@/lib/store/auth-store";
@@ -331,10 +332,12 @@ function ProductFormModal({
   const { t } = useDictionary("dashboard");
   const isEditing = !!product;
   const { data: taskTypes = [] } = useTaskTypes();
-  // Best-effort name -> FK resolution. Stopgap for P0; replaced by real
-  // pickers in P0-2. When the typed value matches an existing catalog row
-  // (case-insensitive, trimmed) we write the FK alongside the legacy text;
-  // otherwise the FK is left NULL and only the legacy column is written.
+  // Catalog lookups feed the legacy-text reconciliation path: when an
+  // editing form opens with a free-text `unit` / `category` from a row
+  // that pre-dates the FK columns, we look it up by name on first
+  // render so the picker shows the matching row instead of the
+  // placeholder. New writes always carry the FK directly via the
+  // picker callbacks.
   const { categories: catalogCategories, units: catalogUnits } =
     useCatalogLookups();
 
@@ -343,10 +346,16 @@ function ProductFormModal({
   const [defaultPrice, setDefaultPrice] = useState(product?.defaultPrice ?? 0);
   const [unitCost, setUnitCost] = useState(product?.unitCost ?? 0);
   const [unit, setUnit] = useState(product?.unit ?? "each");
+  const [unitId, setUnitId] = useState<string | null>(product?.unitId ?? null);
   const [category, setCategory] = useState(product?.category ?? "");
+  const [categoryId, setCategoryId] = useState<string | null>(
+    product?.categoryId ?? null
+  );
   const [taskTypeId, setTaskTypeId] = useState<string | null>(product?.taskTypeId ?? null);
   const [isTaxable, setIsTaxable] = useState(product?.isTaxable ?? true);
   const [isActive, setIsActive] = useState(product?.isActive ?? true);
+  const [showNewCategoryDialog, setShowNewCategoryDialog] = useState(false);
+  const [showNewUnitDialog, setShowNewUnitDialog] = useState(false);
 
   // Reset form when product changes
   useEffect(() => {
@@ -356,7 +365,9 @@ function ProductFormModal({
       setDefaultPrice(product.defaultPrice);
       setUnitCost(product.unitCost ?? 0);
       setUnit(product.unit ?? "each");
+      setUnitId(product.unitId ?? null);
       setCategory(product.category ?? "");
+      setCategoryId(product.categoryId ?? null);
       setTaskTypeId(product.taskTypeId ?? null);
       setIsTaxable(product.isTaxable);
       setIsActive(product.isActive);
@@ -366,22 +377,46 @@ function ProductFormModal({
       setDefaultPrice(0);
       setUnitCost(0);
       setUnit("each");
+      setUnitId(null);
       setCategory("");
+      setCategoryId(null);
       setTaskTypeId(null);
       setIsTaxable(true);
       setIsActive(true);
     }
   }, [product]);
 
+  // Backfill FK ids from legacy free-text values for products that
+  // pre-date the FK columns. This only runs when the form has a text
+  // value but no id, and the lookup tables have loaded — once a match
+  // is found the picker reflects it. New rows skip this entirely
+  // because the picker writes the id at selection time.
+  useEffect(() => {
+    if (!categoryId && category.trim() && catalogCategories.length > 0) {
+      const trimmed = category.trim().toLowerCase();
+      const match = catalogCategories.find(
+        (c) => c.name.trim().toLowerCase() === trimmed
+      );
+      if (match) setCategoryId(match.id);
+    }
+  }, [categoryId, category, catalogCategories]);
+
+  useEffect(() => {
+    if (!unitId && unit.trim() && catalogUnits.length > 0) {
+      const trimmed = unit.trim().toLowerCase();
+      const match =
+        catalogUnits.find(
+          (u) => u.display.trim().toLowerCase() === trimmed
+        ) ??
+        catalogUnits.find(
+          (u) => (u.abbreviation ?? "").trim().toLowerCase() === trimmed
+        );
+      if (match) setUnitId(match.id);
+    }
+  }, [unitId, unit, catalogUnits]);
+
   const handleSubmit = () => {
     if (!name.trim()) return;
-
-    const trimmedCategory = category.trim() || null;
-    const resolvedCategoryId = resolveCategoryId(
-      trimmedCategory,
-      catalogCategories
-    );
-    const resolvedUnitId = resolveUnitId(unit, catalogUnits);
 
     const data = {
       name: name.trim(),
@@ -389,9 +424,9 @@ function ProductFormModal({
       defaultPrice,
       unitCost: unitCost || null,
       unit,
-      unitId: resolvedUnitId,
-      category: trimmedCategory,
-      categoryId: resolvedCategoryId,
+      unitId,
+      category: category.trim() || null,
+      categoryId,
       taskTypeId: taskTypeId || null,
       isTaxable,
       isActive,
@@ -475,27 +510,37 @@ function ProductFormModal({
           {/* Unit / Category */}
           <div className="grid grid-cols-2 gap-2">
             <div className="space-y-0.5">
-              <label className="font-mono text-caption-sm text-text-3 uppercase tracking-widest">
+              <label
+                htmlFor="product-form-unit"
+                className="font-mono text-caption-sm text-text-3 uppercase tracking-widest"
+              >
                 {t("products.labelUnit")}
               </label>
-              <select
-                value={unit}
-                onChange={(e) => setUnit(e.target.value)}
-                className="w-full bg-fill-neutral-dim border border-border rounded px-2 py-1.5 font-mohave text-body text-text"
-              >
-                {UNIT_OPTIONS.map((u) => (
-                  <option key={u} value={u}>{u}</option>
-                ))}
-              </select>
+              <UnitPicker
+                id="product-form-unit"
+                value={unitId}
+                onChange={(id, display) => {
+                  setUnitId(id);
+                  if (display) setUnit(display);
+                }}
+                onCreateNew={() => setShowNewUnitDialog(true)}
+              />
             </div>
             <div className="space-y-0.5">
-              <label className="font-mono text-caption-sm text-text-3 uppercase tracking-widest">
+              <label
+                htmlFor="product-form-category"
+                className="font-mono text-caption-sm text-text-3 uppercase tracking-widest"
+              >
                 {t("products.labelCategory")}
               </label>
-              <Input
-                value={category}
-                onChange={(e) => setCategory(e.target.value)}
-                placeholder={t("products.categoryPlaceholder")}
+              <CategoryPicker
+                id="product-form-category"
+                value={categoryId}
+                onChange={(id, name) => {
+                  setCategoryId(id);
+                  setCategory(name ?? "");
+                }}
+                onCreateNew={() => setShowNewCategoryDialog(true)}
               />
             </div>
           </div>
@@ -573,6 +618,26 @@ function ProductFormModal({
             </Button>
           </div>
         </div>
+
+        {/* Inline catalog create dialogs — opened from the picker rows. */}
+        <InlineCreateCategoryDialog
+          open={showNewCategoryDialog}
+          onOpenChange={setShowNewCategoryDialog}
+          companyId={companyId}
+          onCreated={(id, newName) => {
+            setCategoryId(id);
+            setCategory(newName);
+          }}
+        />
+        <InlineCreateUnitDialog
+          open={showNewUnitDialog}
+          onOpenChange={setShowNewUnitDialog}
+          companyId={companyId}
+          onCreated={(id, display) => {
+            setUnitId(id);
+            setUnit(display);
+          }}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/ops/category-picker.tsx
+++ b/src/components/ops/category-picker.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+/**
+ * CategoryPicker — popover combobox over `catalog_categories` for the
+ * active company. Searchable list + a divider + a trailing
+ * "+ NEW CATEGORY…" item that fires `onCreateNew`. Keyboard navigation
+ * (arrow up/down + Enter + Escape) is provided by cmdk.
+ *
+ * The `onChange` callback hands back BOTH the FK id and the matching
+ * category name so the form can keep writing the legacy free-text
+ * `category` column lockstep with the new `category_id` FK. A null id
+ * with null name represents an explicit "no category" selection.
+ */
+
+import { useMemo, useState } from "react";
+import { ChevronDown, Plus, Check } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  useCatalogLookups,
+  type CatalogCategoryLookup,
+} from "@/lib/hooks/use-catalog-lookups";
+
+export interface CategoryPickerProps {
+  /** The currently selected `catalog_categories.id`, or null/undefined. */
+  value: string | null | undefined;
+  /**
+   * Fires whenever the user picks a category, clears the selection, or
+   * picks the inline "None" entry. Both id and name are emitted so the
+   * caller can mirror the legacy text column.
+   */
+  onChange: (id: string | null, name: string | null) => void;
+  /**
+   * Fires when the user picks "+ NEW CATEGORY…". The caller is expected
+   * to open the inline-create dialog and, on success, call `onChange`
+   * with the new id + name.
+   */
+  onCreateNew: () => void;
+  /** Optional placeholder shown when no value is selected. */
+  placeholder?: string;
+  /** Optional id passed through to the trigger button (form labels). */
+  id?: string;
+  /** Optional disabled state. */
+  disabled?: boolean;
+}
+
+export function CategoryPicker({
+  value,
+  onChange,
+  onCreateNew,
+  placeholder = "Select category",
+  id,
+  disabled,
+}: CategoryPickerProps) {
+  const { categories } = useCatalogLookups();
+  const [open, setOpen] = useState(false);
+
+  const sorted = useMemo<CatalogCategoryLookup[]>(
+    () => [...categories].sort((a, b) => a.name.localeCompare(b.name)),
+    [categories]
+  );
+
+  const selected = useMemo(
+    () => sorted.find((c) => c.id === value) ?? null,
+    [sorted, value]
+  );
+
+  const triggerLabel = selected?.name ?? placeholder;
+  const isPlaceholder = !selected;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          id={id}
+          type="button"
+          disabled={disabled}
+          aria-label={selected ? `Category: ${selected.name}` : placeholder}
+          className={cn(
+            "flex items-center justify-between gap-2 w-full",
+            "min-h-[44px] px-2 py-1.5 rounded-[5px]",
+            "bg-fill-neutral-dim border border-border",
+            "font-mohave text-body text-left",
+            "transition-colors duration-150",
+            "focus:outline-none focus-visible:border-ops-accent",
+            "data-[state=open]:border-[rgba(255,255,255,0.20)]",
+            "disabled:cursor-not-allowed disabled:opacity-40",
+            isPlaceholder ? "text-text-3" : "text-text"
+          )}
+        >
+          <span className="truncate">{triggerLabel}</span>
+          <ChevronDown
+            className="w-[14px] h-[14px] text-text-3 shrink-0"
+            strokeWidth={1.5}
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className="w-[var(--radix-popover-trigger-width)] min-w-[240px] p-0"
+      >
+        <Command>
+          <CommandInput placeholder="Search categories…" />
+          <CommandList>
+            <CommandEmpty>No categories found</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value="__none__"
+                onSelect={() => {
+                  onChange(null, null);
+                  setOpen(false);
+                }}
+              >
+                <span className="flex-1 text-text-3">None</span>
+                {value == null && (
+                  <Check className="w-[14px] h-[14px] text-text-2 shrink-0" />
+                )}
+              </CommandItem>
+              {sorted.map((category) => {
+                const isSelected = category.id === value;
+                return (
+                  <CommandItem
+                    key={category.id}
+                    value={category.name}
+                    onSelect={() => {
+                      onChange(category.id, category.name);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="flex-1 truncate">{category.name}</span>
+                    {isSelected && (
+                      <Check className="w-[14px] h-[14px] text-text-2 shrink-0" />
+                    )}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+            <CommandSeparator />
+            <CommandGroup>
+              <CommandItem
+                value="__create_new__"
+                onSelect={() => {
+                  setOpen(false);
+                  onCreateNew();
+                }}
+                className="text-ops-accent data-[selected=true]:text-ops-accent"
+              >
+                <Plus
+                  className="w-[14px] h-[14px] shrink-0"
+                  strokeWidth={1.5}
+                />
+                <span className="flex-1 font-cakemono font-light uppercase tracking-[0.14em] text-[12px]">
+                  New category…
+                </span>
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/ops/inline-create-category-dialog.tsx
+++ b/src/components/ops/inline-create-category-dialog.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+/**
+ * InlineCreateCategoryDialog — minimal "+ NEW CATEGORY" sheet, opened by
+ * the CategoryPicker. Single field (name). On save, inserts a new
+ * `catalog_categories` row via `useCreateCatalogCategory`, then hands
+ * the new id+name back to the parent picker via `onCreated` so the form
+ * continues writing both the FK and the legacy text column.
+ *
+ * Mirrors the iOS `InlineCreateCategorySheet` UX: tight presentation,
+ * autofocused name field, Enter to save, Escape to cancel.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useCreateCatalogCategory } from "@/lib/hooks/use-catalog-lookups";
+
+export interface InlineCreateCategoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  companyId: string;
+  /**
+   * Fires after a successful insert. Carries the newly created category's
+   * id + name so the picker can select it without waiting for the cache
+   * refetch round-trip.
+   */
+  onCreated: (id: string, name: string) => void;
+}
+
+export function InlineCreateCategoryDialog({
+  open,
+  onOpenChange,
+  companyId,
+  onCreated,
+}: InlineCreateCategoryDialogProps) {
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const createCategory = useCreateCatalogCategory();
+  const isSaving = createCategory.isPending;
+
+  // Reset local state when the dialog opens or closes so re-opening the
+  // sheet always shows an empty form.
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setError(null);
+      // Match iOS sheet timing — short delay to let the dialog finish
+      // its mount animation before stealing focus.
+      const t = setTimeout(() => inputRef.current?.focus(), 80);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  const trimmed = name.trim();
+  const canSave = trimmed.length > 0 && !isSaving;
+
+  async function handleSave() {
+    if (!canSave) return;
+    setError(null);
+    try {
+      const created = await createCategory.mutateAsync({
+        companyId,
+        name: trimmed,
+      });
+      onCreated(created.id, created.name);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create category");
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      void handleSave();
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[420px]">
+        <DialogHeader>
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-mute">
+            {"// NEW CATEGORY"}
+          </p>
+          <DialogTitle className="font-cakemono font-light uppercase tracking-[0.14em] text-[18px]">
+            Add a category
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 mt-1">
+          <div className="space-y-0.5">
+            <label
+              htmlFor="inline-create-category-name"
+              className="font-mono text-caption-sm text-text-3 uppercase tracking-widest"
+            >
+              Name *
+            </label>
+            <Input
+              ref={inputRef}
+              id="inline-create-category-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="e.g. Hardware"
+              maxLength={120}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+
+          {error && (
+            <p
+              className="font-mono text-caption-sm text-[#B58289]"
+              role="alert"
+            >
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-1.5 pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={handleSave}
+              disabled={!canSave}
+            >
+              {isSaving ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ops/inline-create-unit-dialog.tsx
+++ b/src/components/ops/inline-create-unit-dialog.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+/**
+ * InlineCreateUnitDialog — minimal "+ NEW UNIT" sheet, opened by the
+ * UnitPicker. Two fields: display + dimension. On save, inserts a new
+ * `catalog_units` row via `useCreateCatalogUnit`, then hands the new
+ * id+display back to the parent picker.
+ *
+ * Mirrors the iOS `InlineCreateUnitSheet` UX. The dimension values match
+ * the Postgres check constraint on `catalog_units.dimension` —
+ * count/length/area/volume/mass/time. Abbreviation, default flag, and
+ * sort order can be edited from the full Units management screen later.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils/cn";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useCreateCatalogUnit } from "@/lib/hooks/use-catalog-lookups";
+import {
+  CATALOG_UNIT_DIMENSIONS,
+  type CatalogUnitDimension,
+} from "@/lib/api/services/catalog-unit-service";
+
+const DIMENSION_LABELS: Record<CatalogUnitDimension, string> = {
+  count: "Count",
+  length: "Length",
+  area: "Area",
+  volume: "Volume",
+  mass: "Mass",
+  time: "Time",
+};
+
+export interface InlineCreateUnitDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  companyId: string;
+  /**
+   * Fires after a successful insert. Carries the newly created unit's
+   * id + display so the picker can select it without waiting for the
+   * cache refetch round-trip.
+   */
+  onCreated: (id: string, display: string) => void;
+}
+
+export function InlineCreateUnitDialog({
+  open,
+  onOpenChange,
+  companyId,
+  onCreated,
+}: InlineCreateUnitDialogProps) {
+  const [display, setDisplay] = useState("");
+  const [dimension, setDimension] = useState<CatalogUnitDimension>("count");
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const createUnit = useCreateCatalogUnit();
+  const isSaving = createUnit.isPending;
+
+  useEffect(() => {
+    if (open) {
+      setDisplay("");
+      setDimension("count");
+      setError(null);
+      const t = setTimeout(() => inputRef.current?.focus(), 80);
+      return () => clearTimeout(t);
+    }
+  }, [open]);
+
+  const trimmed = display.trim();
+  const canSave = trimmed.length > 0 && !isSaving;
+
+  async function handleSave() {
+    if (!canSave) return;
+    setError(null);
+    try {
+      const created = await createUnit.mutateAsync({
+        companyId,
+        display: trimmed,
+        dimension,
+      });
+      onCreated(created.id, created.display);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create unit");
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      void handleSave();
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[420px]">
+        <DialogHeader>
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-mute">
+            {"// NEW UNIT"}
+          </p>
+          <DialogTitle className="font-cakemono font-light uppercase tracking-[0.14em] text-[18px]">
+            Add a unit
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 mt-1">
+          <div className="space-y-0.5">
+            <label
+              htmlFor="inline-create-unit-display"
+              className="font-mono text-caption-sm text-text-3 uppercase tracking-widest"
+            >
+              Display *
+            </label>
+            <Input
+              ref={inputRef}
+              id="inline-create-unit-display"
+              value={display}
+              onChange={(e) => setDisplay(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="e.g. BOARD FT"
+              maxLength={60}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="font-mono text-caption-sm text-text-3 uppercase tracking-widest">
+              Dimension
+            </label>
+            <div
+              role="radiogroup"
+              aria-label="Dimension"
+              className={cn(
+                "grid grid-cols-3 gap-1 rounded-[5px] p-0.5",
+                "bg-fill-neutral-dim border border-border"
+              )}
+            >
+              {CATALOG_UNIT_DIMENSIONS.map((dim) => {
+                const isSelected = dim === dimension;
+                return (
+                  <button
+                    key={dim}
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    onClick={() => setDimension(dim)}
+                    className={cn(
+                      "min-h-[36px] px-2 py-1 rounded-[4px]",
+                      "font-cakemono font-light uppercase tracking-[0.14em] text-[11px]",
+                      "transition-colors duration-150",
+                      "focus:outline-none focus-visible:border-ops-accent",
+                      isSelected
+                        ? "bg-[rgba(255,255,255,0.08)] text-text border border-[rgba(255,255,255,0.18)]"
+                        : "text-text-3 hover:text-text-2 border border-transparent"
+                    )}
+                  >
+                    {DIMENSION_LABELS[dim]}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {error && (
+            <p
+              className="font-mono text-caption-sm text-[#B58289]"
+              role="alert"
+            >
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-1.5 pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={handleSave}
+              disabled={!canSave}
+            >
+              {isSaving ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ops/unit-picker.tsx
+++ b/src/components/ops/unit-picker.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+/**
+ * UnitPicker — popover combobox over `catalog_units` for the active
+ * company. Mirrors `CategoryPicker` exactly: searchable list +
+ * "+ NEW UNIT…" affordance. Search matches against both `display` and
+ * `abbreviation`.
+ *
+ * `onChange` hands back BOTH the FK id and the unit's `display` text so
+ * the form can keep the legacy free-text `unit` column in sync with the
+ * new `unit_id` FK.
+ */
+
+import { useMemo, useState } from "react";
+import { ChevronDown, Plus, Check } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  useCatalogLookups,
+  type CatalogUnitLookup,
+} from "@/lib/hooks/use-catalog-lookups";
+
+export interface UnitPickerProps {
+  /** The currently selected `catalog_units.id`, or null/undefined. */
+  value: string | null | undefined;
+  /**
+   * Fires whenever the user picks a unit or clears the selection. Both
+   * id and the unit's `display` text are emitted so callers can mirror
+   * the legacy text column.
+   */
+  onChange: (id: string | null, display: string | null) => void;
+  /** Fires when the user picks "+ NEW UNIT…". */
+  onCreateNew: () => void;
+  /** Optional placeholder shown when no value is selected. */
+  placeholder?: string;
+  /** Optional id passed through to the trigger button (form labels). */
+  id?: string;
+  /** Optional disabled state. */
+  disabled?: boolean;
+}
+
+export function UnitPicker({
+  value,
+  onChange,
+  onCreateNew,
+  placeholder = "Select unit",
+  id,
+  disabled,
+}: UnitPickerProps) {
+  const { units } = useCatalogLookups();
+  const [open, setOpen] = useState(false);
+
+  const sorted = useMemo<CatalogUnitLookup[]>(
+    () => [...units].sort((a, b) => a.display.localeCompare(b.display)),
+    [units]
+  );
+
+  const selected = useMemo(
+    () => sorted.find((u) => u.id === value) ?? null,
+    [sorted, value]
+  );
+
+  const triggerLabel = selected?.display ?? placeholder;
+  const isPlaceholder = !selected;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          id={id}
+          type="button"
+          disabled={disabled}
+          aria-label={selected ? `Unit: ${selected.display}` : placeholder}
+          className={cn(
+            "flex items-center justify-between gap-2 w-full",
+            "min-h-[44px] px-2 py-1.5 rounded-[5px]",
+            "bg-fill-neutral-dim border border-border",
+            "font-mohave text-body text-left",
+            "transition-colors duration-150",
+            "focus:outline-none focus-visible:border-ops-accent",
+            "data-[state=open]:border-[rgba(255,255,255,0.20)]",
+            "disabled:cursor-not-allowed disabled:opacity-40",
+            isPlaceholder ? "text-text-3" : "text-text"
+          )}
+        >
+          <span className="truncate">{triggerLabel}</span>
+          <ChevronDown
+            className="w-[14px] h-[14px] text-text-3 shrink-0"
+            strokeWidth={1.5}
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className="w-[var(--radix-popover-trigger-width)] min-w-[240px] p-0"
+      >
+        <Command>
+          <CommandInput placeholder="Search units…" />
+          <CommandList>
+            <CommandEmpty>No units found</CommandEmpty>
+            <CommandGroup>
+              {sorted.map((unit) => {
+                const isSelected = unit.id === value;
+                // cmdk searches the `value` prop. Including the
+                // abbreviation lets users type either "ft" or "feet".
+                const searchTokens = [unit.display, unit.abbreviation ?? ""]
+                  .filter(Boolean)
+                  .join(" ");
+                return (
+                  <CommandItem
+                    key={unit.id}
+                    value={searchTokens}
+                    onSelect={() => {
+                      onChange(unit.id, unit.display);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="flex-1 truncate">{unit.display}</span>
+                    {unit.abbreviation && (
+                      <span className="font-mono text-caption-sm text-text-mute uppercase tracking-wider shrink-0">
+                        {unit.abbreviation}
+                      </span>
+                    )}
+                    {isSelected && (
+                      <Check className="w-[14px] h-[14px] text-text-2 shrink-0" />
+                    )}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+            <CommandSeparator />
+            <CommandGroup>
+              <CommandItem
+                value="__create_new__"
+                onSelect={() => {
+                  setOpen(false);
+                  onCreateNew();
+                }}
+                className="text-ops-accent data-[selected=true]:text-ops-accent"
+              >
+                <Plus
+                  className="w-[14px] h-[14px] shrink-0"
+                  strokeWidth={1.5}
+                />
+                <span className="flex-1 font-cakemono font-light uppercase tracking-[0.14em] text-[12px]">
+                  New unit…
+                </span>
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/lib/api/services/catalog-category-service.ts
+++ b/src/lib/api/services/catalog-category-service.ts
@@ -1,0 +1,113 @@
+/**
+ * OPS Web - Catalog Category Service (Supabase)
+ *
+ * Minimal write-side wrapper around `catalog_categories`. The picker layer
+ * still reads through `useCatalogLookups` for the cached list; this service
+ * is the path the inline-create dialog uses to insert a new row and feed it
+ * back to the picker.
+ *
+ * Mirrors the iOS `CreateCatalogCategoryDTO` field set so the two platforms
+ * stay row-shape-compatible.
+ */
+
+import { requireSupabase } from "@/lib/supabase/helpers";
+
+export interface CatalogCategory {
+  id: string;
+  companyId: string;
+  name: string;
+  parentId: string | null;
+  sortOrder: number;
+  colorHex: string | null;
+  defaultWarningThreshold: number | null;
+  defaultCriticalThreshold: number | null;
+}
+
+export interface CreateCatalogCategoryInput {
+  companyId: string;
+  name: string;
+  parentId?: string | null;
+  /**
+   * Optional explicit sort order. When omitted the service picks
+   * `max(sort_order) + 1` for the company so the new row appends to the
+   * end of the picker list.
+   */
+  sortOrder?: number;
+  colorHex?: string | null;
+  defaultWarningThreshold?: number | null;
+  defaultCriticalThreshold?: number | null;
+}
+
+function mapFromDb(row: Record<string, unknown>): CatalogCategory {
+  return {
+    id: row.id as string,
+    companyId: row.company_id as string,
+    name: row.name as string,
+    parentId: (row.parent_id as string | null) ?? null,
+    sortOrder: (row.sort_order as number) ?? 0,
+    colorHex: (row.color_hex as string | null) ?? null,
+    defaultWarningThreshold:
+      (row.default_warning_threshold as number | null) ?? null,
+    defaultCriticalThreshold:
+      (row.default_critical_threshold as number | null) ?? null,
+  };
+}
+
+/**
+ * Compute the next `sort_order` for the given company. Reads the current
+ * max from non-deleted rows and returns `max + 1`, or `1` if the company
+ * has no categories yet.
+ */
+async function nextSortOrder(companyId: string): Promise<number> {
+  const supabase = requireSupabase();
+  const { data, error } = await supabase
+    .from("catalog_categories")
+    .select("sort_order")
+    .eq("company_id", companyId)
+    .is("deleted_at", null)
+    .order("sort_order", { ascending: false })
+    .limit(1);
+
+  if (error) {
+    throw new Error(
+      `Failed to compute next category sort_order: ${error.message}`
+    );
+  }
+  const max = (data?.[0]?.sort_order as number | undefined) ?? 0;
+  return max + 1;
+}
+
+export const CatalogCategoryService = {
+  /**
+   * Create a new catalog category. When `sortOrder` is not supplied, the
+   * service places the row at the end of the company's list.
+   */
+  async create(input: CreateCatalogCategoryInput): Promise<CatalogCategory> {
+    const supabase = requireSupabase();
+    const sortOrder =
+      input.sortOrder ?? (await nextSortOrder(input.companyId));
+
+    const row = {
+      company_id: input.companyId,
+      name: input.name.trim(),
+      parent_id: input.parentId ?? null,
+      sort_order: sortOrder,
+      color_hex: input.colorHex ?? null,
+      default_warning_threshold: input.defaultWarningThreshold ?? null,
+      default_critical_threshold: input.defaultCriticalThreshold ?? null,
+    };
+
+    const { data, error } = await supabase
+      .from("catalog_categories")
+      .insert(row)
+      .select("*")
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to create catalog category: ${error.message}`);
+    }
+    return mapFromDb(data as Record<string, unknown>);
+  },
+};
+
+export default CatalogCategoryService;

--- a/src/lib/api/services/catalog-unit-service.ts
+++ b/src/lib/api/services/catalog-unit-service.ts
@@ -1,0 +1,116 @@
+/**
+ * OPS Web - Catalog Unit Service (Supabase)
+ *
+ * Minimal write-side wrapper around `catalog_units`. Mirrors the iOS
+ * `CreateCatalogUnitDTO` field set. Used by the inline-create unit dialog
+ * to insert a new row and hand it back to the unit picker.
+ *
+ * The `dimension` value must match the Postgres check constraint on
+ * `catalog_units.dimension`: count / length / area / volume / mass / time.
+ */
+
+import { requireSupabase } from "@/lib/supabase/helpers";
+
+export const CATALOG_UNIT_DIMENSIONS = [
+  "count",
+  "length",
+  "area",
+  "volume",
+  "mass",
+  "time",
+] as const;
+
+export type CatalogUnitDimension = (typeof CATALOG_UNIT_DIMENSIONS)[number];
+
+export interface CatalogUnit {
+  id: string;
+  companyId: string;
+  display: string;
+  abbreviation: string | null;
+  dimension: CatalogUnitDimension;
+  isDefault: boolean;
+  sortOrder: number;
+}
+
+export interface CreateCatalogUnitInput {
+  companyId: string;
+  display: string;
+  dimension: CatalogUnitDimension;
+  abbreviation?: string | null;
+  isDefault?: boolean;
+  /**
+   * Optional explicit sort order. When omitted the service picks
+   * `max(sort_order) + 1` for the company.
+   */
+  sortOrder?: number;
+}
+
+function mapFromDb(row: Record<string, unknown>): CatalogUnit {
+  return {
+    id: row.id as string,
+    companyId: row.company_id as string,
+    display: row.display as string,
+    abbreviation: (row.abbreviation as string | null) ?? null,
+    dimension: row.dimension as CatalogUnitDimension,
+    isDefault: (row.is_default as boolean) ?? false,
+    sortOrder: (row.sort_order as number) ?? 0,
+  };
+}
+
+/**
+ * Compute the next `sort_order` for the given company. Reads the current
+ * max from non-deleted rows and returns `max + 1`, or `1` if the company
+ * has no units yet.
+ */
+async function nextSortOrder(companyId: string): Promise<number> {
+  const supabase = requireSupabase();
+  const { data, error } = await supabase
+    .from("catalog_units")
+    .select("sort_order")
+    .eq("company_id", companyId)
+    .is("deleted_at", null)
+    .order("sort_order", { ascending: false })
+    .limit(1);
+
+  if (error) {
+    throw new Error(
+      `Failed to compute next unit sort_order: ${error.message}`
+    );
+  }
+  const max = (data?.[0]?.sort_order as number | undefined) ?? 0;
+  return max + 1;
+}
+
+export const CatalogUnitService = {
+  /**
+   * Create a new catalog unit. When `sortOrder` is not supplied, the
+   * service places the row at the end of the company's list.
+   */
+  async create(input: CreateCatalogUnitInput): Promise<CatalogUnit> {
+    const supabase = requireSupabase();
+    const sortOrder =
+      input.sortOrder ?? (await nextSortOrder(input.companyId));
+
+    const row = {
+      company_id: input.companyId,
+      display: input.display.trim(),
+      abbreviation: input.abbreviation?.trim() || null,
+      dimension: input.dimension,
+      is_default: input.isDefault ?? false,
+      sort_order: sortOrder,
+    };
+
+    const { data, error } = await supabase
+      .from("catalog_units")
+      .insert(row)
+      .select("*")
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to create catalog unit: ${error.message}`);
+    }
+    return mapFromDb(data as Record<string, unknown>);
+  },
+};
+
+export default CatalogUnitService;

--- a/src/lib/api/services/index.ts
+++ b/src/lib/api/services/index.ts
@@ -27,6 +27,19 @@ export type { FetchCalendarEventsOptions } from "./calendar-service";
 
 export { TaskTypeService } from "./task-type-service";
 
+export { CatalogCategoryService } from "./catalog-category-service";
+export type {
+  CatalogCategory,
+  CreateCatalogCategoryInput,
+} from "./catalog-category-service";
+
+export { CatalogUnitService, CATALOG_UNIT_DIMENSIONS } from "./catalog-unit-service";
+export type {
+  CatalogUnit,
+  CatalogUnitDimension,
+  CreateCatalogUnitInput,
+} from "./catalog-unit-service";
+
 export { uploadImage, uploadMultipleImages, ImageUploadError } from "./image-service";
 export type { ImageUploadErrorCode } from "./image-service";
 
@@ -110,6 +123,8 @@ export { ApprovalQueueService } from "./approval-queue-service";
 export type { ProposeActionParams, QueueFilters, QueueStats } from "@/lib/types/approval-queue";
 
 export { ProductMaterialsService } from "./product-materials-service";
+export { ProductOptionsService } from "./product-options-service";
+export { ProductPricingModifiersService } from "./product-pricing-modifiers-service";
 export { TaskMaterialsService } from "./task-materials-service";
 export { InventoryDeductionService } from "./inventory-deduction-service";
 export { LineItemMaterialsService } from "./line-item-materials-service";

--- a/src/lib/api/services/index.ts
+++ b/src/lib/api/services/index.ts
@@ -123,8 +123,6 @@ export { ApprovalQueueService } from "./approval-queue-service";
 export type { ProposeActionParams, QueueFilters, QueueStats } from "@/lib/types/approval-queue";
 
 export { ProductMaterialsService } from "./product-materials-service";
-export { ProductOptionsService } from "./product-options-service";
-export { ProductPricingModifiersService } from "./product-pricing-modifiers-service";
 export { TaskMaterialsService } from "./task-materials-service";
 export { InventoryDeductionService } from "./inventory-deduction-service";
 export { LineItemMaterialsService } from "./line-item-materials-service";

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -126,11 +126,13 @@ export {
   useDeleteProduct,
 } from "./use-products";
 
-// Catalog lookups (categories + units; read-only)
+// Catalog lookups (categories + units; read + inline-create writes)
 export {
   useCatalogLookups,
   resolveCategoryId,
   resolveUnitId,
+  useCreateCatalogCategory,
+  useCreateCatalogUnit,
 } from "./use-catalog-lookups";
 export type {
   CatalogCategoryLookup,

--- a/src/lib/hooks/use-catalog-lookups.ts
+++ b/src/lib/hooks/use-catalog-lookups.ts
@@ -1,19 +1,26 @@
 /**
  * OPS Web - Catalog Lookups Hook
  *
- * Lightweight read-only fetcher for `catalog_categories` and `catalog_units`
- * scoped to the active company. Used by the products form to resolve a
- * user-typed `category` / `unit` string into its FK id when an exact match
- * exists in the catalog (case-insensitive, trimmed). When no match, the
- * caller leaves the FK NULL and writes only the legacy free-text column.
+ * Read-side fetcher for `catalog_categories` and `catalog_units` scoped
+ * to the active company. Powers the FK-backed pickers on the products
+ * form (and inline-create dialogs reuse it for the post-insert refresh).
  *
- * This is a stopgap for the P0 FK-write parity with iOS. Replace with real
- * pickers (Menu/Combobox over both tables) in P0-2.
+ * The legacy `resolveCategoryId` / `resolveUnitId` helpers remain exported
+ * for backward-compat fallback paths but are no longer the primary route —
+ * pickers hand the FK directly to the form.
  */
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { requireSupabase } from "@/lib/supabase/helpers";
 import { useAuthStore } from "@/lib/store/auth-store";
+import {
+  CatalogCategoryService,
+  type CreateCatalogCategoryInput,
+} from "@/lib/api/services/catalog-category-service";
+import {
+  CatalogUnitService,
+  type CreateCatalogUnitInput,
+} from "@/lib/api/services/catalog-unit-service";
 
 export interface CatalogCategoryLookup {
   id: string;
@@ -119,4 +126,42 @@ export function resolveUnitId(
     (u) => (u.abbreviation ?? "").trim().toLowerCase() === trimmed
   );
   return byAbbrev?.id ?? null;
+}
+
+// ─── Mutations ────────────────────────────────────────────────────────────────
+
+/**
+ * Create a new `catalog_categories` row, then invalidate the cached
+ * lookup so the picker reactively shows the new entry. Returns the
+ * inserted row so callers (the inline-create dialog) can hand the new
+ * id back to the parent picker without waiting for the refetch.
+ */
+export function useCreateCatalogCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateCatalogCategoryInput) =>
+      CatalogCategoryService.create(input),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["catalog-categories", variables.companyId],
+      });
+    },
+  });
+}
+
+/**
+ * Create a new `catalog_units` row, then invalidate the cached lookup so
+ * the picker reactively shows the new entry. Returns the inserted row.
+ */
+export function useCreateCatalogUnit() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateCatalogUnitInput) =>
+      CatalogUnitService.create(input),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["catalog-units", variables.companyId],
+      });
+    },
+  });
 }

--- a/tests/unit/components/category-picker.test.tsx
+++ b/tests/unit/components/category-picker.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CategoryPicker } from "@/components/ops/category-picker";
+
+// jsdom doesn't ship `scrollIntoView` on Element. cmdk calls it when
+// activating an item — without the stub, every popover interaction
+// crashes with "scrollIntoView is not a function".
+if (!("scrollIntoView" in Element.prototype)) {
+  Element.prototype.scrollIntoView = function () {};
+}
+
+// Stub the lookup hook with a static set so we don't need a real
+// Supabase client / auth store during unit tests. The picker only
+// reads `categories` and `units` from the hook; nothing else here
+// is exercised.
+vi.mock("@/lib/hooks/use-catalog-lookups", () => ({
+  useCatalogLookups: () => ({
+    categories: [
+      { id: "cat-1", name: "Hardware" },
+      { id: "cat-2", name: "Labor" },
+      { id: "cat-3", name: "Materials" },
+    ],
+    units: [],
+    isLoading: false,
+  }),
+}));
+
+describe("<CategoryPicker>", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the placeholder when no value is selected", () => {
+    render(
+      <CategoryPicker
+        value={null}
+        onChange={() => {}}
+        onCreateNew={() => {}}
+      />
+    );
+    expect(screen.getByRole("button", { name: /select category/i })).toBeInTheDocument();
+  });
+
+  it("renders the selected category name when value matches a row", () => {
+    render(
+      <CategoryPicker
+        value="cat-2"
+        onChange={() => {}}
+        onCreateNew={() => {}}
+      />
+    );
+    expect(screen.getByRole("button", { name: /category: labor/i })).toBeInTheDocument();
+  });
+
+  it("opens the popover and lists every category sorted alphabetically", async () => {
+    const user = userEvent.setup();
+    render(
+      <CategoryPicker
+        value={null}
+        onChange={() => {}}
+        onCreateNew={() => {}}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /select category/i }));
+    // cmdk renders items inside the popover. Names should all be present.
+    expect(await screen.findByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("Labor")).toBeInTheDocument();
+    expect(screen.getByText("Materials")).toBeInTheDocument();
+  });
+
+  it("fires onChange with id + name when a category is picked", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CategoryPicker
+        value={null}
+        onChange={onChange}
+        onCreateNew={() => {}}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /select category/i }));
+    const item = await screen.findByText("Labor");
+    await user.click(item);
+    expect(onChange).toHaveBeenCalledWith("cat-2", "Labor");
+  });
+
+  it("fires onChange with (null, null) when None is picked", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CategoryPicker
+        value="cat-1"
+        onChange={onChange}
+        onCreateNew={() => {}}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /category: hardware/i }));
+    const noneItem = await screen.findByText("None");
+    await user.click(noneItem);
+    expect(onChange).toHaveBeenCalledWith(null, null);
+  });
+
+  it("fires onCreateNew when the inline + NEW item is picked", async () => {
+    const onCreateNew = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CategoryPicker
+        value={null}
+        onChange={() => {}}
+        onCreateNew={onCreateNew}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /select category/i }));
+    const createItem = await screen.findByText(/new category…/i);
+    await user.click(createItem);
+    expect(onCreateNew).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/components/category-picker.test.tsx
+++ b/tests/unit/components/category-picker.test.tsx
@@ -7,7 +7,10 @@ import { CategoryPicker } from "@/components/ops/category-picker";
 // activating an item — without the stub, every popover interaction
 // crashes with "scrollIntoView is not a function".
 if (!("scrollIntoView" in Element.prototype)) {
-  Element.prototype.scrollIntoView = function () {};
+  // Cast through unknown so the assignment compiles under strict mode
+  // (Element.prototype's type doesn't include the method when missing).
+  (Element.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView =
+    function () {};
 }
 
 // Stub the lookup hook with a static set so we don't need a real

--- a/tests/unit/components/unit-picker.test.tsx
+++ b/tests/unit/components/unit-picker.test.tsx
@@ -7,7 +7,10 @@ import { UnitPicker } from "@/components/ops/unit-picker";
 // activating an item — without the stub, every popover interaction
 // crashes with "scrollIntoView is not a function".
 if (!("scrollIntoView" in Element.prototype)) {
-  Element.prototype.scrollIntoView = function () {};
+  // Cast through unknown so the assignment compiles under strict mode
+  // (Element.prototype's type doesn't include the method when missing).
+  (Element.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView =
+    function () {};
 }
 
 vi.mock("@/lib/hooks/use-catalog-lookups", () => ({

--- a/tests/unit/components/unit-picker.test.tsx
+++ b/tests/unit/components/unit-picker.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UnitPicker } from "@/components/ops/unit-picker";
+
+// jsdom doesn't ship `scrollIntoView` on Element. cmdk calls it when
+// activating an item — without the stub, every popover interaction
+// crashes with "scrollIntoView is not a function".
+if (!("scrollIntoView" in Element.prototype)) {
+  Element.prototype.scrollIntoView = function () {};
+}
+
+vi.mock("@/lib/hooks/use-catalog-lookups", () => ({
+  useCatalogLookups: () => ({
+    categories: [],
+    units: [
+      { id: "u-1", display: "EACH", abbreviation: "EA" },
+      { id: "u-2", display: "HOUR", abbreviation: "HR" },
+      { id: "u-3", display: "BOARD FT", abbreviation: null },
+    ],
+    isLoading: false,
+  }),
+}));
+
+describe("<UnitPicker>", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the placeholder when no value is selected", () => {
+    render(
+      <UnitPicker
+        value={null}
+        onChange={() => {}}
+        onCreateNew={() => {}}
+      />
+    );
+    expect(screen.getByRole("button", { name: /select unit/i })).toBeInTheDocument();
+  });
+
+  it("renders the selected unit's display when value matches a row", () => {
+    render(
+      <UnitPicker
+        value="u-2"
+        onChange={() => {}}
+        onCreateNew={() => {}}
+      />
+    );
+    expect(screen.getByRole("button", { name: /unit: hour/i })).toBeInTheDocument();
+  });
+
+  it("opens the popover and lists units alphabetically with abbreviations", async () => {
+    const user = userEvent.setup();
+    render(
+      <UnitPicker
+        value={null}
+        onChange={() => {}}
+        onCreateNew={() => {}}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /select unit/i }));
+    expect(await screen.findByText("BOARD FT")).toBeInTheDocument();
+    expect(screen.getByText("EACH")).toBeInTheDocument();
+    expect(screen.getByText("HOUR")).toBeInTheDocument();
+    // Abbreviations render alongside their display.
+    expect(screen.getByText("EA")).toBeInTheDocument();
+    expect(screen.getByText("HR")).toBeInTheDocument();
+  });
+
+  it("fires onChange with id + display when a unit is picked", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <UnitPicker
+        value={null}
+        onChange={onChange}
+        onCreateNew={() => {}}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /select unit/i }));
+    const item = await screen.findByText("HOUR");
+    await user.click(item);
+    expect(onChange).toHaveBeenCalledWith("u-2", "HOUR");
+  });
+
+  it("fires onCreateNew when the inline + NEW item is picked", async () => {
+    const onCreateNew = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <UnitPicker
+        value={null}
+        onChange={() => {}}
+        onCreateNew={onCreateNew}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /select unit/i }));
+    const createItem = await screen.findByText(/new unit…/i);
+    await user.click(createItem);
+    expect(onCreateNew).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the free-text category Input and the hardcoded UNIT_OPTIONS select on the products form with FK-backed pickers (Combobox over `catalog_categories` and `catalog_units`) plus inline-create dialogs that mirror the iOS `InlineCreateCategorySheet` / `InlineCreateUnitSheet` UX.
- Web now writes `category_id` and `unit_id` directly via the picker callbacks; the legacy `category` / `unit` text columns stay in lockstep for backward compat.
- Adds `CatalogCategoryService.create` + `CatalogUnitService.create` (auto-computes next `sort_order`, mirrors iOS DTO field set) and `useCreateCatalogCategory` / `useCreateCatalogUnit` mutation hooks that invalidate the lookup cache on success.

**Stacks on #38** (FK writes). Merge order: #38 first, then this.

## Verification (run after deploy)

```sql
-- New products via web after deploy: confirm both FK + legacy text written
SELECT id, name, category, category_id, unit, unit_id, created_at
FROM products
WHERE deleted_at IS NULL AND created_at > now() - interval '24 hours'
ORDER BY created_at DESC;
```

## Test plan

- [ ] Open Products → Add Item → category picker shows existing categories with search, unit picker shows units alphabetically with abbreviations
- [ ] Pick a category → form submits with `category_id` populated and `category` text mirrored
- [ ] Pick "+ NEW CATEGORY…" → dialog opens with name field autofocused → save → new row inserted, picker selects it automatically
- [ ] Pick "+ NEW UNIT…" → dimension defaults to "count", radio group switches dimension, save → new row inserted, picker selects it
- [ ] Edit a legacy product (no FK ids, only legacy text) → backfill matches the text and picker shows the matching row
- [ ] Edit a product with FK ids → pickers immediately reflect the FK
- [ ] iOS: open the same product on iOS → category + unit display matches what web wrote

## Notes

- Dialogs use the shared `Dialog`/`DialogContent` primitive which already applies `glass-dense`. No divergence from spec.
- Pickers' popovers stack above the form modal via Radix portal (z-index `modal: 3000`). Verified visually consistent.
- 11 new unit tests across both pickers; full suite passes (897 / 5 skipped).