### PR TITLE
chore(ci): disable Vercel previews on inbox sub-phase branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,18 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "regions": ["iad1"],
+  "git": {
+    "deploymentEnabled": {
+      "feat/inbox-rework-phase-a": false,
+      "feat/inbox-rework-phase-b": false,
+      "feat/inbox-rework-phase-c": false,
+      "feat/inbox-rework-phase-d": false,
+      "feat/inbox-rework-phase-e": false,
+      "feat/inbox-rework-phase-e-pr": false,
+      "feat/inbox-rework-phase-f": false,
+      "feat/inbox-rework-phase-g": false
+    }
+  },
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary

- Cuts ~80%+ of Vercel build minutes during the multi-phase inbox rework.
- Disables preview deployments on the 8 sub-phase branches that are internal-only and consumed by their phase PR.
- \`main\` and \`feat/inbox-redesign\` continue to deploy. PRs against either still get a preview.

## Why

Each parallel Claude agent push (8+ agents during this rework) triggers a Vercel build by default. With a 3–5 min Next.js build, that's ~12,000 build minutes/month — well past the included tier on Pro.

## Trade-off

PRs from sub-phase branches no longer have their own preview URL. Reviewers see the diff + the integration branch's preview after merge. For our agent-produced TDD-tested code with green CI elsewhere, this is fine.

## Follow-up

Set Vercel project's Ignored Build Step (UI-only, can't be set via vercel.json) to a branch-allowlist bash script for a durable policy that doesn't need to enumerate sub-phase names per future rework:

\`\`\`bash
if [[ \"\$VERCEL_GIT_COMMIT_REF\" == \"main\" ]] || [[ \"\$VERCEL_GIT_COMMIT_REF\" == \"feat/inbox-redesign\" ]]; then
  exit 1  # build
fi
exit 0  # skip
\`\`\`

## Test plan

- [ ] Merge to main
- [ ] Push a commit to one of the disabled sub-phase branches; confirm no Vercel build fires
- [ ] Push to \`feat/inbox-redesign\` or open a PR against it; confirm preview still builds
- [ ] Push to main (via this PR's merge); confirm production build fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)