### PR TITLE
feat(inbox): Phase G — modals + toast + mobile tactical voice

### DIFF
--- a/src/components/ops/inbox/__tests__/archive-confirm-modal.test.tsx
+++ b/src/components/ops/inbox/__tests__/archive-confirm-modal.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import {
+  ArchiveConfirmModal,
+  type ArchiveConfirmContext,
+} from "../archive-confirm-modal";
+
+const noop = () => {};
+
+const baseContext: ArchiveConfirmContext = {
+  currentThread: {
+    id: "t-current",
+    subject: "Roof RFQ — revised quote",
+    latestSenderName: "Calloway",
+    latestSenderEmail: "ops@calloway.com",
+  },
+  linkedOpportunity: {
+    id: "opp-1",
+    title: "Calloway · Re-roof",
+  } as ArchiveConfirmContext["linkedOpportunity"],
+  siblingThreads: [],
+  leadPreference: "ask",
+  connectionId: "conn-1",
+};
+
+describe("<ArchiveConfirmModal>", () => {
+  it("renders the // ARCHIVE slash title and instructional body", () => {
+    render(
+      <ArchiveConfirmModal
+        open={true}
+        onOpenChange={noop}
+        context={baseContext}
+        onConfirm={noop}
+      />,
+    );
+    // Slash title
+    expect(screen.getByText("// ARCHIVE")).toBeInTheDocument();
+    // Body
+    expect(
+      screen.getByText(
+        /this thread will move to archive\. nothing is deleted\./i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the // THIS THREAD section label and locked current-thread row", () => {
+    render(
+      <ArchiveConfirmModal
+        open={true}
+        onOpenChange={noop}
+        context={baseContext}
+        onConfirm={noop}
+      />,
+    );
+    // Match the bracketed-section label, distinct from the body sentence
+    // which contains lowercase "this thread" prose. The section is rendered
+    // as `// THIS THREAD` (ALL CAPS).
+    expect(screen.getByText(/^\/\/ THIS THREAD$/)).toBeInTheDocument();
+    expect(screen.getByText("Roof RFQ — revised quote")).toBeInTheDocument();
+  });
+
+  it("renders the // OTHER THREADS ON THIS LEAD section when siblings exist", () => {
+    const ctx: ArchiveConfirmContext = {
+      ...baseContext,
+      siblingThreads: [
+        {
+          id: "sib-1",
+          subject: "Initial site walk · Calloway",
+          latestSenderName: "Calloway",
+          latestSenderEmail: "ops@calloway.com",
+          latestSnippet: "We agreed on Friday",
+          lastMessageAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        },
+      ] as ArchiveConfirmContext["siblingThreads"],
+    };
+    render(
+      <ArchiveConfirmModal
+        open={true}
+        onOpenChange={noop}
+        context={ctx}
+        onConfirm={noop}
+      />,
+    );
+    expect(screen.getByText(/OTHER THREADS ON THIS LEAD/i)).toBeInTheDocument();
+    expect(screen.getByText("Initial site walk · Calloway")).toBeInTheDocument();
+  });
+
+  it("renders the // PIPELINE LEAD section + linked opp title and item count footer", () => {
+    render(
+      <ArchiveConfirmModal
+        open={true}
+        onOpenChange={noop}
+        context={baseContext}
+        onConfirm={noop}
+      />,
+    );
+    expect(screen.getByText(/PIPELINE LEAD/i)).toBeInTheDocument();
+    expect(screen.getByText("Calloway · Re-roof")).toBeInTheDocument();
+    // Default count: current thread + lead = 2 items
+    expect(screen.getByText(/\[2 items to archive\]/i)).toBeInTheDocument();
+  });
+
+  it("renders the CANCEL and ARCHIVE buttons with the inline ⌘↵ key hint on confirm", () => {
+    render(
+      <ArchiveConfirmModal
+        open={true}
+        onOpenChange={noop}
+        context={baseContext}
+        onConfirm={noop}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /CANCEL/i })).toBeInTheDocument();
+    // Find the ARCHIVE button via its bare text — distinct from the inner
+    // "Archive lead" toggle which uses different casing/wording.
+    const archiveBtn = screen.getByText("ARCHIVE").closest("button");
+    expect(archiveBtn).toBeTruthy();
+    // The inline KeyHint emits a <kbd> with [⌘↵]
+    expect(archiveBtn!.querySelector("kbd")?.textContent).toBe("[⌘↵]");
+  });
+
+  it("preserves sibling-toggle behavior — clicking a sibling row updates the count", () => {
+    const ctx: ArchiveConfirmContext = {
+      ...baseContext,
+      leadPreference: "leave", // disables lead checkbox by default
+      siblingThreads: [
+        {
+          id: "sib-1",
+          subject: "Initial site walk",
+          latestSenderName: "Calloway",
+          latestSenderEmail: "ops@calloway.com",
+          latestSnippet: null,
+          lastMessageAt: new Date().toISOString(),
+        },
+      ] as ArchiveConfirmContext["siblingThreads"],
+    };
+    render(
+      <ArchiveConfirmModal
+        open={true}
+        onOpenChange={noop}
+        context={ctx}
+        onConfirm={noop}
+      />,
+    );
+    // current + sibling = 2 items by default (lead off because leadPreference='leave')
+    expect(screen.getByText(/\[2 items to archive\]/i)).toBeInTheDocument();
+    const sibButton = screen.getByText("Initial site walk").closest("button");
+    expect(sibButton).toBeTruthy();
+    fireEvent.click(sibButton!);
+    // After deselecting, current only = 1 item
+    expect(screen.getByText(/\[1 item to archive\]/i)).toBeInTheDocument();
+  });
+
+  it("calls onConfirm with the right thread + opp args when ARCHIVE clicked", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <ArchiveConfirmModal
+        open={true}
+        onOpenChange={noop}
+        context={baseContext}
+        onConfirm={onConfirm}
+      />,
+    );
+    const archiveBtn = screen.getByText("ARCHIVE").closest("button");
+    fireEvent.click(archiveBtn!);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][0]).toEqual({
+      threadIds: ["t-current"],
+      archiveOpportunityId: "opp-1",
+      saveLeadPreference: "archive",
+    });
+  });
+});

--- a/src/components/ops/inbox/__tests__/mobile-stacked-shell.test.tsx
+++ b/src/components/ops/inbox/__tests__/mobile-stacked-shell.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import { MobileStackedShell } from "../mobile-stacked-shell";
 
 describe("<MobileStackedShell>", () => {
-  it("renders the list pane when activePane='list'", () => {
+  it("renders the list pane with // LIST header when activePane='list'", () => {
     render(
       <MobileStackedShell
         activePane="list"
@@ -16,9 +16,23 @@ describe("<MobileStackedShell>", () => {
     expect(screen.getByTestId("list")).toBeInTheDocument();
     expect(screen.queryByTestId("detail")).not.toBeInTheDocument();
     expect(screen.queryByTestId("context")).not.toBeInTheDocument();
+    expect(screen.getByText("// LIST")).toBeInTheDocument();
   });
 
-  it("renders the detail pane with a back arrow when activePane='detail'", () => {
+  it("does not render the back button on the list pane", () => {
+    render(
+      <MobileStackedShell
+        activePane="list"
+        onPaneChange={() => {}}
+        threadList={<div data-testid="list" />}
+        detail={<div />}
+        contextRail={<div />}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /back/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the detail pane with // THREAD header and a back arrow when activePane='detail'", () => {
     const onPaneChange = vi.fn();
     render(
       <MobileStackedShell
@@ -30,11 +44,12 @@ describe("<MobileStackedShell>", () => {
       />,
     );
     expect(screen.getByTestId("detail")).toBeInTheDocument();
+    expect(screen.getByText("// THREAD")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /back/i }));
     expect(onPaneChange).toHaveBeenCalledWith("list");
   });
 
-  it("renders the context pane and back returns to detail", () => {
+  it("renders the context pane with // CONTEXT header and back returns to detail", () => {
     const onPaneChange = vi.fn();
     render(
       <MobileStackedShell
@@ -46,6 +61,7 @@ describe("<MobileStackedShell>", () => {
       />,
     );
     expect(screen.getByTestId("context")).toBeInTheDocument();
+    expect(screen.getByText("// CONTEXT")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /back/i }));
     expect(onPaneChange).toHaveBeenCalledWith("detail");
   });

--- a/src/components/ops/inbox/__tests__/recategorize-menu.test.tsx
+++ b/src/components/ops/inbox/__tests__/recategorize-menu.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const recategorizeMutate = vi.fn();
+const enqueueMock = vi.fn();
+
+vi.mock("@/lib/hooks/use-inbox-threads", () => ({
+  useThreadActions: () => ({
+    recategorize: { mutate: recategorizeMutate },
+  }),
+}));
+
+vi.mock("../undo-toast", () => ({
+  enqueueUndoToast: (input: unknown) => enqueueMock(input),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+import { RecategorizeMenu } from "../recategorize-menu";
+
+describe("<RecategorizeMenu>", () => {
+  beforeEach(() => {
+    recategorizeMutate.mockReset();
+    enqueueMock.mockReset();
+  });
+
+  it("renders the // RECATEGORIZE slash title and instructional body", () => {
+    render(
+      <RecategorizeMenu
+        threadId="t-1"
+        currentCategory="OTHER"
+        trigger={<button>Recategorize</button>}
+        open={true}
+      />,
+    );
+    expect(screen.getByText("// RECATEGORIZE")).toBeInTheDocument();
+    expect(
+      screen.getByText(/move this thread to a different group/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders each category as a plain JetBrains Mono uppercase label with its hotkey", () => {
+    render(
+      <RecategorizeMenu
+        threadId="t-1"
+        currentCategory="OTHER"
+        trigger={<button>Recategorize</button>}
+        open={true}
+      />,
+    );
+    // CUSTOMER label appears (not as a chip — as plain mono text)
+    expect(screen.getByText("CUSTOMER")).toBeInTheDocument();
+    // The hotkey hint for CUSTOMER is "U", rendered via inline KeyHint as [U]
+    expect(screen.getByText("[U]")).toBeInTheDocument();
+    // LEAD + [L]
+    expect(screen.getByText("LEAD")).toBeInTheDocument();
+    expect(screen.getByText("[L]")).toBeInTheDocument();
+  });
+
+  it("excludes the current category from the list", () => {
+    render(
+      <RecategorizeMenu
+        threadId="t-1"
+        currentCategory="VENDOR"
+        trigger={<button>Recategorize</button>}
+        open={true}
+      />,
+    );
+    // VENDOR is the current → excluded
+    expect(screen.queryByText("VENDOR")).toBeNull();
+    // Other categories present
+    expect(screen.getByText("CUSTOMER")).toBeInTheDocument();
+  });
+
+  it("renders the // PHASE C NOTE — OPTIONAL section with the note textarea", () => {
+    render(
+      <RecategorizeMenu
+        threadId="t-1"
+        currentCategory="OTHER"
+        trigger={<button>Recategorize</button>}
+        open={true}
+      />,
+    );
+    expect(screen.getByText("// PHASE C NOTE — OPTIONAL")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("clicking a category fires recategorize.mutate with the right args", () => {
+    render(
+      <RecategorizeMenu
+        threadId="t-1"
+        currentCategory="OTHER"
+        trigger={<button>Recategorize</button>}
+        open={true}
+      />,
+    );
+    fireEvent.click(screen.getByText("CUSTOMER"));
+    expect(recategorizeMutate).toHaveBeenCalledTimes(1);
+    const arg = recategorizeMutate.mock.calls[0][0] as {
+      threadId: string;
+      toCategory: string;
+    };
+    expect(arg.threadId).toBe("t-1");
+    expect(arg.toCategory).toBe("CUSTOMER");
+  });
+});

--- a/src/components/ops/inbox/__tests__/snooze-picker.test.tsx
+++ b/src/components/ops/inbox/__tests__/snooze-picker.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const snoozeMutate = vi.fn();
+const unsnoozeMutate = vi.fn();
+const enqueueMock = vi.fn();
+
+vi.mock("@/lib/hooks/use-inbox-threads", () => ({
+  useThreadActions: () => ({
+    snooze: { mutate: snoozeMutate },
+    unsnooze: { mutate: unsnoozeMutate },
+  }),
+}));
+
+vi.mock("../undo-toast", () => ({
+  enqueueUndoToast: (input: unknown) => enqueueMock(input),
+}));
+
+import { SnoozePicker } from "../snooze-picker";
+
+describe("<SnoozePicker>", () => {
+  beforeEach(() => {
+    snoozeMutate.mockReset();
+    unsnoozeMutate.mockReset();
+    enqueueMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the // SNOOZE slash title and instructional body", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T10:00:00")); // weekday morning
+    render(
+      <SnoozePicker threadId="t-1" trigger={<button>Snooze</button>} open={true} />,
+    );
+    expect(screen.getByText("// SNOOZE")).toBeInTheDocument();
+    expect(
+      screen.getByText(/hide until · returns to inbox automatically/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders preset rows in bracketed JetBrains Mono uppercase form", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T10:00:00"));
+    render(
+      <SnoozePicker threadId="t-1" trigger={<button>Snooze</button>} open={true} />,
+    );
+    expect(screen.getByText("[LATER TODAY]")).toBeInTheDocument();
+    expect(screen.getByText("[TOMORROW 8AM]")).toBeInTheDocument();
+    expect(screen.getByText("[WEEKEND]")).toBeInTheDocument();
+    expect(screen.getByText("[NEXT MON]")).toBeInTheDocument();
+    expect(screen.getByText("[NEXT MONTH]")).toBeInTheDocument();
+  });
+
+  it("hides the [LATER TODAY] preset when current time is past 18:00", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T19:30:00")); // 7:30pm
+    render(
+      <SnoozePicker threadId="t-1" trigger={<button>Snooze</button>} open={true} />,
+    );
+    expect(screen.queryByText("[LATER TODAY]")).toBeNull();
+    // tomorrow still shows
+    expect(screen.getByText("[TOMORROW 8AM]")).toBeInTheDocument();
+  });
+
+  it("hides the [WEEKEND] preset when today is Saturday", () => {
+    vi.useFakeTimers();
+    // 2026-05-09 is a Saturday
+    vi.setSystemTime(new Date("2026-05-09T10:00:00"));
+    render(
+      <SnoozePicker threadId="t-1" trigger={<button>Snooze</button>} open={true} />,
+    );
+    expect(screen.queryByText("[WEEKEND]")).toBeNull();
+  });
+
+  it("renders the custom datetime row with 'pick a date and time…'", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T10:00:00"));
+    render(
+      <SnoozePicker threadId="t-1" trigger={<button>Snooze</button>} open={true} />,
+    );
+    expect(screen.getByText(/pick a date and time/i)).toBeInTheDocument();
+  });
+
+  it("clicking a preset commits via useThreadActions().snooze.mutate", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T10:00:00"));
+    render(
+      <SnoozePicker threadId="t-1" trigger={<button>Snooze</button>} open={true} />,
+    );
+    fireEvent.click(screen.getByText("[TOMORROW 8AM]"));
+    expect(snoozeMutate).toHaveBeenCalledTimes(1);
+    const arg = snoozeMutate.mock.calls[0][0] as { threadId: string; until: Date };
+    expect(arg.threadId).toBe("t-1");
+    expect(arg.until).toBeInstanceOf(Date);
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ops/inbox/__tests__/undo-toast.test.tsx
+++ b/src/components/ops/inbox/__tests__/undo-toast.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  UndoToastHost,
+  enqueueUndoToast,
+  dismissUndoToast,
+} from "../undo-toast";
+
+describe("<UndoToastHost> + enqueueUndoToast", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the SYS :: prefix message body when a toast is enqueued", () => {
+    render(<UndoToastHost />);
+    act(() => {
+      enqueueUndoToast({
+        message: "SYS :: THREAD ARCHIVED",
+        onUndo: vi.fn(),
+      });
+    });
+    expect(screen.getByText(/SYS :: THREAD ARCHIVED/)).toBeInTheDocument();
+  });
+
+  it("renders the UNDO button with the inline [Z] keyhint", () => {
+    render(<UndoToastHost />);
+    act(() => {
+      enqueueUndoToast({
+        message: "SYS :: THREAD ARCHIVED",
+        onUndo: vi.fn(),
+      });
+    });
+    // The verb sits inside a button; the [Z] hint is rendered as inline kbd.
+    expect(screen.getByRole("button")).toHaveTextContent(/UNDO/);
+    expect(screen.getByText("[Z]")).toBeInTheDocument();
+  });
+
+  it("clicking the UNDO button fires the onUndo callback", () => {
+    const onUndo = vi.fn();
+    render(<UndoToastHost />);
+    act(() => {
+      enqueueUndoToast({ message: "SYS :: THREAD ARCHIVED", onUndo });
+    });
+    fireEvent.click(screen.getByRole("button"));
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-dismisses after the default 5000ms duration", () => {
+    vi.useFakeTimers();
+    const onExpire = vi.fn();
+    render(<UndoToastHost />);
+    act(() => {
+      enqueueUndoToast({
+        message: "SYS :: THREAD ARCHIVED",
+        onUndo: vi.fn(),
+        onExpire,
+      });
+    });
+    expect(screen.getByText(/SYS :: THREAD ARCHIVED/)).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(4999);
+    });
+    // Still visible just before the threshold.
+    expect(screen.queryByText(/SYS :: THREAD ARCHIVED/)).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it("bare-Z keydown triggers onUndo on the most recent toast", () => {
+    const onUndo = vi.fn();
+    render(<UndoToastHost />);
+    act(() => {
+      enqueueUndoToast({ message: "SYS :: THREAD ARCHIVED", onUndo });
+    });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "z" }));
+    });
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it("Cmd+Z does NOT trigger onUndo (modifier excluded)", () => {
+    const onUndo = vi.fn();
+    render(<UndoToastHost />);
+    act(() => {
+      enqueueUndoToast({ message: "SYS :: THREAD ARCHIVED", onUndo });
+    });
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "z", metaKey: true }),
+      );
+    });
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+
+  it("Ctrl+Z does NOT trigger onUndo (modifier excluded)", () => {
+    const onUndo = vi.fn();
+    render(<UndoToastHost />);
+    act(() => {
+      enqueueUndoToast({ message: "SYS :: THREAD ARCHIVED", onUndo });
+    });
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "z", ctrlKey: true }),
+      );
+    });
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+
+  it("ignores bare-Z keydown when focus is in an input", () => {
+    const onUndo = vi.fn();
+    render(<UndoToastHost />);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    act(() => {
+      enqueueUndoToast({ message: "SYS :: THREAD ARCHIVED", onUndo });
+    });
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "z", bubbles: true }),
+      );
+    });
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+
+  it("caps the visible stack at 3 toasts (oldest dropped silently)", () => {
+    render(<UndoToastHost />);
+    act(() => {
+      enqueueUndoToast({ message: "SYS :: ONE", onUndo: vi.fn() });
+      enqueueUndoToast({ message: "SYS :: TWO", onUndo: vi.fn() });
+      enqueueUndoToast({ message: "SYS :: THREE", onUndo: vi.fn() });
+      enqueueUndoToast({ message: "SYS :: FOUR", onUndo: vi.fn() });
+    });
+    // ONE is dropped, TWO/THREE/FOUR remain.
+    expect(screen.queryByText(/SYS :: ONE/)).toBeNull();
+    expect(screen.getByText(/SYS :: TWO/)).toBeInTheDocument();
+    expect(screen.getByText(/SYS :: THREE/)).toBeInTheDocument();
+    expect(screen.getByText(/SYS :: FOUR/)).toBeInTheDocument();
+  });
+
+  it("renders the optional detail subline when supplied", () => {
+    render(<UndoToastHost />);
+    act(() => {
+      enqueueUndoToast({
+        message: "SYS :: MOVED TO LEAD",
+        detail: "[—] phase c will learn from this correction.",
+        onUndo: vi.fn(),
+      });
+    });
+    expect(
+      screen.getByText(/phase c will learn from this correction/i),
+    ).toBeInTheDocument();
+  });
+
+  it("dismissUndoToast removes a toast without firing onUndo", () => {
+    const onUndo = vi.fn();
+    render(<UndoToastHost />);
+    let id = "";
+    act(() => {
+      id = enqueueUndoToast({
+        message: "SYS :: THREAD ARCHIVED",
+        onUndo,
+      });
+    });
+    act(() => {
+      dismissUndoToast(id);
+    });
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+
+  it("toast row carries role=status and aria-live=polite", () => {
+    render(<UndoToastHost />);
+    act(() => {
+      enqueueUndoToast({ message: "SYS :: THREAD ARCHIVED", onUndo: vi.fn() });
+    });
+    const row = screen.getByRole("status");
+    expect(row).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/src/components/ops/inbox/__tests__/writeback-preference-modal.test.tsx
+++ b/src/components/ops/inbox/__tests__/writeback-preference-modal.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const setPreferenceMutateAsync = vi.fn();
+
+vi.mock("@/lib/hooks/use-inbox-threads", () => ({
+  useThreadActions: () => ({
+    setWritebackPreference: { mutateAsync: setPreferenceMutateAsync },
+  }),
+}));
+
+import { WritebackPreferenceModal } from "../writeback-preference-modal";
+
+const noop = () => {};
+
+describe("<WritebackPreferenceModal>", () => {
+  beforeEach(() => {
+    setPreferenceMutateAsync.mockReset();
+    setPreferenceMutateAsync.mockResolvedValue(undefined);
+  });
+
+  it("renders the // WRITEBACK PREFERENCE slash title and instructional body", () => {
+    render(
+      <WritebackPreferenceModal
+        open={true}
+        onOpenChange={noop}
+        connectionId="conn-1"
+        onConfirmed={noop}
+      />,
+    );
+    expect(screen.getByText("// WRITEBACK PREFERENCE")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /when you archive, what should happen in your connected inbox\?/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all three options with tactical labels and bracketed body lines", () => {
+    render(
+      <WritebackPreferenceModal
+        open={true}
+        onOpenChange={noop}
+        connectionId="conn-1"
+        onConfirmed={noop}
+      />,
+    );
+    expect(screen.getByText("ARCHIVE IN GMAIL/OUTLOOK")).toBeInTheDocument();
+    expect(
+      screen.getByText(/mark as read AND move to archive/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("MARK AS READ ONLY")).toBeInTheDocument();
+    expect(screen.getByText(/mark as read, leave in inbox/i)).toBeInTheDocument();
+    expect(screen.getByText("OPS-ONLY")).toBeInTheDocument();
+    expect(
+      screen.getByText(/no change to your connected inbox/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render captions like 'Recommended' / 'Safer for starters' / 'Maximum control'", () => {
+    render(
+      <WritebackPreferenceModal
+        open={true}
+        onOpenChange={noop}
+        connectionId="conn-1"
+        onConfirmed={noop}
+      />,
+    );
+    expect(screen.queryByText(/Recommended/i)).toBeNull();
+    expect(screen.queryByText(/Safer for starters/i)).toBeNull();
+    expect(screen.queryByText(/Maximum control/i)).toBeNull();
+  });
+
+  it("renders NOT NOW + SAVE & ARCHIVE bare uppercase buttons", () => {
+    render(
+      <WritebackPreferenceModal
+        open={true}
+        onOpenChange={noop}
+        connectionId="conn-1"
+        onConfirmed={noop}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /NOT NOW/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /SAVE & ARCHIVE/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the 'learn more about writeback →' footer link", () => {
+    render(
+      <WritebackPreferenceModal
+        open={true}
+        onOpenChange={noop}
+        connectionId="conn-1"
+        onConfirmed={noop}
+      />,
+    );
+    const link = screen.getByText(/learn more about writeback/i);
+    expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe("A");
+  });
+
+  it("defaults to archive_in_gmail and persists that choice when SAVE & ARCHIVE clicked", async () => {
+    const onConfirmed = vi.fn();
+    render(
+      <WritebackPreferenceModal
+        open={true}
+        onOpenChange={noop}
+        connectionId="conn-1"
+        onConfirmed={onConfirmed}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /SAVE & ARCHIVE/i }));
+    // wait microtask
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(setPreferenceMutateAsync).toHaveBeenCalledWith({
+      connectionId: "conn-1",
+      preference: "archive_in_gmail",
+    });
+  });
+
+  it("clicking MARK AS READ ONLY updates selection and saves that preference", async () => {
+    render(
+      <WritebackPreferenceModal
+        open={true}
+        onOpenChange={noop}
+        connectionId="conn-1"
+        onConfirmed={noop}
+      />,
+    );
+    fireEvent.click(screen.getByText("MARK AS READ ONLY"));
+    fireEvent.click(screen.getByRole("button", { name: /SAVE & ARCHIVE/i }));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(setPreferenceMutateAsync).toHaveBeenCalledWith({
+      connectionId: "conn-1",
+      preference: "mark_read_only",
+    });
+  });
+});

--- a/src/components/ops/inbox/archive-confirm-modal.tsx
+++ b/src/components/ops/inbox/archive-confirm-modal.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils/cn";
 import { useDictionary } from "@/i18n/client";
+import { SlashLabel } from "./voice/slash-label";
+import { KeyHint } from "@/components/ui/key-hint";
 import type { ArchiveLeadPreference } from "@/lib/types/email-thread";
 import type {
   ArchiveLinkedOpportunity,
@@ -199,44 +201,29 @@ export function ArchiveConfirmModal({
 
   const { currentThread, linkedOpportunity, siblingThreads } = context;
   const hasSiblings = siblingThreads.length > 0;
-  const headerLabel = hasSiblings
-    ? `// ${t("archiveModal.prefix.siblings", "ARCHIVE")}`
-    : `// ${t("archiveModal.prefix.firstLead", "FIRST OPP-LINKED ARCHIVE")}`;
-  const headerTitle = hasSiblings
-    ? t("archiveModal.title.siblings", "What else should we archive?")
-    : t("archiveModal.title.firstLead", "Archive the lead too?");
-  const siblingsCount = siblingThreads.length;
-  const headerDescription = hasSiblings
-    ? t(
-        siblingsCount === 1
-          ? "archiveModal.description.siblings_one"
-          : "archiveModal.description.siblings_other",
-        siblingsCount === 1
-          ? "This thread is part of a lead with 1 other open thread. Pick what to clean up."
-          : "This thread is part of a lead with {count} other open threads. Pick what to clean up.",
-      ).replace("{count}", String(siblingsCount))
-    : t(
-        "archiveModal.description.firstLead",
-        "OPS noticed this thread is tied to a pipeline lead. Want the lead archived alongside the thread? We'll remember your answer.",
-      );
-  const buttonLabel = t("archiveModal.confirm", "Archive ({count})").replace(
-    "{count}",
-    String(totalCount),
+  const archiveTitle = t("modal.archive.title", "// ARCHIVE");
+  const archiveBody = t(
+    "modal.archive.body",
+    "[—] this thread will move to archive. nothing is deleted.",
   );
 
   return (
     <Dialog open={open} onOpenChange={close}>
       <DialogContent className="max-w-[560px] p-0 max-h-[85vh] overflow-hidden flex flex-col">
+        <DialogTitle className="sr-only">
+          {t("action.archive", "Archive")}
+        </DialogTitle>
+        <DialogDescription className="sr-only">
+          {t(
+            "archiveModal.a11yDescription",
+            "Confirm archive action.",
+          )}
+        </DialogDescription>
         <div className="px-4 pt-4 pb-3 border-b border-line">
-          <p className="font-mono text-[11px] uppercase tracking-[0.20em] text-text-mute">
-            {headerLabel}
+          <SlashLabel label={archiveTitle} size="md" />
+          <p className="font-mono text-[11px] text-text-3 mt-2 leading-relaxed">
+            {archiveBody}
           </p>
-          <DialogTitle className="font-cakemono font-light uppercase text-[20px] tracking-[0.10em] text-text mt-1">
-            {headerTitle}
-          </DialogTitle>
-          <DialogDescription className="font-mohave text-[13px] text-text-2 mt-1">
-            {headerDescription}
-          </DialogDescription>
         </div>
 
         <div className="overflow-y-auto flex-1">
@@ -427,23 +414,33 @@ export function ArchiveConfirmModal({
                 "disabled:opacity-50 disabled:cursor-not-allowed",
               )}
             >
-              {t("archiveModal.cancel", "Cancel")}
+              {t("modal.archive.cancel", "CANCEL")}
             </button>
             <button
               type="button"
               onClick={submit}
               disabled={submitting}
               className={cn(
-                "px-3 py-1.5 rounded-[2.5px]",
-                "bg-ops-accent text-black",
+                "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[2.5px]",
+                "border border-ops-accent text-ops-accent",
                 "font-cakemono font-light uppercase text-[11px] tracking-[0.14em]",
-                "hover:bg-ops-accent/90 transition-colors duration-150",
+                "hover:bg-ops-accent hover:text-black transition-colors duration-150",
                 "disabled:opacity-50 disabled:cursor-not-allowed",
               )}
             >
-              {submitting
-                ? t("archiveModal.submitting", "Archiving…")
-                : buttonLabel}
+              {submitting ? (
+                t("archiveModal.submitting", "Archiving…")
+              ) : (
+                <>
+                  <span>{t("modal.archive.confirm", "ARCHIVE")}</span>
+                  {totalCount > 1 && (
+                    <span className="font-mono tabular-nums opacity-80">
+                      ({totalCount})
+                    </span>
+                  )}
+                  <KeyHint variant="inline" keys={["⌘", "↵"]} />
+                </>
+              )}
             </button>
           </div>
         </div>

--- a/src/components/ops/inbox/inbox-route.tsx
+++ b/src/components/ops/inbox/inbox-route.tsx
@@ -283,7 +283,7 @@ export function InboxRoute({ threadId }: InboxRouteProps) {
           return;
         }
         enqueueUndoToast({
-          message: t("toast.archived", "Archived"),
+          message: t("toast.archivedTactic", "SYS :: THREAD ARCHIVED"),
           onUndo: () => threadActions.unarchive.mutate(threadId),
         });
       },
@@ -636,7 +636,7 @@ export function InboxRoute({ threadId }: InboxRouteProps) {
           setArchiveOpen(false);
           setArchiveContext(null);
           enqueueUndoToast({
-            message: t("toast.archived", "Archived"),
+            message: t("toast.archivedTactic", "SYS :: THREAD ARCHIVED"),
             onUndo: () =>
               threadActions.unarchiveBatch.mutate({
                 threadIds: args.threadIds,

--- a/src/components/ops/inbox/mobile-stacked-shell.tsx
+++ b/src/components/ops/inbox/mobile-stacked-shell.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft } from "lucide-react";
 import type { ReactNode } from "react";
 import { useDictionary } from "@/i18n/client";
 import { cn } from "@/lib/utils/cn";
+import { SlashLabel } from "@/components/ops/inbox/voice/slash-label";
 
 export type MobileInboxPane = "list" | "detail" | "context";
 
@@ -31,6 +32,12 @@ export function MobileStackedShell({
   className,
 }: MobileStackedShellProps) {
   const { t } = useDictionary("inbox");
+  const paneLabel =
+    activePane === "list"
+      ? t("mobile.listPane", "// LIST")
+      : activePane === "detail"
+        ? t("mobile.threadPane", "// THREAD")
+        : t("mobile.contextPane", "// CONTEXT");
   return (
     <div
       className={cn(
@@ -38,8 +45,8 @@ export function MobileStackedShell({
         className,
       )}
     >
-      {activePane !== "list" && (
-        <header className="flex h-12 shrink-0 items-center gap-2 border-b border-line bg-inbox-panel px-3">
+      <header className="flex h-12 shrink-0 items-center gap-2 border-b border-line bg-inbox-panel px-3">
+        {activePane !== "list" && (
           <button
             type="button"
             onClick={() => onPaneChange(BACK_TARGET[activePane])}
@@ -48,13 +55,9 @@ export function MobileStackedShell({
           >
             <ChevronLeft aria-hidden className="h-4 w-4" strokeWidth={1.5} />
           </button>
-          <span className="font-cakemono text-[11px] font-light uppercase leading-none tracking-[0.18em] text-text-3">
-            {activePane === "detail"
-              ? t("mobile.thread", "Thread")
-              : t("mobile.context", "Context")}
-          </span>
-        </header>
-      )}
+        )}
+        <SlashLabel label={paneLabel} tone="text-2" />
+      </header>
       <div className="flex min-h-0 flex-1 flex-col">
         {activePane === "list" && threadList}
         {activePane === "detail" && detail}

--- a/src/components/ops/inbox/recategorize-menu.tsx
+++ b/src/components/ops/inbox/recategorize-menu.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useCallback, useMemo, useState } from "react";
-import { Check, Sparkles } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils/cn";
 import { useDictionary } from "@/i18n/client";
@@ -20,7 +20,9 @@ import {
   type EmailThreadCategory,
 } from "@/lib/types/email-thread";
 import { useThreadActions } from "@/lib/hooks/use-inbox-threads";
-import { CategoryChip, categoryLabel } from "./category-chip";
+import { categoryLabel } from "./category-chip";
+import { SlashLabel } from "./voice/slash-label";
+import { KeyHint } from "@/components/ui/key-hint";
 import { enqueueUndoToast } from "./undo-toast";
 import { toast } from "sonner";
 
@@ -145,13 +147,16 @@ export function RecategorizeMenu({
         onKeyDown={handleKeyDown}
       >
         {/* Header */}
-        <div className="px-3 pt-2.5 pb-1.5 border-b border-line">
-          <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-text-mute">
-            {"// "}
-            {t("recategorize.prefix", "Reclassify")}
-          </p>
-          <p className="font-cakemono font-light uppercase text-[13px] tracking-[0.14em] text-text mt-0.5">
-            {t("recategorize.title", "Move thread to")}
+        <div className="px-3 pt-2.5 pb-2 border-b border-line">
+          <SlashLabel
+            label={t("modal.recat.title", "// RECATEGORIZE")}
+            size="md"
+          />
+          <p className="font-mono text-[11px] text-text-3 mt-1.5 leading-relaxed">
+            {t(
+              "modal.recat.body",
+              "[—] move this thread to a different group",
+            )}
           </p>
         </div>
 
@@ -168,23 +173,36 @@ export function RecategorizeMenu({
                 "focus:outline-none focus:bg-inbox-elev/60",
               )}
             >
-              <CategoryChip category={cat} size="sm" />
-              <span className="flex-1" />
-              <span className="font-mono text-[11px] text-text-mute tabular-nums">
-                {CATEGORY_HOTKEYS[cat]}
+              <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-text-2">
+                {categoryLabel(cat)}
               </span>
+              <span className="flex-1" />
+              <KeyHint
+                variant="inline"
+                keys={CATEGORY_HOTKEYS[cat]}
+                className="text-text-mute"
+              />
             </button>
           ))}
         </div>
 
-        {/* "Tell Phase C why" note */}
+        {/* "Tell Phase C why" note — Cake lavender authority label */}
         <div className="px-3 py-2 border-t border-line">
           <label
             htmlFor={`recat-note-${threadId}`}
-            className="flex items-center gap-1 font-mono text-[11px] uppercase tracking-[0.16em] text-text-mute mb-1"
+            className="flex items-center gap-1.5 mb-1"
           >
-            <Sparkles className="w-[14px] h-[14px]" strokeWidth={1.5} />
-            {t("recategorize.noteLabel", "Tell Phase C why (optional)")}
+            <Sparkles
+              className="w-[14px] h-[14px] text-agent-hi"
+              strokeWidth={1.5}
+            />
+            <SlashLabel
+              label={t(
+                "modal.recat.phaseCNote",
+                "// PHASE C NOTE — OPTIONAL",
+              )}
+              tone="agent"
+            />
           </label>
           <textarea
             id={`recat-note-${threadId}`}
@@ -202,15 +220,6 @@ export function RecategorizeMenu({
               "focus:outline-none focus:border-line-hi",
             )}
           />
-          <div className="flex items-center gap-1 mt-1">
-            <Check className="w-[14px] h-[14px] text-text-mute" strokeWidth={1.5} />
-            <p className="font-mono text-[11px] text-text-mute">
-              {t(
-                "recategorize.appliedNote",
-                "Applied to similar threads automatically.",
-              )}
-            </p>
-          </div>
         </div>
       </PopoverContent>
     </Popover>

--- a/src/components/ops/inbox/recategorize-menu.tsx
+++ b/src/components/ops/inbox/recategorize-menu.tsx
@@ -95,13 +95,13 @@ export function RecategorizeMenu({
         {
           onSuccess: () => {
             enqueueUndoToast({
-              message: t("toast.recategorized", "Marked as {category}").replace(
+              message: t("toast.recategorizedTactic", "SYS :: MOVED TO {category}").replace(
                 "{category}",
                 categoryLabel(next),
               ),
               detail: t(
                 "toast.recategorizedDetail",
-                "Phase C will learn from this correction.",
+                "[—] phase c will learn from this correction.",
               ),
               onUndo: () => {
                 recategorize.mutate({ threadId, toCategory: currentCategory });

--- a/src/components/ops/inbox/snooze-picker.tsx
+++ b/src/components/ops/inbox/snooze-picker.tsx
@@ -186,9 +186,9 @@ export function SnoozePicker({
       setOpen(false);
       snooze.mutate({ threadId, until });
       enqueueUndoToast({
-        message: t("toast.snoozed", "Snoozed until {when}").replace(
-          "{when}",
-          humanLabel,
+        message: t("toast.snoozedTactic", "SYS :: SNOOZED UNTIL {time}").replace(
+          "{time}",
+          humanLabel.toUpperCase(),
         ),
         onUndo: () => unsnooze.mutate(threadId),
       });

--- a/src/components/ops/inbox/snooze-picker.tsx
+++ b/src/components/ops/inbox/snooze-picker.tsx
@@ -10,11 +10,11 @@
  */
 
 import { useCallback, useMemo, useState } from "react";
-import { Clock, Calendar as CalendarIcon } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils/cn";
 import { useDictionary } from "@/i18n/client";
 import { useThreadActions } from "@/lib/hooks/use-inbox-threads";
+import { SlashLabel } from "./voice/slash-label";
 import { enqueueUndoToast } from "./undo-toast";
 
 interface SnoozePickerProps {
@@ -84,43 +84,46 @@ function nextMonth(now: Date): Date {
 }
 
 function buildPresets(): SnoozePreset[] {
+  // Tactical voice — bracketed JetBrains Mono uppercase labels per § 7.
+  // The dictionary keys live under `modal.snooze.preset*` (Phase A) but we
+  // keep the legacy `snooze.*.sub` sublabel keys (preserved presets, not new).
   return [
     {
       id: "later-today",
-      labelKey: "snooze.laterToday",
-      labelDefault: "Later today",
+      labelKey: "modal.snooze.presetLaterToday",
+      labelDefault: "[LATER TODAY]",
       sublabelKey: "snooze.laterToday.sub",
       sublabelDefault: "in 3 hours",
       compute: laterToday,
     },
     {
       id: "tomorrow",
-      labelKey: "snooze.tomorrow",
-      labelDefault: "Tomorrow",
+      labelKey: "modal.snooze.presetTomorrow",
+      labelDefault: "[TOMORROW 8AM]",
       sublabelKey: "snooze.tomorrow.sub",
       sublabelDefault: "8:00 AM",
       compute: tomorrowMorning,
     },
     {
       id: "weekend",
-      labelKey: "snooze.weekend",
-      labelDefault: "This weekend",
+      labelKey: "modal.snooze.presetWeekend",
+      labelDefault: "[WEEKEND]",
       sublabelKey: "snooze.weekend.sub",
       sublabelDefault: "Sat 9:00 AM",
       compute: thisWeekend,
     },
     {
       id: "next-week",
-      labelKey: "snooze.nextWeek",
-      labelDefault: "Next week",
+      labelKey: "modal.snooze.presetNextMon",
+      labelDefault: "[NEXT MON]",
       sublabelKey: "snooze.nextWeek.sub",
       sublabelDefault: "Mon 8:00 AM",
       compute: nextWeek,
     },
     {
       id: "next-month",
-      labelKey: "snooze.nextMonth",
-      labelDefault: "Next month",
+      labelKey: "modal.snooze.presetNextMonth",
+      labelDefault: "[NEXT MONTH]",
       sublabelKey: "snooze.nextMonth.sub",
       sublabelDefault: "1st at 8:00 AM",
       compute: nextMonth,
@@ -205,16 +208,16 @@ export function SnoozePicker({
       <PopoverContent
         align={align}
         sideOffset={6}
-        className="w-[260px] p-0"
+        className="w-[280px] p-0"
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
-        <div className="px-3 pt-2.5 pb-1.5 border-b border-line">
-          <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-text-mute">
-            {"// "}
-            {t("snooze.label", "Snooze")}
-          </p>
-          <p className="font-cakemono font-light uppercase text-[13px] tracking-[0.14em] text-text mt-0.5">
-            {t("snooze.title", "Come back when")}
+        <div className="px-3 pt-2.5 pb-2 border-b border-line">
+          <SlashLabel label={t("modal.snooze.title", "// SNOOZE")} size="md" />
+          <p className="font-mono text-[11px] text-text-3 mt-1.5 leading-relaxed">
+            {t(
+              "modal.snooze.body",
+              "[—] hide until · returns to inbox automatically",
+            )}
           </p>
         </div>
 
@@ -232,15 +235,10 @@ export function SnoozePicker({
                   "hover:bg-inbox-elev/40 transition-colors duration-150",
                 )}
               >
-                <Clock className="w-[14px] h-[14px] text-text-mute shrink-0" strokeWidth={1.5} />
-                <div className="flex-1 min-w-0">
-                  <p className="font-cakemono font-light uppercase text-[12px] tracking-[0.14em] text-text-2">
-                    {t(preset.labelKey, preset.labelDefault)}
-                  </p>
-                  <p className="font-mono text-[11px] text-text-mute mt-[1px]">
-                    {t(preset.sublabelKey, preset.sublabelDefault)}
-                  </p>
-                </div>
+                <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-text-2 shrink-0">
+                  {t(preset.labelKey, preset.labelDefault)}
+                </span>
+                <span className="flex-1" />
                 <span className="font-mono text-[11px] text-text-mute tabular-nums shrink-0">
                   {formatPresetValue(computed)}
                 </span>
@@ -252,10 +250,9 @@ export function SnoozePicker({
         <div className="px-3 pt-2 pb-2.5 border-t border-line">
           <label
             htmlFor={`snooze-custom-${threadId}`}
-            className="flex items-center gap-1 font-mono text-[11px] uppercase tracking-[0.16em] text-text-mute mb-1"
+            className="block font-mohave italic text-[12px] text-text-3 lowercase mb-1"
           >
-            <CalendarIcon className="w-[14px] h-[14px]" strokeWidth={1.5} />
-            {t("snooze.custom", "Pick date & time")}
+            {t("modal.snooze.presetCustom", "pick a date and time…")}
           </label>
           <div className="flex items-stretch gap-1">
             <input

--- a/src/components/ops/inbox/undo-toast.tsx
+++ b/src/components/ops/inbox/undo-toast.tsx
@@ -27,7 +27,6 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
-import { Undo2 } from "lucide-react";
 import { EASE_SMOOTH } from "@/lib/utils/motion";
 import { KeyHint } from "@/components/ui/key-hint";
 import { useDictionary } from "@/i18n/client";
@@ -193,16 +192,17 @@ function ToastRow({ toast, onResolve }: ToastRowProps) {
       aria-labelledby={`${id}-msg`}
       className="pointer-events-auto glass-dense relative w-[340px] overflow-hidden"
     >
-      <div className="flex items-center gap-3 px-3 py-2">
+      <div className="flex items-center gap-2 px-3 py-2">
         <div className="min-w-0 flex-1">
           <p
             id={`${id}-msg`}
-            className="font-cakemono font-light uppercase text-[12px] tracking-[0.12em] text-text leading-tight"
+            className="font-mono uppercase text-[11px] tracking-[0.14em] text-text-2 leading-tight"
           >
             {toast.message}
+            <span aria-hidden className="text-text-mute"> · </span>
           </p>
           {toast.detail && (
-            <p className="font-mono text-[11px] text-text-3 mt-0.5 truncate">
+            <p className="font-mohave text-[12px] text-text-3 mt-0.5 truncate lowercase">
               {toast.detail}
             </p>
           )}
@@ -210,11 +210,10 @@ function ToastRow({ toast, onResolve }: ToastRowProps) {
         <button
           type="button"
           onClick={handleUndo}
-          className="flex items-center gap-1.5 shrink-0 px-2 py-1 rounded-[2.5px] border border-line bg-inbox-elev/60 hover:bg-inbox-elev transition-colors"
+          className="flex items-center gap-1.5 shrink-0 px-2 py-1 border border-line-hi hover:bg-inbox-elev transition-colors"
         >
-          <Undo2 className="w-4 h-4 text-text-2" strokeWidth={1.5} />
-          <span className="font-cakemono font-light uppercase text-[11px] tracking-[0.14em] text-text-2">
-            {t("toast.undo", "Undo")}
+          <span className="font-mono uppercase text-[11px] tracking-[0.14em] text-text leading-none">
+            {t("toast.undoTactic", "UNDO")}
           </span>
           <KeyHint keys="Z" variant="inline" className="text-text-mute" />
         </button>

--- a/src/components/ops/inbox/writeback-preference-modal.tsx
+++ b/src/components/ops/inbox/writeback-preference-modal.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useCallback, useState } from "react";
-import { ArchiveRestore, Eye, ServerOff, Check } from "lucide-react";
+import { Check } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -21,6 +21,7 @@ import {
 import { cn } from "@/lib/utils/cn";
 import { useDictionary } from "@/i18n/client";
 import { useThreadActions } from "@/lib/hooks/use-inbox-threads";
+import { SlashLabel } from "./voice/slash-label";
 import type { ArchiveWritebackPreference } from "@/lib/types/email-thread";
 
 interface WritebackPreferenceModalProps {
@@ -35,48 +36,35 @@ interface WritebackPreferenceModalProps {
 
 interface PreferenceOption {
   id: Exclude<ArchiveWritebackPreference, "ask">;
-  icon: typeof ArchiveRestore;
-  /** Dictionary key (e.g. "writeback.archive") + fallback English string. */
+  /** Dictionary key for the bracketed/uppercase tactical label. */
   labelKey: string;
   labelDefault: string;
-  detailKey: string;
-  detailDefault: string;
-  captionKey: string;
-  captionDefault: string;
+  /** Dictionary key for the [—]-prefixed body line. */
+  bodyKey: string;
+  bodyDefault: string;
 }
 
 const OPTIONS: readonly PreferenceOption[] = [
   {
     id: "archive_in_gmail",
-    icon: ArchiveRestore,
-    labelKey: "writeback.archive",
-    labelDefault: "Archive in Gmail / Outlook",
-    detailKey: "writeback.archive.detail",
-    detailDefault: "Cleanest. Thread leaves your provider inbox too.",
-    captionKey: "writeback.archive.caption",
-    captionDefault: "Recommended",
+    labelKey: "modal.writeback.archiveInGmail",
+    labelDefault: "ARCHIVE IN GMAIL/OUTLOOK",
+    bodyKey: "modal.writeback.archiveInGmailBody",
+    bodyDefault: "[—] mark as read AND move to archive",
   },
   {
     id: "mark_read_only",
-    icon: Eye,
-    labelKey: "writeback.markRead",
-    labelDefault: "Just mark as read",
-    detailKey: "writeback.markRead.detail",
-    detailDefault:
-      "Keeps the thread in your Gmail / Outlook inbox, but silences it there.",
-    captionKey: "writeback.markRead.caption",
-    captionDefault: "Safer for starters",
+    labelKey: "modal.writeback.markAsRead",
+    labelDefault: "MARK AS READ ONLY",
+    bodyKey: "modal.writeback.markAsReadBody",
+    bodyDefault: "[—] mark as read, leave in inbox",
   },
   {
     id: "ops_only",
-    icon: ServerOff,
-    labelKey: "writeback.opsOnly",
-    labelDefault: "Only inside OPS",
-    detailKey: "writeback.opsOnly.detail",
-    detailDefault:
-      "Leaves Gmail / Outlook untouched. Archive is local to OPS.",
-    captionKey: "writeback.opsOnly.caption",
-    captionDefault: "Maximum control",
+    labelKey: "modal.writeback.opsOnly",
+    labelDefault: "OPS-ONLY",
+    bodyKey: "modal.writeback.opsOnlyBody",
+    bodyDefault: "[—] no change to your connected inbox",
   },
 ] as const;
 
@@ -125,28 +113,36 @@ export function WritebackPreferenceModal({
     }
   }, [connectionId, selected, setWritebackPreference, onOpenChange, onConfirmed, t]);
 
+  const writebackTitle = t(
+    "modal.writeback.title",
+    "// WRITEBACK PREFERENCE",
+  );
+  const writebackBody = t(
+    "modal.writeback.body",
+    "[—] when you archive, what should happen in your connected inbox?",
+  );
+
   return (
     <Dialog open={open} onOpenChange={close}>
       <DialogContent className="max-w-[520px] p-0">
+        <DialogTitle className="sr-only">
+          {t("writeback.a11yTitle", "Writeback preference")}
+        </DialogTitle>
+        <DialogDescription className="sr-only">
+          {t(
+            "writeback.a11yDescription",
+            "Pick how archive should behave in your connected inbox.",
+          )}
+        </DialogDescription>
         <div className="px-4 pt-4 pb-3 border-b border-line">
-          <p className="font-mono text-[11px] uppercase tracking-[0.20em] text-text-mute">
-            {"// "}
-            {t("writeback.prefix", "First archive")}
+          <SlashLabel label={writebackTitle} size="md" />
+          <p className="font-mono text-[11px] text-text-3 mt-2 leading-relaxed">
+            {writebackBody}
           </p>
-          <DialogTitle className="font-cakemono font-light uppercase text-[20px] tracking-[0.10em] text-text mt-1">
-            {t("writeback.title", "What should archive do?")}
-          </DialogTitle>
-          <DialogDescription className="font-mohave text-[13px] text-text-2 mt-1">
-            {t(
-              "writeback.description",
-              "OPS can keep your Gmail or Outlook inbox in sync when you archive in here. Pick once — you can change it later in Settings.",
-            )}
-          </DialogDescription>
         </div>
 
         <div className="p-3 space-y-1.5">
           {OPTIONS.map((opt) => {
-            const Icon = opt.icon;
             const isActive = opt.id === selected;
             return (
               <button
@@ -154,46 +150,24 @@ export function WritebackPreferenceModal({
                 type="button"
                 onClick={() => setSelected(opt.id)}
                 className={cn(
-                  "flex items-start gap-2.5 w-full p-3 rounded-sidebar text-left",
-                  "border transition-colors duration-150",
+                  "flex items-start gap-2.5 w-full text-left",
+                  "rounded-[2.5px] border px-3.5 py-3 transition-colors duration-150",
                   isActive
                     ? "border-line-hi bg-inbox-elev/60"
                     : "border-line bg-inbox-bg-deep hover:bg-inbox-elev/40",
                 )}
               >
-                <div
-                  className={cn(
-                    "w-[28px] h-[28px] rounded-[2.5px] flex items-center justify-center shrink-0",
-                    "border",
-                    isActive
-                      ? "border-line-hi bg-inbox-elev/80"
-                      : "border-line bg-inbox-elev/40",
-                  )}
-                >
-                  <Icon
+                <div className="flex-1 min-w-0">
+                  <p
                     className={cn(
-                      "w-[14px] h-[14px]",
+                      "font-mono text-[11px] uppercase tracking-[0.14em]",
                       isActive ? "text-text" : "text-text-2",
                     )}
-                    strokeWidth={1.5}
-                  />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-1.5">
-                    <p
-                      className={cn(
-                        "font-cakemono font-light uppercase text-[12px] tracking-[0.14em]",
-                        isActive ? "text-text" : "text-text-2",
-                      )}
-                    >
-                      {t(opt.labelKey, opt.labelDefault)}
-                    </p>
-                    <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-text-mute">
-                      {t(opt.captionKey, opt.captionDefault)}
-                    </span>
-                  </div>
-                  <p className="font-mohave text-[12px] text-text-3 mt-0.5 leading-snug">
-                    {t(opt.detailKey, opt.detailDefault)}
+                  >
+                    {t(opt.labelKey, opt.labelDefault)}
+                  </p>
+                  <p className="font-mohave text-[12px] text-text-3 mt-1 leading-snug">
+                    {t(opt.bodyKey, opt.bodyDefault)}
                   </p>
                 </div>
                 {isActive && (
@@ -213,7 +187,7 @@ export function WritebackPreferenceModal({
           </div>
         )}
 
-        <div className="flex justify-end gap-1.5 px-4 pb-4 pt-1 border-t border-line">
+        <div className="flex justify-end gap-1.5 px-4 pt-2 pb-2 border-t border-line">
           <button
             type="button"
             onClick={() => close(false)}
@@ -225,7 +199,7 @@ export function WritebackPreferenceModal({
               "disabled:opacity-50 disabled:cursor-not-allowed",
             )}
           >
-            {t("writeback.notNow", "Not now")}
+            {t("modal.writeback.notNow", "NOT NOW")}
           </button>
           <button
             type="button"
@@ -233,16 +207,33 @@ export function WritebackPreferenceModal({
             disabled={submitting || !connectionId}
             className={cn(
               "px-3 py-1.5 rounded-[2.5px]",
-              "bg-ops-accent text-black",
+              "border border-ops-accent text-ops-accent",
               "font-cakemono font-light uppercase text-[11px] tracking-[0.14em]",
-              "hover:bg-ops-accent/90 transition-colors duration-150",
+              "hover:bg-ops-accent hover:text-black transition-colors duration-150",
               "disabled:opacity-50 disabled:cursor-not-allowed",
             )}
           >
             {submitting
               ? t("writeback.saving", "Saving…")
-              : t("writeback.confirm", "Save & archive")}
+              : t("modal.writeback.saveArchive", "SAVE & ARCHIVE")}
           </button>
+        </div>
+
+        <div className="px-4 pb-4 pt-1">
+          <a
+            href="https://docs.opsltd.com/writeback"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              "font-mohave italic text-[11px] lowercase",
+              "text-text-3 hover:text-text-2 transition-colors duration-150",
+            )}
+          >
+            {t(
+              "modal.writeback.learnMore",
+              "learn more about writeback →",
+            )}
+          </a>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/i18n/dictionaries/en/inbox.json
+++ b/src/i18n/dictionaries/en/inbox.json
@@ -461,12 +461,12 @@
   "rail.oppMetaThisThread": "↗ this thread",
   "rail.photosCount": "{n} PHOTOS",
 
-  "modal.archive.title": "// ARCHIVE THREAD",
+  "modal.archive.title": "// ARCHIVE",
   "modal.archive.body": "[—] this thread will move to archive. nothing is deleted.",
   "modal.archive.cancel": "CANCEL",
   "modal.archive.confirm": "ARCHIVE",
 
-  "modal.snooze.title": "// SNOOZE THREAD",
+  "modal.snooze.title": "// SNOOZE",
   "modal.snooze.body": "[—] hide until · returns to inbox automatically",
   "modal.snooze.preset1H": "[1H]",
   "modal.snooze.preset4H": "[4H]",
@@ -474,6 +474,7 @@
   "modal.snooze.presetTomorrow": "[TOMORROW 8AM]",
   "modal.snooze.presetWeekend": "[WEEKEND]",
   "modal.snooze.presetNextMon": "[NEXT MON]",
+  "modal.snooze.presetNextMonth": "[NEXT MONTH]",
   "modal.snooze.presetCustom": "pick a date and time…",
 
   "modal.recat.title": "// RECATEGORIZE",

--- a/src/i18n/dictionaries/en/inbox.json
+++ b/src/i18n/dictionaries/en/inbox.json
@@ -284,7 +284,7 @@
   "toast.archivedBack": "Moved back to inbox",
   "toast.snoozed": "Snoozed until {when}",
   "toast.recategorized": "Marked as {category}",
-  "toast.recategorizedDetail": "Phase C will learn from this correction.",
+  "toast.recategorizedDetail": "[—] phase c will learn from this correction.",
   "toast.undo": "Undo",
 
   "phaseC.drafted.primary": "Phase C drafted a reply for you",

--- a/src/i18n/dictionaries/es/inbox.json
+++ b/src/i18n/dictionaries/es/inbox.json
@@ -430,12 +430,12 @@
   "rail.oppMetaThisThread": "↗ este hilo",
   "rail.photosCount": "{n} FOTOS",
 
-  "modal.archive.title": "// ARCHIVAR HILO",
+  "modal.archive.title": "// ARCHIVAR",
   "modal.archive.body": "[—] este hilo se moverá al archivo. nada se elimina.",
   "modal.archive.cancel": "CANCELAR",
   "modal.archive.confirm": "ARCHIVAR",
 
-  "modal.snooze.title": "// POSPONER HILO",
+  "modal.snooze.title": "// POSPONER",
   "modal.snooze.body": "[—] ocultar hasta · vuelve a la bandeja automáticamente",
   "modal.snooze.preset1H": "[1H]",
   "modal.snooze.preset4H": "[4H]",
@@ -443,6 +443,7 @@
   "modal.snooze.presetTomorrow": "[MAÑANA 8AM]",
   "modal.snooze.presetWeekend": "[FIN DE SEMANA]",
   "modal.snooze.presetNextMon": "[PRÓX LUN]",
+  "modal.snooze.presetNextMonth": "[PRÓX MES]",
   "modal.snooze.presetCustom": "elige fecha y hora…",
 
   "modal.recat.title": "// RECATEGORIZAR",

--- a/src/i18n/dictionaries/es/inbox.json
+++ b/src/i18n/dictionaries/es/inbox.json
@@ -220,6 +220,7 @@
 
   "toast.archived": "Archivado",
   "toast.archivedBack": "Devuelto a la bandeja",
+  "toast.recategorizedDetail": "[—] phase c aprenderá de esta corrección.",
   "toast.undo": "Deshacer",
 
   "phaseC.drafted.primary": "Phase C redactó una respuesta",


### PR DESCRIPTION
## Summary

Phase G of the Inbox brand-intent rework. Voice-only changes across modals, undo toast, and the mobile stacked shell. All affordances + behaviors preserved.

- **G1: 4 modal voice rewrites** — archive-confirm, snooze-picker, recategorize-menu, writeback-preference. `// SLASH-LABEL` titles, `[—] body` micro-text, `<KeyHint inline>` for shortcuts. Sibling-threads + lead checkbox + dynamic snooze presets + hotkey letters + three writeback options all preserved.
- **G2: Undo toast** — `SYS :: THREAD ARCHIVED · UNDO Z` voice, bare-`Z` keybinding kept (no Cmd modifier per cross-platform convention), 5-second auto-dismiss + 3-toast stack cap preserved. Callers in `inbox-route.tsx` / `snooze-picker.tsx` / `recategorize-menu.tsx` switched to the new `toast.*Tactic` dict keys.
- **G3: Mobile stacked shell** — `// LIST` / `// THREAD` / `// CONTEXT` pane indicators rendered via `<SlashLabel>`. LIST pane now gets a header (previously had none); back button hidden on LIST since back is a no-op there.

Spec: \`docs/superpowers/specs/2026-05-08-inbox-brand-rework-design.md\` § 7
Plan: \`docs/superpowers/plans/2026-05-08-inbox-brand-rework.md\` Phase G

## Commits

- \`e79ef2e0\` — feat(inbox): tactical voice on all modals (G1)
- \`cafe260a\` — feat(inbox): undo toast SYS :: voice (G2)
- \`018e5e3f\` — feat(inbox): mobile shell // LIST / // THREAD / // CONTEXT pane labels (G3)

## Known follow-ups (out of scope for voice-only)

- **Toast position:** Spec § 7 says bottom-left above FAB column. Current impl is \`top-[72px] right-6\`. Position is behavior, not voice — left as-is. Worth reconciling in a separate task.
- **Dictionary cleanup:** Old \`toast.archived\` / \`toast.snoozed\` / \`toast.recategorized\` keys are now unused in production code but retained for now. Removable in a cleanup pass.
- **TS enum:** \`ArchiveWritebackPreference\` still uses \`mark_read_only\`. Spec § 7 example uses \`mark_as_read\` — label difference only; the visible UI string is \`MARK AS READ ONLY\` so user-facing voice matches.

## Test plan

- [x] Inbox unit suite — \`npm run test -- src/components/ops/inbox src/lib/inbox --run\` → 30 files / **195 tests** passing (+25 new in G1, +12 in G2, +1 in G3)
- [x] Type-check — \`npx tsc --noEmit\` → clean
- [x] Lint — no new warnings on Phase G files
- [x] Dev server smoke — \`/inbox\` route compiles in 4s and returns HTTP 200
- [ ] Browser walkthrough (reviewer): open archive / snooze / recategorize modals → verify Cake \`// HEADER\` + bracketed body; archive → toast reads \`SYS :: THREAD ARCHIVED · UNDO Z\`; press \`Z\` → undoes; resize < 768px → mobile shell shows \`// LIST\` header with no back button, \`// THREAD\` and \`// CONTEXT\` headers with back buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)