### PR TITLE
Nightly Bug Sweep — web — 2026-05-11 — Batch 01

### DIFF
--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -42,6 +42,7 @@ import { queryKeys } from "@/lib/api/query-client";
 import { getSupabaseClient } from "@/lib/supabase/client";
 import { UserRole, type TeamMember } from "@/lib/types/models";
 
+import { QueryErrorState } from "@/components/ops/query-error-state";
 import { CalendarHeader } from "./_components/calendar-header";
 import { CalendarToolbar } from "./_components/calendar-toolbar";
 import { CrewScrollContainer } from "./_components/crew/crew-scroll-container";
@@ -209,10 +210,13 @@ export default function CalendarPage() {
 
   const { data: calendarMetrics = [], isLoading: calendarMetricsLoading } = useCalendarMetrics();
 
-  const { data: scheduledTasks, isLoading } = useScheduledTasks(
-    rangeStart,
-    rangeEnd
-  );
+  const {
+    data: scheduledTasks,
+    isLoading,
+    isError: scheduledTasksError,
+    isFetching: scheduledTasksFetching,
+    refetch: refetchScheduledTasks,
+  } = useScheduledTasks(rangeStart, rangeEnd);
 
   // Personal events + time-off requests in the visible range. Mirrors the iOS
   // CalendarViewModel, which renders ProjectTask + CalendarUserEvent together.
@@ -363,7 +367,7 @@ export default function CalendarPage() {
                 month/week/day reuses the previous range's data via
                 placeholderData on useScheduledTasks — so the calendar stays
                 mounted and the user never sees a flash. */}
-            {isLoading && events.length === 0 && (
+            {isLoading && events.length === 0 && !scheduledTasksError && (
               <div className="flex flex-col items-center justify-center flex-1 min-h-[200px] gap-3">
                 <Loader2 className="w-[32px] h-[32px] text-text-2 animate-spin" />
                 <p className="font-mohave text-body-sm text-text-3">
@@ -371,7 +375,18 @@ export default function CalendarPage() {
                 </p>
               </div>
             )}
-            {(!isLoading || events.length > 0) && (
+            {scheduledTasksError && events.length === 0 && (
+              <div className="flex flex-col items-center justify-center flex-1 min-h-[200px] gap-3 p-4">
+                <QueryErrorState
+                  title="Could not load schedule."
+                  description="The schedule query failed. Check your connection — the calendar will reload as soon as it can talk to the server again."
+                  errorCode="CALENDAR_SCHEDULED_TASKS"
+                  onRetry={() => refetchScheduledTasks()}
+                  isRetrying={scheduledTasksFetching}
+                />
+              </div>
+            )}
+            {(!isLoading || events.length > 0) && !scheduledTasksError && (
               <AnimatePresence mode="wait" initial={false}>
                 <motion.div
                   key={view}

--- a/src/app/(dashboard)/invoices/page.tsx
+++ b/src/app/(dashboard)/invoices/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { usePageTitle } from "@/lib/hooks/use-page-title";
 import { useDictionary, useLocale } from "@/i18n/client";
@@ -206,8 +206,17 @@ export default function InvoicesPage() {
     return map;
   }, [projects]);
 
+  // Project filter pulled from the URL — set when the projects canvas
+  // hands off to the invoices page for a "Record payment" workflow
+  // (bug 272b3751). Kept reactive on every query-string change so the
+  // user can clear it via the back button without an extra re-route.
+  const projectIdFilter = searchParams.get("projectId");
+
   const filtered = useMemo(() => {
     let list = [...invoices];
+    if (projectIdFilter) {
+      list = list.filter((i) => i.projectId === projectIdFilter);
+    }
     if (filterStatus !== "all") {
       list = list.filter((i) => i.status === filterStatus);
     }
@@ -220,7 +229,34 @@ export default function InvoicesPage() {
       );
     }
     return list;
-  }, [invoices, filterStatus, searchQuery, clientMap]);
+  }, [invoices, projectIdFilter, filterStatus, searchQuery, clientMap]);
+
+  // Auto-open the record-payment modal when the project canvas routes
+  // here with action=recordPayment AND there's exactly one outstanding
+  // invoice for the project — the common case. If there's more than
+  // one, we leave the user on the filtered list to choose.
+  const autoPaymentRanRef = useRef(false);
+  useEffect(() => {
+    if (autoPaymentRanRef.current) return;
+    if (searchParams.get("action") !== "recordPayment") return;
+    if (!projectIdFilter) return;
+    if (!can("invoices.record_payment")) return;
+    const outstanding = invoices.filter(
+      (i) =>
+        i.projectId === projectIdFilter &&
+        i.status !== InvoiceStatus.Paid &&
+        i.status !== InvoiceStatus.Void &&
+        i.status !== InvoiceStatus.Draft,
+    );
+    if (outstanding.length === 1) {
+      setPaymentInvoice(outstanding[0]);
+      autoPaymentRanRef.current = true;
+    } else if (outstanding.length === 0 && invoices.length > 0) {
+      // No outstanding invoices to apply payment to — tell the user.
+      toast.info(t("invoices.payment.noOutstanding"));
+      autoPaymentRanRef.current = true;
+    }
+  }, [searchParams, projectIdFilter, invoices, can, t]);
 
   const metrics = useMemo(() => {
     // Drafts are not yet sent and therefore not "outstanding" — exclude them

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -31,7 +31,7 @@ const ROUTE_PERMISSIONS: Record<string, string> = {
   "/inbox": "pipeline.view",
   "/intel": "pipeline.view",
   "/calibration": "email.configure_ai",
-  "/agent": "pipeline.view",
+  "/agent": "agent.queue.view",
   // testing-grounds uses a per-user special permission check on the page itself
 };
 

--- a/src/app/(dashboard)/map/page.tsx
+++ b/src/app/(dashboard)/map/page.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils/cn";
 import { useScopedProjects } from "@/lib/hooks/use-projects";
 import { useMapMetrics } from "@/lib/hooks";
 import { MetricsHeader } from "@/components/metrics";
+import { QueryErrorState } from "@/components/ops/query-error-state";
 import {
   ProjectStatus,
   PROJECT_STATUS_COLORS,
@@ -134,7 +135,13 @@ export default function MapPage() {
   const [showSidebar, setShowSidebar] = useState(true);
 
   const { data: mapMetrics = [], isLoading: mapMetricsLoading } = useMapMetrics();
-  const { data, isLoading } = useScopedProjects();
+  const {
+    data,
+    isLoading,
+    isError: projectsError,
+    isFetching: projectsFetching,
+    refetch: refetchProjects,
+  } = useScopedProjects();
   const projects = useMemo(() => data?.projects ?? [], [data]);
 
   const STATUS_FILTERS: { value: "all" | "active" | ProjectStatus; label: string }[] = useMemo(() => [
@@ -273,7 +280,17 @@ export default function MapPage() {
 
         {/* Project list */}
         <div className="flex-1 overflow-y-auto p-1 space-y-[4px]">
-          {isLoading ? (
+          {projectsError && !data ? (
+            <div className="py-3 px-1">
+              <QueryErrorState
+                title="Could not load projects."
+                description="The map could not reach the project list. Pins may be missing or stale until you retry."
+                errorCode="MAP_PROJECTS"
+                onRetry={() => refetchProjects()}
+                isRetrying={projectsFetching}
+              />
+            </div>
+          ) : isLoading ? (
             <div className="flex flex-col items-center justify-center py-6">
               <Loader2 className="w-[20px] h-[20px] text-text-2 animate-spin" />
               <span className="font-mono text-micro text-text-mute mt-1">

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef, memo } from "react";
 import { Loader2 } from "lucide-react";
 import { useDictionary } from "@/i18n/client";
+import { QueryErrorState } from "@/components/ops/query-error-state";
 import { usePageTitle } from "@/lib/hooks/use-page-title";
 import { trackScreenView } from "@/lib/analytics/analytics";
 import { toast } from "@/components/ui/toast";
@@ -185,7 +186,13 @@ export default function ProjectsPage() {
   const canDelete = can("projects.delete");
 
   // ── Data fetching ──
-  const { data: projectsData, isLoading } = useScopedProjects();
+  const {
+    data: projectsData,
+    isLoading,
+    isError: projectsError,
+    isFetching: projectsFetching,
+    refetch: refetchProjects,
+  } = useScopedProjects();
   const { data: clientsData } = useClients();
   const { data: teamData } = useTeamMembers();
   const { data: invoicesData } = useInvoices();
@@ -682,6 +689,25 @@ export default function ProjectsPage() {
   const batchCount = activeCardId && useProjectCanvasStore.getState().selectedCardIds.has(activeCardId)
     ? selectedCount
     : 1;
+
+  // ── Error ──
+  // Surface a retry path on full failure so the canvas isn't stuck on
+  // the spinner state (bug 03241853). We only swap in the error pane
+  // when there's no cached data — if we already have a previous result
+  // the canvas renders that and the background refetch continues silently.
+  if (projectsError && !projectsData) {
+    return (
+      <div className="flex flex-col h-full items-center justify-center gap-3 p-4">
+        <QueryErrorState
+          title="Could not load projects."
+          description="The project canvas couldn't reach the server. Try again — your unsaved layout edits are preserved locally."
+          errorCode="PROJECTS_CANVAS"
+          onRetry={() => refetchProjects()}
+          isRetrying={projectsFetching}
+        />
+      </div>
+    );
+  }
 
   // ── Loading ──
   if (isLoading) {

--- a/src/app/(dashboard)/projects/page.tsx
+++ b/src/app/(dashboard)/projects/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, memo } from "react";
 import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useDictionary } from "@/i18n/client";
 import { QueryErrorState } from "@/components/ops/query-error-state";
 import { usePageTitle } from "@/lib/hooks/use-page-title";
@@ -175,6 +176,7 @@ export default function ProjectsPage() {
   usePageTitle("Projects");
   const { t } = useDictionary("projects-canvas");
   const { can } = usePermissionStore();
+  const router = useRouter();
   const { isComplete: setupComplete, needsWebSetup, missingSteps } = useSetupGate();
   const [showSetupModal, setShowSetupModal] = useState(false);
 
@@ -182,7 +184,10 @@ export default function ProjectsPage() {
   const canManage = can("projects.edit");
   const canViewAccounting = can("accounting.view");
   const canCreateTasks = can("tasks.create");
-  const canRecordPayment = can("accounting.edit");
+  // Record-payment lives on the invoices surface — gate the project
+  // canvas action on the same permission the destination page enforces
+  // so we never advertise an action a user can't complete (bug 272b3751).
+  const canRecordPayment = can("invoices.record_payment");
   const canDelete = can("projects.delete");
 
   // ── Data fetching ──
@@ -563,10 +568,20 @@ export default function ProjectsPage() {
     [openWindow, projectMap]
   );
 
-  const handleRecordPayment = useCallback((_projectId: string) => {
-    // TODO: Open payment recording form
-    toast.info("Payment recording coming soon");
-  }, []);
+  // Hand off to the invoices page filtered to this project with the
+  // record-payment intent. The invoices page auto-opens the payment
+  // modal when there's exactly one outstanding invoice and toasts a
+  // clear message when there are none — that's a real workflow rather
+  // than the previous "Payment recording coming soon" dead end
+  // (bug 272b3751).
+  const handleRecordPayment = useCallback(
+    (projectId: string) => {
+      router.push(
+        `/invoices?projectId=${encodeURIComponent(projectId)}&action=recordPayment`,
+      );
+    },
+    [router],
+  );
 
   const handleArchive = useCallback(
     (projectId: string) => {

--- a/src/app/(dashboard)/team/page.tsx
+++ b/src/app/(dashboard)/team/page.tsx
@@ -25,6 +25,7 @@ import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ConfirmDialog } from "@/components/ops/confirm-dialog";
+import { QueryErrorState } from "@/components/ops/query-error-state";
 import { InviteModal } from "@/components/ops/invite-modal";
 import {
   useTeamMembers,
@@ -486,7 +487,13 @@ export default function TeamPage() {
   useEffect(() => { trackScreenView("team"); }, []);
 
   // ─── Data hooks ──────────────────────────────────────────────────────────
-  const { data: teamData, isLoading } = useTeamMembers();
+  const {
+    data: teamData,
+    isLoading,
+    isError: teamError,
+    isFetching: teamFetching,
+    refetch: refetchTeam,
+  } = useTeamMembers();
   const updateRoleMutation = useUpdateUserRole();
   const removeEmployeeMutation = useRemoveSeatedEmployee();
 
@@ -610,7 +617,17 @@ export default function TeamPage() {
       </div>
 
       {/* Content */}
-      {isLoading ? (
+      {teamError && !teamData ? (
+        <div className="py-4">
+          <QueryErrorState
+            title="Could not load the team roster."
+            description="The directory query failed. Roles and seat counts may be stale until you retry."
+            errorCode="TEAM_DIRECTORY"
+            onRetry={() => refetchTeam()}
+            isRetrying={teamFetching}
+          />
+        </div>
+      ) : isLoading ? (
         <LoadingSkeleton />
       ) : filteredTeam.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-8">

--- a/src/components/layouts/quick-actions-drawer.tsx
+++ b/src/components/layouts/quick-actions-drawer.tsx
@@ -14,6 +14,7 @@ import { useSetupGate } from "@/hooks/useSetupGate";
 import { SetupInterceptionModal } from "@/components/setup/SetupInterceptionModal";
 import {
   isWindowAction,
+  resolveActionLabel,
   type FABAction,
 } from "@/lib/constants/fab-actions";
 import {
@@ -133,7 +134,7 @@ export function QuickActionsDrawer() {
         } else {
           openWindow({
             id: action.target,
-            title: action.label,
+            title: resolveActionLabel(action, t),
             type: action.target,
           });
         }
@@ -354,7 +355,7 @@ export function QuickActionsDrawer() {
                           whiteSpace: "nowrap",
                         }}
                       >
-                        {action.label}
+                        {resolveActionLabel(action, t)}
                       </span>
                       <span
                         aria-hidden

--- a/src/components/layouts/sidebar.tsx
+++ b/src/components/layouts/sidebar.tsx
@@ -82,7 +82,7 @@ function buildNavItems(t: (key: string) => string): NavEntry[] {
     { label: t("nav.inventory"), href: "/inventory", icon: Boxes, permission: "inventory.view" },
     { label: t("nav.accounting"), href: "/accounting", icon: Calculator, permission: "accounting.view" },
     "divider",
-    { label: t("nav.agentQueue"), href: "/agent/queue", icon: BrainCircuit, permission: "admin" },
+    { label: t("nav.agentQueue"), href: "/agent/queue", icon: BrainCircuit, permission: "agent.queue.view" },
     "divider",
     { label: t("nav.settings"), href: "/settings", icon: Settings },
   ];

--- a/src/components/ops/query-error-state.tsx
+++ b/src/components/ops/query-error-state.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import * as React from "react";
+import { AlertTriangle, RotateCw } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+import { Button } from "@/components/ui/button";
+
+/**
+ * QueryErrorState — fallback UI for TanStack Query errors on core
+ * operations pages (calendar, map, team, projects). Renders the failure
+ * in OPS tactical voice (`// FAILED ::` prefix, brick-bordered panel) and
+ * exposes a retry path so users on flaky connections can recover without
+ * a full page reload (bug 03241853).
+ *
+ * Keep this lean and dictionary-free — every consumer passes copy in
+ * already-translated strings; this component just provides the layout
+ * and retry affordance.
+ */
+
+export interface QueryErrorStateProps {
+  /** One-line headline, e.g. "Could not load schedule." */
+  title: string;
+  /**
+   * Optional supporting paragraph. Recommended copy: explain what part
+   * of the page failed and that the data may be stale.
+   */
+  description?: string;
+  /** Bracketed [TECHNICAL CODE] shown small below the headline. */
+  errorCode?: string;
+  /** Click handler for the retry button. */
+  onRetry?: () => void;
+  /** Disable the retry button while a refetch is in flight. */
+  isRetrying?: boolean;
+  /** Override the retry label. Defaults to "Retry". */
+  retryLabel?: string;
+  className?: string;
+}
+
+const QueryErrorState = React.forwardRef<HTMLDivElement, QueryErrorStateProps>(
+  (
+    {
+      title,
+      description,
+      errorCode,
+      onRetry,
+      isRetrying = false,
+      retryLabel = "Retry",
+      className,
+    },
+    ref,
+  ) => (
+    <div
+      ref={ref}
+      role="alert"
+      aria-live="polite"
+      className={cn(
+        "flex items-start gap-3 px-4 py-4 max-w-[480px]",
+        "border-l-2 border-l-[#93321A]",
+        "bg-[rgba(147,50,26,0.05)] rounded-r-sm",
+        className,
+      )}
+    >
+      <AlertTriangle
+        className="w-[18px] h-[18px] text-[#B58289] shrink-0 mt-[2px]"
+        aria-hidden="true"
+      />
+      <div className="flex flex-col items-start gap-1 min-w-0">
+        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-[#B58289]">
+          {"// FAILED ::"}
+        </span>
+        <h3 className="font-mohave text-body-lg text-text">{title}</h3>
+        {description && (
+          <p className="font-mohave text-body-sm text-text-3 max-w-[400px]">
+            {description}
+          </p>
+        )}
+        {errorCode && (
+          <span className="font-mono text-[10px] text-text-mute mt-0.5">
+            [{errorCode}]
+          </span>
+        )}
+        {onRetry && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onRetry}
+            disabled={isRetrying}
+            className="mt-2 gap-1.5"
+          >
+            <RotateCw
+              className={cn(
+                "w-[14px] h-[14px]",
+                isRetrying && "animate-spin",
+              )}
+            />
+            {isRetrying ? "Retrying…" : retryLabel}
+          </Button>
+        )}
+      </div>
+    </div>
+  ),
+);
+QueryErrorState.displayName = "QueryErrorState";
+
+export { QueryErrorState };

--- a/src/components/ops/task-form.tsx
+++ b/src/components/ops/task-form.tsx
@@ -230,7 +230,13 @@ function StatusDropdown({
 
         {open && (
           <div className="absolute z-[60] left-0 right-0 top-full mt-[4px] bg-[rgba(13,13,13,0.9)] backdrop-blur-xl border border-[rgba(255,255,255,0.08)] rounded-sm max-h-[200px] overflow-y-auto">
-            {Object.values(TaskStatus).map((s) => (
+            {/* In Progress is omitted: project_tasks.status has no DB slot
+                for it (collapses to active on write, reads back as Booked).
+                See task-list.tsx STATUS_OPTIONS and task-service.ts comment
+                for context (bug 452d7865). */}
+            {Object.values(TaskStatus)
+              .filter((s) => s !== TaskStatus.InProgress)
+              .map((s) => (
               <button
                 key={s}
                 type="button"

--- a/src/components/ops/task-list.tsx
+++ b/src/components/ops/task-list.tsx
@@ -97,9 +97,18 @@ function taskStatusToKey(status: TaskStatus): StatusBadgeTaskStatus {
   }
 }
 
+// Project task statuses available in the inline status menu.
+// project_tasks.status has a CHECK constraint of ('active','completed','cancelled')
+// — In Progress is intentionally NOT a persistable slot at the DB layer
+// (the migrate_task_status_to_active migration collapsed Booked+InProgress
+// into a single 'active' state, see task-service.ts:serializeTaskStatus).
+// Exposing it in the menu caused users to "set" In Progress only to have
+// the value collapse to active on write and read back as Booked on the
+// next refetch (bug 452d7865). The TS enum keeps the value for iOS
+// parity but no surface should offer it for project tasks until the
+// constraint is widened in a future migration.
 const STATUS_OPTIONS: { value: TaskStatus; label: string }[] = [
   { value: TaskStatus.Booked, label: "Booked" },
-  { value: TaskStatus.InProgress, label: "In Progress" },
   { value: TaskStatus.Completed, label: "Completed" },
   { value: TaskStatus.Cancelled, label: "Cancelled" },
 ];

--- a/src/components/ops/task-list.tsx
+++ b/src/components/ops/task-list.tsx
@@ -499,6 +499,16 @@ function TaskList({ projectId, companyId, className }: TaskListProps) {
     (values: TaskFormValues) => {
       if (!editingTask) return;
 
+      // Schedule fields come from the form as `YYYY-MM-DD` strings (or "").
+      // Convert to Date | null so the update mirrors the shape of
+      // ProjectTask.startDate/endDate. Sending undefined here would let the
+      // partial update skip these fields entirely — the bug (c0d4abe7) was
+      // dispatchers editing the schedule and the new dates never persisting.
+      const startDate = values.startDate
+        ? new Date(values.startDate)
+        : null;
+      const endDate = values.endDate ? new Date(values.endDate) : null;
+
       updateTaskMutation.mutate(
         {
           id: editingTask.id,
@@ -507,6 +517,8 @@ function TaskList({ projectId, companyId, className }: TaskListProps) {
             taskTypeId: values.taskTypeId,
             taskColor: values.taskColor || "#59779F",
             teamMemberIds: values.teamMemberIds || [],
+            startDate,
+            endDate,
           },
         },
         {

--- a/src/components/ops/task-list.tsx
+++ b/src/components/ops/task-list.tsx
@@ -208,8 +208,11 @@ function TaskRow({
         {title}
       </p>
 
-      {/* Assignee avatars */}
-      <div className="hidden sm:flex items-center shrink-0">
+      {/* Assignee avatars — visible at every breakpoint so phone users
+          can re-assign or open the team picker directly from the row.
+          Was previously `hidden sm:flex`, which hid the control on mobile
+          and made the row a dead end for field crews (bug 29fcbf09). */}
+      <div className="flex items-center shrink-0">
         {assignedMembers.length > 0 ? (
           <div className="flex items-center">
             {assignedMembers.slice(0, 3).map((member, idx) => (
@@ -244,8 +247,11 @@ function TaskRow({
         )}
       </div>
 
-      {/* Date range */}
-      <div className="hidden sm:flex items-center shrink-0">
+      {/* Date range — visible at every breakpoint so the unscheduled
+          badge / mini-calendar popover stays reachable on mobile. The
+          start/end date string itself is short (e.g. "Jul 14") and
+          collapses gracefully alongside the truncating task title. */}
+      <div className="flex items-center shrink-0">
         {hasStartDate ? (
           <span
             className={cn(
@@ -300,12 +306,17 @@ function TaskRow({
         </SelectContent>
       </Select>
 
-      {/* Overflow menu */}
+      {/* Overflow menu — always visible. Touch devices have no hover
+          state, so the previous `opacity-0 group-hover:opacity-100`
+          treatment made Edit/Delete unreachable on phones (bug 29fcbf09).
+          Trigger is always rendered; pointer-fine devices simply see the
+          full-opacity glyph at rest. */}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
-            className="p-[4px] text-text-mute hover:text-text-3 transition-colors shrink-0 opacity-0 group-hover:opacity-100"
+            className="p-[4px] text-text-3 hover:text-text transition-colors shrink-0"
             onClick={(e) => e.stopPropagation()}
+            aria-label="Task actions"
           >
             <MoreVertical className="w-[14px] h-[14px]" />
           </button>

--- a/src/components/settings/preferences-tab.tsx
+++ b/src/components/settings/preferences-tab.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useCompanySettings, useUpdateCompanySettings } from "@/lib/hooks";
 import { usePreferencesStore, type DashboardLayoutId, type SchedulingTypeId } from "@/stores/preferences-store";
 import { useAuthStore } from "@/lib/store/auth-store";
-import { ALL_ACTIONS, DEFAULT_ACTION_IDS } from "@/lib/constants/fab-actions";
+import { ALL_ACTIONS, DEFAULT_ACTION_IDS, resolveActionLabel } from "@/lib/constants/fab-actions";
 import { toast } from "sonner";
 import { useLocale, useDictionary } from "@/i18n/client";
 import type { Locale } from "@/i18n/types";
@@ -172,6 +172,7 @@ function LifecycleSettings() {
 
 function QuickActionsCard() {
   const { t } = useDictionary("settings");
+  const { t: tQa } = useDictionary("quick-actions");
   const { currentUser, updateFabActions } = useAuthStore();
   const activeIds: string[] = currentUser?.fabActions ?? DEFAULT_ACTION_IDS;
 
@@ -212,7 +213,7 @@ function QuickActionsCard() {
             >
               <Icon className="w-[16px] h-[16px] text-text-2 shrink-0" />
               <span className="font-mohave text-[14px] text-text flex-1">
-                {action.label}
+                {resolveActionLabel(action, tQa)}
               </span>
               <button
                 onClick={() => toggle(action.id)}

--- a/src/components/settings/quick-actions-tab.tsx
+++ b/src/components/settings/quick-actions-tab.tsx
@@ -3,13 +3,15 @@
 import { cn } from "@/lib/utils/cn";
 import { Card, CardContent } from "@/components/ui/card";
 import { useAuthStore } from "@/lib/store/auth-store";
-import { ALL_ACTIONS, DEFAULT_ACTION_IDS } from "@/lib/constants/fab-actions";
+import { ALL_ACTIONS, DEFAULT_ACTION_IDS, resolveActionLabel } from "@/lib/constants/fab-actions";
+import { useDictionary } from "@/i18n/client";
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function QuickActionsTab() {
   const { currentUser, updateFabActions } = useAuthStore();
   const activeIds: string[] = currentUser?.fabActions ?? DEFAULT_ACTION_IDS;
+  const { t } = useDictionary("quick-actions");
 
   function toggle(id: string) {
     const isActive = activeIds.includes(id);
@@ -38,6 +40,7 @@ export function QuickActionsTab() {
             const Icon = action.icon;
             const isActive = activeIds.includes(action.id);
             const isLast = index === ALL_ACTIONS.length - 1;
+            const label = resolveActionLabel(action, t);
 
             return (
               <div
@@ -49,7 +52,7 @@ export function QuickActionsTab() {
               >
                 <Icon className="w-[16px] h-[16px] text-text-2 shrink-0" />
                 <span className="font-mohave text-[14px] text-text flex-1">
-                  {action.label}
+                  {label}
                 </span>
                 <button
                   onClick={() => toggle(action.id)}
@@ -59,7 +62,7 @@ export function QuickActionsTab() {
                     "disabled:opacity-40 disabled:cursor-not-allowed",
                     isActive ? "bg-text-2" : "bg-fill-neutral-dim"
                   )}
-                  aria-label={isActive ? `Remove ${action.label}` : `Add ${action.label}`}
+                  aria-label={`${isActive ? t("actions.remove") : t("actions.add")} ${label}`}
                 >
                   <span
                     className={cn(

--- a/src/i18n/dictionaries/en/pipeline.json
+++ b/src/i18n/dictionaries/en/pipeline.json
@@ -211,6 +211,7 @@
   "invoices.payment.method": "Method",
   "invoices.payment.reference": "Reference #",
   "invoices.payment.notes": "Notes",
+  "invoices.payment.noOutstanding": "No outstanding invoices on this project — payment cannot be recorded.",
   "invoices.actions.downloadPdf": "Download PDF",
   "invoices.actions.send": "Send",
   "invoices.actions.recordPayment": "Record Payment",

--- a/src/i18n/dictionaries/en/quick-actions.json
+++ b/src/i18n/dictionaries/en/quick-actions.json
@@ -12,5 +12,18 @@
   "footer.customize": "CUSTOMIZE",
   "footer.customizeAriaLabel": "Customize quick actions",
 
-  "empty.noActions": "[ no actions available ]"
+  "empty.noActions": "[ no actions available ]",
+
+  "actions.expense.label": "ADD EXPENSE",
+  "actions.lead.label": "NEW LEAD",
+  "actions.estimate.label": "NEW ESTIMATE",
+  "actions.invoice.label": "NEW INVOICE",
+  "actions.client.label": "NEW CLIENT",
+  "actions.project.label": "NEW PROJECT",
+  "actions.task.label": "NEW TASK",
+  "actions.task-type.label": "NEW TASK TYPE",
+  "actions.inventory-item.label": "NEW ITEM",
+
+  "actions.add": "Add",
+  "actions.remove": "Remove"
 }

--- a/src/i18n/dictionaries/es/pipeline.json
+++ b/src/i18n/dictionaries/es/pipeline.json
@@ -191,6 +191,7 @@
   "invoices.payment.method": "Método",
   "invoices.payment.reference": "Referencia #",
   "invoices.payment.notes": "Notas",
+  "invoices.payment.noOutstanding": "No hay facturas pendientes en este proyecto — no se puede registrar el pago.",
   "invoices.actions.downloadPdf": "Descargar PDF",
   "invoices.actions.send": "Enviar",
   "invoices.actions.recordPayment": "Registrar pago",

--- a/src/i18n/dictionaries/es/quick-actions.json
+++ b/src/i18n/dictionaries/es/quick-actions.json
@@ -13,5 +13,18 @@
   "footer.customize": "CUSTOMIZE",
   "footer.customizeAriaLabel": "Customize quick actions",
 
-  "empty.noActions": "[ no actions available ]"
+  "empty.noActions": "[ no actions available ]",
+
+  "actions.expense.label": "AÑADIR GASTO",
+  "actions.lead.label": "NUEVO LEAD",
+  "actions.estimate.label": "NUEVA ESTIMACIÓN",
+  "actions.invoice.label": "NUEVA FACTURA",
+  "actions.client.label": "NUEVO CLIENTE",
+  "actions.project.label": "NUEVO PROYECTO",
+  "actions.task.label": "NUEVA TAREA",
+  "actions.task-type.label": "NUEVO TIPO DE TAREA",
+  "actions.inventory-item.label": "NUEVO ARTÍCULO",
+
+  "actions.add": "Añadir",
+  "actions.remove": "Quitar"
 }

--- a/src/lib/constants/fab-actions.ts
+++ b/src/lib/constants/fab-actions.ts
@@ -17,7 +17,20 @@ import type {
 
 export interface FABAction {
   id: string;
-  label: string;
+  /**
+   * i18n dictionary key under the `quick-actions` namespace. Resolves to the
+   * tactical-voice action label (e.g. "actions.expense.label" -> "ADD EXPENSE").
+   * All production `ALL_ACTIONS` entries set this; consumers should read via
+   * `useDictionary("quick-actions").t(action.labelKey)`. Optional only to
+   * permit pre-i18n test fixtures (which fall back to `label`).
+   */
+  labelKey?: string;
+  /**
+   * @deprecated Legacy literal label retained only so older test fixtures keep
+   * type-checking and as the dictionary fallback. Production consumers must
+   * prefer `labelKey` via the dictionary.
+   */
+  label?: string;
   /** 3-letter uppercase mono code shown right-aligned in the Quick Actions drawer (e.g. "EXP", "LED"). */
   hintCode: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -38,18 +51,32 @@ export function isWindowAction(action: FABAction): action is FABAction & { targe
   return action.handler === "window";
 }
 
+/**
+ * Resolve an action's display label. Pass a translator (`t` from
+ * `useDictionary("quick-actions")`) to render the dictionary value; if no
+ * translator is supplied, or no `labelKey` is set, the legacy `label` is used.
+ * Returns an empty string if neither is available.
+ */
+export function resolveActionLabel(
+  action: FABAction,
+  t?: (key: string) => string,
+): string {
+  if (action.labelKey && t) return t(action.labelKey);
+  return action.label ?? "";
+}
+
 export const ALL_ACTIONS: FABAction[] = [
-  { id: "expense",        label: "Add Expense",   hintCode: "EXP", icon: Receipt,       triggerAction: "expenses",   handler: "route",  target: "/accounting?tab=expenses", requiredPermission: "expenses.create" },
-  { id: "lead",           label: "New Lead",      hintCode: "LED", icon: TrendingUp,    triggerAction: "leads",      handler: "window", target: "create-lead",              requiredPermission: "pipeline.manage" },
-  { id: "estimate",       label: "New Estimate",  hintCode: "EST", icon: Calculator,    triggerAction: "estimates",  handler: "window", target: "create-estimate",          requiredPermission: "estimates.create" },
-  { id: "invoice",        label: "New Invoice",   hintCode: "INV", icon: FileText,      triggerAction: "invoices",   handler: "route",  target: "/invoices?action=new",     requiredPermission: "invoices.create" },
-  { id: "client",         label: "New Client",    hintCode: "CLI", icon: Users,         triggerAction: "clients",    handler: "window", target: "create-client",            requiredPermission: "clients.create" },
+  { id: "expense",        labelKey: "actions.expense.label",       hintCode: "EXP", icon: Receipt,       triggerAction: "expenses",   handler: "route",  target: "/accounting?tab=expenses", requiredPermission: "expenses.create" },
+  { id: "lead",           labelKey: "actions.lead.label",          hintCode: "LED", icon: TrendingUp,    triggerAction: "leads",      handler: "window", target: "create-lead",              requiredPermission: "pipeline.manage" },
+  { id: "estimate",       labelKey: "actions.estimate.label",      hintCode: "EST", icon: Calculator,    triggerAction: "estimates",  handler: "window", target: "create-estimate",          requiredPermission: "estimates.create" },
+  { id: "invoice",        labelKey: "actions.invoice.label",       hintCode: "INV", icon: FileText,      triggerAction: "invoices",   handler: "route",  target: "/invoices?action=new",     requiredPermission: "invoices.create" },
+  { id: "client",         labelKey: "actions.client.label",        hintCode: "CLI", icon: Users,         triggerAction: "clients",    handler: "window", target: "create-client",            requiredPermission: "clients.create" },
   // Phase 9.1 — "New Project" routes through the unified workspace
   // window in creating mode instead of the legacy create-project modal.
-  { id: "project",        label: "New Project",   hintCode: "PRJ", icon: FolderKanban,  triggerAction: "projects",   handler: "window", target: "project-workspace",        requiredPermission: "projects.create", meta: { initialMode: "creating" } },
-  { id: "task",           label: "New Task",      hintCode: "TSK", icon: ClipboardList, triggerAction: "tasks",      handler: "window", target: "create-task",              requiredPermission: "tasks.create" },
-  { id: "task-type",      label: "New Task Type", hintCode: "TTY", icon: Tag,           triggerAction: "task-types", handler: "route",  target: "/settings?tab=company",    requiredPermission: "settings.company" },
-  { id: "inventory-item", label: "New Item",      hintCode: "ITM", icon: Boxes,         triggerAction: "inventory",  handler: "route",  target: "/inventory?action=new",    requiredPermission: "inventory.manage" },
+  { id: "project",        labelKey: "actions.project.label",       hintCode: "PRJ", icon: FolderKanban,  triggerAction: "projects",   handler: "window", target: "project-workspace",        requiredPermission: "projects.create", meta: { initialMode: "creating" } },
+  { id: "task",           labelKey: "actions.task.label",          hintCode: "TSK", icon: ClipboardList, triggerAction: "tasks",      handler: "window", target: "create-task",              requiredPermission: "tasks.create" },
+  { id: "task-type",      labelKey: "actions.task-type.label",     hintCode: "TTY", icon: Tag,           triggerAction: "task-types", handler: "route",  target: "/settings?tab=company",    requiredPermission: "settings.company" },
+  { id: "inventory-item", labelKey: "actions.inventory-item.label",hintCode: "ITM", icon: Boxes,         triggerAction: "inventory",  handler: "route",  target: "/inventory?action=new",    requiredPermission: "inventory.manage" },
 ];
 
 export const DEFAULT_ACTION_IDS = ALL_ACTIONS.map((a) => a.id);

--- a/src/lib/types/permissions.ts
+++ b/src/lib/types/permissions.ts
@@ -301,6 +301,21 @@ const reportsModule: PermissionModule = {
   ],
 };
 
+// The agent queue surfaces proposed financial actions (invoices, payment
+// reminders, etc.) with full client/project context. The API gate at
+// /api/agent/queue uses requireAdminOrOwner — only account holders and
+// company admins should see the nav entry or reach the page. Adding the
+// permission here also keeps the route gate, sidebar, and ALL_PERMISSIONS
+// lookup consistent (bug 63d0cf8d — previously the sidebar used the
+// non-existent "admin" key and the route gate fell back to pipeline.view).
+const agentModule: PermissionModule = {
+  id: "agent",
+  label: "Agent",
+  actions: [
+    { id: "agent.queue.view", label: "View agent action queue", scopes: ["all"] },
+  ],
+};
+
 // ─── Category Groupings ──────────────────────────────────────────────────────
 
 export const PERMISSION_CATEGORIES: PermissionCategory[] = [
@@ -327,7 +342,7 @@ export const PERMISSION_CATEGORIES: PermissionCategory[] = [
   {
     id: "admin",
     label: "Admin",
-    modules: [settingsModule, emailModule, inboxModule, portalModule, reportsModule],
+    modules: [settingsModule, emailModule, inboxModule, portalModule, reportsModule, agentModule],
   },
 ];
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,8 @@ const protectedPrefixes = [
   "/projects",
   "/calendar",
   "/clients",
-
+  "/inbox",
+  "/agent",
   "/team",
   "/map",
   "/pipeline",


### PR DESCRIPTION
## Summary

Batch 01 of the 2026-05-11 web nightly bug sweep — 8 fixed, 2 escalated.

## Fixes

- **7ea0db1b** · security · Protect `/inbox` and `/agent` prefixes in middleware. Added both routes to `protectedPrefixes` so unauthenticated requests are redirected at the edge before client hydration.
- **6c4f2a6c** · ui · Dictionary-back FAB quick action labels. Added `labelKey` to FABAction, populated `quick-actions.json` for EN + ES, and updated drawer + settings tabs to resolve via the dictionary using a `resolveActionLabel` helper.
- **63d0cf8d** · functional · Unify Agent Queue permission. Introduced `agent.queue.view` permission, used it in both sidebar nav and the dashboard route gate. Resolves the prior mismatch where the sidebar's "admin" key was a category id (not a permission) and the route mapped /agent to pipeline.view.
- **c0d4abe7** · functional · **COMPLEX** · Persist schedule edits from project task list edit form. `handleEditSubmit` now converts the form's `YYYY-MM-DD` strings to `Date | null` and includes `startDate` + `endDate` in the partial update so `TaskService.updateTask` writes `start_date`/`end_date` columns.
- **29fcbf09** · ui · **COMPLEX** · Show task assignee, schedule, and overflow controls on mobile. Removed `hidden sm:flex` from the assignee + date-range groups and dropped the hover-only opacity on the overflow trigger. Added an aria-label.
- **452d7865** · functional · **COMPLEX** · Hide In Progress from project task status menus. The `project_tasks.status` CHECK constraint only allows active/completed/cancelled — the UI exposed In Progress, but writes collapsed to active and reads mapped back to Booked. Removed from `STATUS_OPTIONS` and filtered out of `StatusDropdown` until a future migration widens the constraint.
- **03241853** · ui · Added shared `QueryErrorState` component (brick-bordered tactical panel + retry button with spinner) and wired it into calendar, projects, map, and team pages. Error pane only swaps in when no cached data is present; otherwise the prior result remains visible while the background refetch retries.
- **272b3751** · functional · Wired project Record Payment action to the invoices flow. The action now routes to `/invoices?projectId={id}&action=recordPayment`, the invoices page filters by project and auto-opens the existing Record Payment modal when there's one outstanding invoice (toasts a dictionary-backed "no outstanding invoices" message otherwise). Re-gated `canRecordPayment` on the project canvas to `invoices.record_payment` to match the destination.

## Escalated (requires human review)

- **ae2cf28a** · functional · Product options TypeScript build failure. None of the referenced files exist on main and `npm run type-check` passes cleanly. Likely filed against an unmerged branch — needs a human to confirm whether to scaffold the missing module or close as obsolete.
- **fcd58fbb** · functional · Product options page JSX comment lint. Same surface as `ae2cf28a` — `src/app/(dashboard)/products/[id]/options/page.tsx` does not exist on main. Cannot run/repair lint when no source file exists.

## Test plan

- [ ] Unauthenticated `/inbox` and `/agent/queue` requests redirect to `/login` (edge, not client).
- [ ] FAB quick action drawer labels render dictionary copy in EN and ES; settings tabs render the same copy.
- [ ] Sidebar shows Agent Queue entry for account holders / company admins; route gate 404s non-admins.
- [ ] Editing a task's start/end date in the project task list persists across refresh.
- [ ] Task row on mobile (≤ 640px) shows assignee avatars, date range, and an always-visible overflow trigger; tapping the trigger opens Edit/Delete.
- [ ] Setting task status — In Progress no longer appears in the inline menu or the form dropdown.
- [ ] Forcing a network failure on calendar / projects / map / team shows the QueryErrorState pane with a working Retry button.
- [ ] Clicking Record Payment on a project with one outstanding invoice opens the Record Payment modal on the invoices page; with zero outstanding invoices it shows the dictionary-backed toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)