### PR TITLE
fix(inbox): drop duplicate ✦ from draft-switcher Claude tab label

### DIFF
--- a/src/components/ops/inbox/composer/draft-switcher.tsx
+++ b/src/components/ops/inbox/composer/draft-switcher.tsx
@@ -57,7 +57,7 @@ const SOURCE_LABEL_KEY: Record<DraftSource, string> = {
 
 const SOURCE_LABEL_FALLBACK: Record<DraftSource, string> = {
   yours: "{n} · YOURS",
-  claude: "✦ {n} · CLAUDE",
+  claude: "{n} · CLAUDE",
   gmail: "{n} · GMAIL",
   outlook: "{n} · OUTLOOK",
   new: "{n} · NEW",

--- a/src/i18n/dictionaries/en/inbox.json
+++ b/src/i18n/dictionaries/en/inbox.json
@@ -428,7 +428,7 @@
   "draftSwitcher.outlookLabel": "{n} · OUTLOOK",
   "draftSwitcher.yoursLabel": "{n} · YOURS",
   "draftSwitcher.newLabel": "{n} · NEW",
-  "draftSwitcher.claudeLabel": "✦ {n} · CLAUDE",
+  "draftSwitcher.claudeLabel": "{n} · CLAUDE",
   "draftSwitcher.addNew": "[+]",
   "draftSwitcher.addNewAria": "Add new draft",
 

--- a/src/i18n/dictionaries/es/inbox.json
+++ b/src/i18n/dictionaries/es/inbox.json
@@ -398,7 +398,7 @@
   "draftSwitcher.outlookLabel": "{n} · OUTLOOK",
   "draftSwitcher.yoursLabel": "{n} · TÚ",
   "draftSwitcher.newLabel": "{n} · NUEVO",
-  "draftSwitcher.claudeLabel": "✦ {n} · CLAUDE",
+  "draftSwitcher.claudeLabel": "{n} · CLAUDE",
   "draftSwitcher.addNew": "[+]",
   "draftSwitcher.addNewAria": "Añadir borrador",
 


### PR DESCRIPTION
## Summary

The Claude draft tab was rendering a **double sparkle** — one from the Lucide \`<Sparkles>\` SVG the component renders before the label, plus one from a unicode ✦ glyph baked into the i18n string + fallback const.

This fix was captured in a sibling-agent WIP stash from Phase F1 during the inbox brand-intent rework but never made it into the final shipped state of PR #48. Surfaced during stash cleanup after the rework landed on main.

## Change

Three one-line edits removing the unicode ✦ from:
- \`src/i18n/dictionaries/en/inbox.json\` — \`"draftSwitcher.claudeLabel"\`
- \`src/i18n/dictionaries/es/inbox.json\` — same key
- \`src/components/ops/inbox/composer/draft-switcher.tsx\` — \`SOURCE_LABEL_FALLBACK.claude\` const

The Lucide \`<Sparkles>\` SVG (\`h-3.5 w-3.5 text-agent\`) remains as the sole visual sparkle.

## Test plan

- [ ] Open a thread with 2+ drafts where one is from Claude
- [ ] Confirm the Claude draft tab shows ONE sparkle (the SVG), not two
- [ ] Confirm the count + \"· CLAUDE\" label still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)