### PR TITLE
feat(inbox): Phase E — detail-header thread picker

### DIFF
--- a/src/components/ops/inbox/__tests__/thread-picker.test.tsx
+++ b/src/components/ops/inbox/__tests__/thread-picker.test.tsx
@@ -64,7 +64,7 @@ beforeEach(() => {
 });
 
 describe("<ThreadPicker>", () => {
-  it("renders the trigger with the count and JetBrains Mono uppercase styling when threads exist", () => {
+  it("renders the trigger with the count when threads exist", () => {
     const threads = [
       makeThread("t1", "Quote follow-up", stateYours),
       makeThread("t2", "Inspection rescheduling", stateTheirs),
@@ -82,10 +82,7 @@ describe("<ThreadPicker>", () => {
       name: /3 other threads/i,
     });
     expect(trigger).toBeInTheDocument();
-    // JetBrains Mono uppercase trigger label
-    expect(trigger.className).toMatch(/font-mono/);
-    expect(trigger.className).toMatch(/uppercase/);
-    // Hairline border on active trigger
+    // Hairline border on active trigger — visual contract per spec § 5.1
     expect(trigger.className).toMatch(/\bborder\b/);
     // The visible label text (after the chevron) shows the count
     expect(trigger).toHaveTextContent(/3 OTHER THREADS/);

--- a/src/components/ops/inbox/__tests__/thread-picker.test.tsx
+++ b/src/components/ops/inbox/__tests__/thread-picker.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks (must be hoisted before importing the component) ─────────────────
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push,
+    prefetch: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/i18n/client", () => ({
+  useDictionary: () => ({
+    t: (_k: string, fallback?: string) => fallback ?? _k,
+    dict: {},
+  }),
+  useLocale: () => ({ locale: "en", setLocale: vi.fn() }),
+}));
+
+import { ThreadPicker, type ThreadPickerThread } from "../thread-picker";
+import type { StateTagResult } from "@/lib/inbox/format-wait";
+
+const stateYours: StateTagResult = {
+  kind: "yours",
+  tone: "accent",
+  prefix: "YOURS",
+  value: "18H",
+  alarmStrip: false,
+};
+
+const stateTheirs: StateTagResult = {
+  kind: "theirs",
+  tone: "neutral",
+  prefix: "THEIRS",
+  value: "2D",
+  alarmStrip: false,
+};
+
+const stateFyi: StateTagResult = {
+  kind: "fyi",
+  tone: "neutral",
+  prefix: "FYI",
+  alarmStrip: false,
+};
+
+function makeThread(
+  id: string,
+  subject: string,
+  state: StateTagResult,
+  unread = false,
+): ThreadPickerThread {
+  return { id, subject, unread, state };
+}
+
+beforeEach(() => {
+  push.mockReset();
+});
+
+describe("<ThreadPicker>", () => {
+  it("renders the trigger with the count and JetBrains Mono uppercase styling when threads exist", () => {
+    const threads = [
+      makeThread("t1", "Quote follow-up", stateYours),
+      makeThread("t2", "Inspection rescheduling", stateTheirs),
+      makeThread("t3", "Final invoice", stateFyi),
+    ];
+    render(
+      <ThreadPicker
+        threads={threads}
+        currentThreadId="current"
+        clientName="ACME"
+      />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: /3 other threads/i,
+    });
+    expect(trigger).toBeInTheDocument();
+    // JetBrains Mono uppercase trigger label
+    expect(trigger.className).toMatch(/font-mono/);
+    expect(trigger.className).toMatch(/uppercase/);
+    // Hairline border on active trigger
+    expect(trigger.className).toMatch(/\bborder\b/);
+    // The visible label text (after the chevron) shows the count
+    expect(trigger).toHaveTextContent(/3 OTHER THREADS/);
+  });
+
+  it("renders the disabled mute label and no button when threads is empty", () => {
+    render(
+      <ThreadPicker
+        threads={[]}
+        currentThreadId="current"
+        clientName="ACME"
+      />,
+    );
+
+    expect(screen.getByText("· 0 OTHER THREADS")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("clicking the trigger opens the popover and renders rows + the slash header", async () => {
+    const user = userEvent.setup();
+    const threads = [
+      makeThread("t1", "Quote follow-up", stateYours),
+      makeThread("t2", "Inspection rescheduling", stateTheirs),
+    ];
+    render(
+      <ThreadPicker
+        threads={threads}
+        currentThreadId="current"
+        clientName="ACME"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /2 other threads/i }));
+
+    expect(screen.getByText("Quote follow-up")).toBeInTheDocument();
+    expect(screen.getByText("Inspection rescheduling")).toBeInTheDocument();
+    expect(
+      screen.getByText("// THREADS WITH ACME · 2"),
+    ).toBeInTheDocument();
+  });
+
+  it("highlights a row whose id matches currentThreadId with the accent tint (defensive case)", async () => {
+    const user = userEvent.setup();
+    // Defensive: hook should normally exclude current thread, but if it appears
+    // we still tint it and disable the click.
+    const threads = [
+      makeThread("current", "This very thread", stateYours),
+      makeThread("t2", "Another thread", stateTheirs),
+    ];
+    render(
+      <ThreadPicker
+        threads={threads}
+        currentThreadId="current"
+        clientName="ACME"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /2 other threads/i }));
+
+    const currentRow = screen.getByText("This very thread").closest("[data-thread-row]");
+    expect(currentRow).not.toBeNull();
+    // Accent tint marker class on the row container
+    expect((currentRow as HTMLElement).className).toMatch(/bg-ops-accent\/\[0\.08\]/);
+
+    // Clicking the current-thread row should NOT push (it has no onClick)
+    await user.click(currentRow as HTMLElement);
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("clicking a non-current row pushes the router and closes the popover", async () => {
+    const user = userEvent.setup();
+    const threads = [
+      makeThread("t1", "Quote follow-up", stateYours),
+      makeThread("t2", "Inspection rescheduling", stateTheirs),
+    ];
+    render(
+      <ThreadPicker
+        threads={threads}
+        currentThreadId="current"
+        clientName="ACME"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /2 other threads/i }));
+    expect(screen.getByText("Quote follow-up")).toBeInTheDocument();
+
+    const row = screen.getByRole("button", { name: "Quote follow-up" });
+    await user.click(row);
+
+    expect(push).toHaveBeenCalledWith("/inbox/t1");
+    // Popover closed → header text no longer in DOM
+    expect(
+      screen.queryByText("// THREADS WITH ACME · 2"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ops/inbox/inbox-route.tsx
+++ b/src/components/ops/inbox/inbox-route.tsx
@@ -193,26 +193,23 @@ export function InboxRoute({ threadId }: InboxRouteProps) {
   // direction stamps lastMessageAt, the other side gets null. This is the
   // best fidelity we have without a second join, and matches what the
   // sibling-context view already does.
-  const pickerThreads = useMemo<ThreadPickerThread[]>(() => {
-    const list = clientThreadsQuery.data ?? [];
-    return list.map((row) => {
-      const ts = row.lastMessageAt.getTime();
-      return {
-        id: row.id,
-        subject: row.subject ?? "",
-        unread: (row.unreadCount ?? 0) > 0,
-        state: computeStateTag({
-          lastInboundAt: row.latestDirection === "inbound" ? ts : null,
-          lastOutboundAt: row.latestDirection === "outbound" ? ts : null,
-          hasAiDraft: false,
-          sentByAgentRecently: false,
-          category: row.primaryCategory,
-          closed: row.archivedAt !== null,
-          now,
-        }),
-      };
-    });
-  }, [clientThreadsQuery.data, now]);
+  const pickerThreads: ThreadPickerThread[] = (clientThreadsQuery.data ?? []).map((row) => {
+    const ts = row.lastMessageAt.getTime();
+    return {
+      id: row.id,
+      subject: row.subject ?? "",
+      unread: (row.unreadCount ?? 0) > 0,
+      state: computeStateTag({
+        lastInboundAt: row.latestDirection === "inbound" ? ts : null,
+        lastOutboundAt: row.latestDirection === "outbound" ? ts : null,
+        hasAiDraft: false,
+        sentByAgentRecently: false,
+        category: row.primaryCategory,
+        closed: row.archivedAt !== null,
+        now,
+      }),
+    };
+  });
 
   const commitments = useMemo<TodayCommitment[]>(
     () => threads.flatMap(toCommitments).slice(0, 3),

--- a/src/components/ops/inbox/inbox-route.tsx
+++ b/src/components/ops/inbox/inbox-route.tsx
@@ -48,6 +48,9 @@ import { useClientFiles } from "@/lib/hooks/use-client-files";
 import { useClient, useSubClients } from "@/lib/hooks/use-clients";
 import { useThreadOpportunityLinks } from "@/lib/hooks/use-thread-opportunity-links";
 import { useClientTasks } from "@/lib/hooks/use-client-tasks";
+import { useClientThreads } from "@/lib/hooks/use-client-threads";
+import { ThreadPicker, type ThreadPickerThread } from "./thread-picker";
+import { computeStateTag } from "@/lib/inbox/format-wait";
 import { useWindowStore } from "@/stores/window-store";
 import { ResponsiveInboxShell } from "./responsive-inbox-shell";
 import { ThreadColumnHeader } from "./thread-column-header";
@@ -166,6 +169,9 @@ export function InboxRoute({ threadId }: InboxRouteProps) {
   const filesQuery = useClientFiles(clientId);
   const clientQuery = useClient(clientId ?? undefined);
   const subClientsQuery = useSubClients(clientId ?? undefined);
+  const clientThreadsQuery = useClientThreads(clientId, {
+    excludeId: threadId ?? null,
+  });
   const linkedOpsQuery = useThreadOpportunityLinks(threadId ?? null);
   const linkedOppIds = useMemo(
     () => new Set(linkedOpsQuery.data ?? []),
@@ -179,6 +185,34 @@ export function InboxRoute({ threadId }: InboxRouteProps) {
     () => threads.map(toThreadListItem),
     [threads],
   );
+
+  // ThreadPicker feed — map sibling EmailThread rows to the picker's
+  // ThreadPickerThread shape via computeStateTag. Per-row inbound/outbound
+  // timestamps don't exist on EmailThread (only `lastMessageAt` +
+  // `latestDirection`), so we derive both timestamps from those: the
+  // direction stamps lastMessageAt, the other side gets null. This is the
+  // best fidelity we have without a second join, and matches what the
+  // sibling-context view already does.
+  const pickerThreads = useMemo<ThreadPickerThread[]>(() => {
+    const list = clientThreadsQuery.data ?? [];
+    return list.map((row) => {
+      const ts = row.lastMessageAt.getTime();
+      return {
+        id: row.id,
+        subject: row.subject ?? "",
+        unread: (row.unreadCount ?? 0) > 0,
+        state: computeStateTag({
+          lastInboundAt: row.latestDirection === "inbound" ? ts : null,
+          lastOutboundAt: row.latestDirection === "outbound" ? ts : null,
+          hasAiDraft: false,
+          sentByAgentRecently: false,
+          category: row.primaryCategory,
+          closed: row.archivedAt !== null,
+          now,
+        }),
+      };
+    });
+  }, [clientThreadsQuery.data, now]);
 
   const commitments = useMemo<TodayCommitment[]>(
     () => threads.flatMap(toCommitments).slice(0, 3),
@@ -324,6 +358,19 @@ export function InboxRoute({ threadId }: InboxRouteProps) {
         ) : (
           button
         )
+      }
+      threadPickerSlot={
+        threadId && clientId ? (
+          <ThreadPicker
+            threads={pickerThreads}
+            currentThreadId={threadId}
+            clientName={
+              detail.thread.clientName ??
+              guessSenderName(detail.messages) ??
+              ""
+            }
+          />
+        ) : undefined
       }
     >
       <CommitmentPills

--- a/src/components/ops/inbox/thread-detail-header.tsx
+++ b/src/components/ops/inbox/thread-detail-header.tsx
@@ -44,6 +44,9 @@ interface ThreadDetailHeaderProps {
   onSnooze?: () => void;
   onRecategorize?: () => void;
   onMore?: () => void;
+  /** Inline slot rendered in the meta strip after the message count.
+   *  Typically a `<ThreadPicker />` populated by the parent route. */
+  threadPickerSlot?: ReactNode;
   className?: string;
 }
 
@@ -85,6 +88,7 @@ export function ThreadDetailHeader({
   onSnooze,
   onRecategorize,
   onMore,
+  threadPickerSlot,
   className,
 }: ThreadDetailHeaderProps) {
   const { t } = useDictionary("inbox");
@@ -172,6 +176,14 @@ export function ThreadDetailHeader({
                 String(messageCount),
               )}
         </span>
+        {threadPickerSlot && (
+          <>
+            <span aria-hidden className="text-text-mute">
+              ·
+            </span>
+            {threadPickerSlot}
+          </>
+        )}
       </div>
     </header>
   );

--- a/src/components/ops/inbox/thread-detail.tsx
+++ b/src/components/ops/inbox/thread-detail.tsx
@@ -21,6 +21,9 @@ interface ThreadDetailProps {
   onSnooze?: () => void;
   onRecategorize?: () => void;
   onMore?: () => void;
+  /** Inline slot rendered in the detail-header meta strip after the message
+   *  count. Forwarded as-is to <ThreadDetailHeader>. */
+  threadPickerSlot?: ReactNode;
   className?: string;
   children?: ReactNode;
 }
@@ -48,6 +51,7 @@ export function ThreadDetail({
   onSnooze,
   onRecategorize,
   onMore,
+  threadPickerSlot,
   className,
   children,
 }: ThreadDetailProps) {
@@ -82,6 +86,7 @@ export function ThreadDetail({
         onSnooze={onSnooze}
         onRecategorize={onRecategorize}
         onMore={onMore}
+        threadPickerSlot={threadPickerSlot}
       />
       <div className="flex min-h-0 flex-1 flex-col">{children}</div>
     </div>

--- a/src/components/ops/inbox/thread-picker.tsx
+++ b/src/components/ops/inbox/thread-picker.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+/**
+ * ThreadPicker — inline trigger + popover that lists OTHER threads with the
+ * same client. Lives in the detail-header meta strip, after the message count.
+ *
+ * Spec § 5.1 (plan Phase E1):
+ *   - Trigger: chevron-prefixed JetBrains Mono uppercase 11 with hairline
+ *     border. Disabled (mute, no border, no chevron) when no other threads.
+ *   - Popover: glass-dense, 12px radius (inherited from .glass-dense), anchored
+ *     to the trigger's right edge, ~340px wide. Header SlashLabel + thread
+ *     rows. Click row → router.push(`/inbox/{id}`) + close popover.
+ *
+ * Data feed: parent (E2 wiring in inbox-route.tsx) pre-computes the
+ * ThreadPickerThread[] via useClientThreads + computeStateTag.
+ */
+
+import { useCallback, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useDictionary } from "@/i18n/client";
+import { cn } from "@/lib/utils/cn";
+import { StateTag } from "./state-tag";
+import { SlashLabel } from "./voice/slash-label";
+import type { StateTagResult } from "@/lib/inbox/format-wait";
+
+export interface ThreadPickerThread {
+  id: string;
+  subject: string;
+  unread: boolean;
+  state: StateTagResult;
+}
+
+export interface ThreadPickerProps {
+  /** All other threads for this client (current thread already excluded by hook). */
+  threads: ThreadPickerThread[];
+  /** Current thread id — defensive guard against the hook including it. */
+  currentThreadId: string | null;
+  /** Client display name for the popover header label. */
+  clientName: string;
+  /** Optional className for the trigger wrapper. */
+  className?: string;
+}
+
+export function ThreadPicker({
+  threads,
+  currentThreadId,
+  clientName,
+  className,
+}: ThreadPickerProps) {
+  const { t } = useDictionary("inbox");
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  const count = threads.length;
+
+  const handleRowClick = useCallback(
+    (threadId: string) => {
+      router.push(`/inbox/${threadId}`);
+      setOpen(false);
+    },
+    [router],
+  );
+
+  // Disabled mute label — no other threads
+  if (count === 0) {
+    return (
+      <span
+        className={cn(
+          "font-mono uppercase tracking-[0.10em] text-[11px] text-text-mute",
+          className,
+        )}
+      >
+        {t("picker.triggerNone", "· 0 OTHER THREADS")}
+      </span>
+    );
+  }
+
+  // Strip the leading "▾ " from the dictionary value because we render the
+  // chevron icon ourselves via Lucide. Then interpolate the count.
+  const triggerLabel = t("picker.trigger", "▾ {count} OTHER THREADS")
+    .replace(/^▾\s*/, "")
+    .replace("{count}", String(count));
+
+  const ariaLabel = `Show ${count} other threads with ${clientName}`;
+
+  const headerLabel = t("picker.header", "// THREADS WITH {client} · {count}")
+    .replace("{client}", clientName)
+    .replace("{count}", String(count));
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          className={cn(
+            "inline-flex h-[26px] items-center gap-1 rounded-chip border px-1.5 py-0.5",
+            "font-mono uppercase tracking-[0.10em] text-[11px] text-text-2",
+            "border-[rgba(255,255,255,0.10)]",
+            "transition-colors",
+            "hover:border-[rgba(255,255,255,0.20)] hover:text-text",
+            "focus-visible:outline-none focus-visible:ring-[1.5px] focus-visible:ring-ops-accent focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+            className,
+          )}
+        >
+          {open ? (
+            <ChevronUp aria-hidden className="h-3.5 w-3.5" strokeWidth={1.5} />
+          ) : (
+            <ChevronDown aria-hidden className="h-3.5 w-3.5" strokeWidth={1.5} />
+          )}
+          <span>{triggerLabel}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        className="w-[340px] p-2"
+      >
+        {/* Header */}
+        <div className="border-b border-line/50 px-2 py-2">
+          <SlashLabel label={headerLabel} tone="text-mute" size="sm" />
+        </div>
+
+        {/* Thread rows */}
+        <div className="pt-1">
+          {threads.length === 0 ? (
+            <div className="px-2 py-2 font-mono text-[11px] text-text-mute">
+              [—] no other threads
+            </div>
+          ) : (
+            threads.map((thread) => {
+              const isCurrent = thread.id === currentThreadId;
+              const subjectClass = thread.unread ? "text-text" : "text-text-2";
+
+              if (isCurrent) {
+                return (
+                  <div
+                    key={thread.id}
+                    data-thread-row
+                    aria-disabled="true"
+                    className={cn(
+                      "flex items-center justify-between gap-2 rounded-chip px-2 py-2",
+                      "bg-ops-accent/[0.08]",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "min-w-0 flex-1 truncate font-mohave text-[13px]",
+                        subjectClass,
+                      )}
+                    >
+                      {thread.subject}
+                    </span>
+                    <StateTag
+                      tone={thread.state.tone}
+                      variant="bare"
+                      prefix={thread.state.prefix}
+                      value={thread.state.value}
+                    />
+                  </div>
+                );
+              }
+
+              return (
+                <button
+                  key={thread.id}
+                  type="button"
+                  data-thread-row
+                  onClick={() => handleRowClick(thread.id)}
+                  aria-label={thread.subject}
+                  className={cn(
+                    "flex w-full items-center justify-between gap-2 rounded-chip px-2 py-2 text-left",
+                    "transition-colors",
+                    "hover:bg-[rgba(255,255,255,0.04)]",
+                    "focus-visible:outline-none focus-visible:bg-[rgba(255,255,255,0.04)]",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate font-mohave text-[13px]",
+                      subjectClass,
+                    )}
+                  >
+                    {thread.subject}
+                  </span>
+                  <StateTag
+                    tone={thread.state.tone}
+                    variant="bare"
+                    prefix={thread.state.prefix}
+                    value={thread.state.value}
+                  />
+                </button>
+              );
+            })
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/ops/inbox/thread-picker.tsx
+++ b/src/components/ops/inbox/thread-picker.tsx
@@ -15,7 +15,7 @@
  * ThreadPickerThread[] via useClientThreads + computeStateTag.
  */
 
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -55,13 +55,10 @@ export function ThreadPicker({
 
   const count = threads.length;
 
-  const handleRowClick = useCallback(
-    (threadId: string) => {
-      router.push(`/inbox/${threadId}`);
-      setOpen(false);
-    },
-    [router],
-  );
+  function handleRowClick(threadId: string) {
+    router.push(`/inbox/${threadId}`);
+    setOpen(false);
+  }
 
   // Disabled mute label — no other threads
   if (count === 0) {
@@ -77,11 +74,12 @@ export function ThreadPicker({
     );
   }
 
-  // Strip the leading "▾ " from the dictionary value because we render the
-  // chevron icon ourselves via Lucide. Then interpolate the count.
-  const triggerLabel = t("picker.trigger", "▾ {count} OTHER THREADS")
-    .replace(/^▾\s*/, "")
-    .replace("{count}", String(count));
+  // The chevron is rendered separately via Lucide so it can flip on expand;
+  // the dictionary string carries only the count + label.
+  const triggerLabel = t("picker.trigger", "{count} OTHER THREADS").replace(
+    "{count}",
+    String(count),
+  );
 
   const ariaLabel = `Show ${count} other threads with ${clientName}`;
 
@@ -123,58 +121,22 @@ export function ThreadPicker({
           <SlashLabel label={headerLabel} tone="text-mute" size="sm" />
         </div>
 
-        {/* Thread rows */}
+        {/* Thread rows — empty case is handled by the early return above
+            (renders the disabled mute label instead of opening a popover). */}
         <div className="pt-1">
-          {threads.length === 0 ? (
-            <div className="px-2 py-2 font-mono text-[11px] text-text-mute">
-              [—] no other threads
-            </div>
-          ) : (
-            threads.map((thread) => {
-              const isCurrent = thread.id === currentThreadId;
-              const subjectClass = thread.unread ? "text-text" : "text-text-2";
+          {threads.map((thread) => {
+            const isCurrent = thread.id === currentThreadId;
+            const subjectClass = thread.unread ? "text-text" : "text-text-2";
 
-              if (isCurrent) {
-                return (
-                  <div
-                    key={thread.id}
-                    data-thread-row
-                    aria-disabled="true"
-                    className={cn(
-                      "flex items-center justify-between gap-2 rounded-chip px-2 py-2",
-                      "bg-ops-accent/[0.08]",
-                    )}
-                  >
-                    <span
-                      className={cn(
-                        "min-w-0 flex-1 truncate font-mohave text-[13px]",
-                        subjectClass,
-                      )}
-                    >
-                      {thread.subject}
-                    </span>
-                    <StateTag
-                      tone={thread.state.tone}
-                      variant="bare"
-                      prefix={thread.state.prefix}
-                      value={thread.state.value}
-                    />
-                  </div>
-                );
-              }
-
+            if (isCurrent) {
               return (
-                <button
+                <div
                   key={thread.id}
-                  type="button"
                   data-thread-row
-                  onClick={() => handleRowClick(thread.id)}
-                  aria-label={thread.subject}
+                  aria-disabled="true"
                   className={cn(
-                    "flex w-full items-center justify-between gap-2 rounded-chip px-2 py-2 text-left",
-                    "transition-colors",
-                    "hover:bg-[rgba(255,255,255,0.04)]",
-                    "focus-visible:outline-none focus-visible:bg-[rgba(255,255,255,0.04)]",
+                    "flex items-center justify-between gap-2 rounded-chip px-2 py-2",
+                    "bg-ops-accent/[0.08]",
                   )}
                 >
                   <span
@@ -191,10 +153,41 @@ export function ThreadPicker({
                     prefix={thread.state.prefix}
                     value={thread.state.value}
                   />
-                </button>
+                </div>
               );
-            })
-          )}
+            }
+
+            return (
+              <button
+                key={thread.id}
+                type="button"
+                data-thread-row
+                onClick={() => handleRowClick(thread.id)}
+                aria-label={thread.subject}
+                className={cn(
+                  "flex w-full items-center justify-between gap-2 rounded-chip px-2 py-2 text-left",
+                  "transition-colors",
+                  "hover:bg-[rgba(255,255,255,0.04)]",
+                  "focus-visible:outline-none focus-visible:bg-[rgba(255,255,255,0.04)]",
+                )}
+              >
+                <span
+                  className={cn(
+                    "min-w-0 flex-1 truncate font-mohave text-[13px]",
+                    subjectClass,
+                  )}
+                >
+                  {thread.subject}
+                </span>
+                <StateTag
+                  tone={thread.state.tone}
+                  variant="bare"
+                  prefix={thread.state.prefix}
+                  value={thread.state.value}
+                />
+              </button>
+            );
+          })}
         </div>
       </PopoverContent>
     </Popover>

--- a/src/i18n/dictionaries/en/inbox.json
+++ b/src/i18n/dictionaries/en/inbox.json
@@ -385,7 +385,7 @@
   "detail.selectThreadBody": "[—] no thread loaded",
   "detail.metaCount": "{count} MSG",
 
-  "picker.trigger": "▾ {count} OTHER THREADS",
+  "picker.trigger": "{count} OTHER THREADS",
   "picker.triggerNone": "· 0 OTHER THREADS",
   "picker.header": "// THREADS WITH {client} · {count}",
 

--- a/src/i18n/dictionaries/es/inbox.json
+++ b/src/i18n/dictionaries/es/inbox.json
@@ -354,7 +354,7 @@
   "detail.selectThreadBody": "[—] sin hilo cargado",
   "detail.metaCount": "{count} MSG",
 
-  "picker.trigger": "▾ {count} OTROS HILOS",
+  "picker.trigger": "{count} OTROS HILOS",
   "picker.triggerNone": "· 0 OTROS HILOS",
   "picker.header": "// HILOS CON {client} · {count}",
 

--- a/src/lib/hooks/__tests__/use-client-threads.test.ts
+++ b/src/lib/hooks/__tests__/use-client-threads.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { type ReactNode } from "react";
+
+// vi.mock is hoisted; use vi.hoisted() to ensure listSiblings is initialised
+// before the mock factory runs.
+const { listSiblings } = vi.hoisted(() => ({ listSiblings: vi.fn() }));
+
+vi.mock("@/lib/api/services/email-thread-service", () => ({
+  EmailThreadService: { listSiblings },
+}));
+
+// Mock the auth store. The hook calls useAuthStore with selectCompanyId, so
+// the mock returns the value the selector would compute against an in-memory
+// auth-state shape. selectCompanyId is exported as a named selector helper —
+// preserve the export so the hook's import resolves.
+vi.mock("@/lib/store/auth-store", () => ({
+  useAuthStore: <T,>(selector: (state: { company: { id: string } | null }) => T) =>
+    selector({ company: { id: "co-1" } }),
+  selectCompanyId: (state: { company: { id: string } | null }) =>
+    state.company?.id ?? null,
+}));
+
+import { useClientThreads } from "../use-client-threads";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+beforeEach(() => {
+  listSiblings.mockReset();
+});
+
+describe("useClientThreads", () => {
+  it("does not fire listSiblings when clientId is null", async () => {
+    listSiblings.mockResolvedValue([]);
+    const { result } = renderHook(
+      () => useClientThreads(null, { excludeId: "t-current" }),
+      { wrapper },
+    );
+    // The query should be parked — TanStack reports `idle` fetchStatus
+    // until `enabled` flips true.
+    expect(result.current.fetchStatus).toBe("idle");
+    // Allow any microtask-deferred fetch to settle.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(listSiblings).not.toHaveBeenCalled();
+  });
+
+  it("does not fire listSiblings when excludeId is null", async () => {
+    listSiblings.mockResolvedValue([]);
+    const { result } = renderHook(
+      () => useClientThreads("c-1", { excludeId: null }),
+      { wrapper },
+    );
+    expect(result.current.fetchStatus).toBe("idle");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(listSiblings).not.toHaveBeenCalled();
+  });
+
+  it("calls listSiblings with (companyId, clientId, excludeId, 50) and returns its result", async () => {
+    // Build minimal EmailThread shapes — only the fields the test asserts on
+    // need real values; the rest are coerced via `unknown as` to avoid
+    // dragging the full type surface into the test.
+    const mockThreads = [
+      { id: "t-2", subject: "Roof quote" } as unknown as Awaited<
+        ReturnType<typeof listSiblings>
+      >[number],
+      { id: "t-3", subject: "Site visit" } as unknown as Awaited<
+        ReturnType<typeof listSiblings>
+      >[number],
+    ];
+    listSiblings.mockResolvedValue(mockThreads);
+
+    const { result } = renderHook(
+      () => useClientThreads("c-1", { excludeId: "t-current" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockThreads);
+    expect(listSiblings).toHaveBeenCalledTimes(1);
+    expect(listSiblings).toHaveBeenCalledWith("co-1", "c-1", "t-current", 50);
+  });
+});

--- a/src/lib/hooks/use-client-threads.ts
+++ b/src/lib/hooks/use-client-threads.ts
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * useClientThreads — feeds <ThreadPicker> with the OTHER non-archived
+ * email_threads tied to the same client as the thread currently open.
+ *
+ * Server-side guarantees from EmailThreadService.listSiblings (the underlying
+ * service method we wrap):
+ *   - filtered by company_id + client_id
+ *   - excludes the current thread (excludingThreadId)
+ *   - excludes archived (snoozed are kept on purpose — snooze is deferral,
+ *     not closure, and the picker should still surface them as live context)
+ *   - ordered by last_message_at DESC
+ * No client-side filter / sort needed.
+ *
+ * The default service limit is 5 (sized for the right-rail context strip);
+ * the detail-header picker should show all sibling threads, so we override
+ * with a generous safety cap.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { EmailThreadService } from "@/lib/api/services/email-thread-service";
+import { useAuthStore, selectCompanyId } from "@/lib/store/auth-store";
+import type { EmailThread } from "@/lib/types/email-thread";
+
+interface UseClientThreadsOpts {
+  /** The currently-open thread id; passed through to listSiblings as the
+   *  excludingThreadId. The query is disabled when this is null — without
+   *  a thread to exclude there's nothing for the picker to show. */
+  excludeId: string | null;
+}
+
+const PICKER_THREAD_LIMIT = 50;
+
+/**
+ * Fetch all OTHER non-archived email threads belonging to the same client,
+ * sorted last_message_at DESC. The query is disabled until clientId,
+ * companyId, and excludeId are all present. 30s staleTime matches the rest
+ * of the inbox hooks.
+ */
+export function useClientThreads(
+  clientId: string | null | undefined,
+  opts: UseClientThreadsOpts,
+) {
+  const companyId = useAuthStore(selectCompanyId);
+  const excludeId = opts.excludeId;
+  return useQuery<EmailThread[]>({
+    queryKey: [
+      "inbox",
+      "client-threads",
+      companyId ?? "",
+      clientId ?? "",
+      excludeId ?? "",
+    ] as const,
+    queryFn: async () => {
+      // Defensive — TanStack Query won't run queryFn while `enabled` is false,
+      // but typed-narrowing for the service call below requires the explicit
+      // null-check anyway.
+      if (!clientId || !companyId || !excludeId) return [];
+      return EmailThreadService.listSiblings(
+        companyId,
+        clientId,
+        excludeId,
+        PICKER_THREAD_LIMIT,
+      );
+    },
+    enabled: !!clientId && !!companyId && !!excludeId,
+    staleTime: 30_000,
+  });
+}


### PR DESCRIPTION
## Summary

Phase E of the inbox brand-rework — adds the inline thread-picker to the detail-header meta strip. When a thread is loaded, a chevron-prefixed `▾ N OTHER THREADS` button appears in the meta strip; clicking opens a glass-dense popover listing all OTHER non-archived threads with the same client, sorted by `last_message_at desc`. Click a row → `router.push(/inbox/{id})` and popover closes.

- **E1** — `<ThreadPicker>` component (`src/components/ops/inbox/thread-picker.tsx`) + 5 vitest cases. Trigger uses JetBrains Mono uppercase 11 with hairline border + Lucide `ChevronDown`/`ChevronUp` (flips on expand). Disabled mute label when 0 sibling threads. Popover uses centralized `<PopoverContent>` (Radix + `glass-dense` + 12px modal radius). Header uses `<SlashLabel>` with `// THREADS WITH {client} · {count}`. Each row: subject (Mohave 13, text-1 if unread / text-2 if read) + bare `<StateTag>` right-aligned. Defensive guard renders the current-thread row with `bg-ops-accent/[0.08]` tint and no click handler.
- **E2** — `useClientThreads` hook (`src/lib/hooks/use-client-threads.ts`) — TanStack Query wrapper around the existing `EmailThreadService.listSiblings(companyId, clientId, excludingThreadId, 50)`. 30s `staleTime` to match other inbox hooks. Wired into `inbox-route.tsx`: maps each `EmailThread` → `ThreadPickerThread` via `computeStateTag`, renders `<ThreadPicker>` and passes it as `threadPickerSlot` to `<ThreadDetail>`. Picker only mounts when both `threadId` AND `clientId` are present.

Header / detail wiring: `<ThreadDetailHeader>` and `<ThreadDetail>` both gain a `threadPickerSlot?: ReactNode` prop. The header renders the slot in the meta strip after the message count, separated by a `text-mute "·"`, only when present — existing callers without the slot are unaffected.

i18n keys (`picker.trigger`, `picker.triggerNone`, `picker.header`) tweaked to drop the leading `▾` glyph since the chevron is now a real Lucide icon that flips on expand.

No new service methods, no new dependencies, no schema changes — `email_threads.client_id` / `last_message_at` / `subject` / `unread_count` columns all confirmed via direct Supabase query (project `ijeekuhbatykdomumfjx`).

## Test plan

- [x] `npx vitest run src/components/ops/inbox/__tests__/thread-picker.test.tsx` — 5/5 passing (trigger renders count, disabled mute when 0, popover opens on click, current-thread highlight, click→push+close)
- [x] `npx vitest run src/lib/hooks/__tests__/use-client-threads.test.ts` — 3/3 passing (disabled-on-null-clientId, disabled-on-null-excludeId, success path with correct args + return)
- [x] `npx vitest run src/components/ops/inbox/__tests__/thread-detail.test.tsx` — 6/6 passing (no regression on the existing detail wrapper)
- [x] `npx tsc --noEmit` — clean
- [ ] Browser smoke — open a thread that has 2+ other threads with the same client; verify the picker trigger appears in the meta strip, opens the popover, lists the sibling threads with their state tags, and that clicking a row navigates to `/inbox/{id}`. (Deferred to reviewer — local stack not running in this session.)

## Branch hygiene note

This PR branch (`feat/inbox-rework-phase-e-pr`) was cherry-picked from a working branch (`feat/inbox-rework-phase-e`) where parallel agents from other phases interleaved unrelated commits during the session. The PR contains exactly the 4 Phase E commits and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)