### PR TITLE
fix(onboarding-drip): populate email_log.user_id so dedup reconciliation works

### DIFF
--- a/src/app/api/setup/progress/route.ts
+++ b/src/app/api/setup/progress/route.ts
@@ -205,6 +205,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
                 email: operatorEmail,
                 firstName: (userRow.first_name as string | null | undefined) ?? null,
                 onboardingEmailLogId: logRow.id as string,
+                userId,
               });
 
               const update: Record<string, unknown> =

--- a/src/lib/api/services/onboarding-drip-service.ts
+++ b/src/lib/api/services/onboarding-drip-service.ts
@@ -144,6 +144,7 @@ async function dispatchTypedSender(
     email: params.user.email,
     firstName: params.user.first_name,
     onboardingEmailLogId,
+    userId: params.user.id,
   };
   switch (params.emailType) {
     case "onboarding_day_0_welcome":
@@ -153,6 +154,7 @@ async function dispatchTypedSender(
         email: params.user.email,
         ctaUrl: `${process.env.NEXT_PUBLIC_APP_URL}/projects/new`,
         onboardingEmailLogId,
+        userId: params.user.id,
       });
     case "onboarding_day_1_has_project":
       return sendOnboardingDay1HasProject({
@@ -160,6 +162,7 @@ async function dispatchTypedSender(
         projectCount: (params.payload.projectCount as number) ?? 1,
         ctaUrl: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard`,
         onboardingEmailLogId,
+        userId: params.user.id,
       });
     case "onboarding_day_3_inbox":
       return sendOnboardingDay3Inbox(baseArgs);
@@ -168,12 +171,14 @@ async function dispatchTypedSender(
         email: params.user.email,
         ctaUrl: `${process.env.NEXT_PUBLIC_APP_URL}/settings/team`,
         onboardingEmailLogId,
+        userId: params.user.id,
       });
     case "onboarding_day_4_has_notification":
       return sendOnboardingDay4HasNotification({
         email: params.user.email,
         ctaUrl: `${process.env.NEXT_PUBLIC_APP_URL}/projects?filter=recurring`,
         onboardingEmailLogId,
+        userId: params.user.id,
       });
     case "onboarding_day_8_estimates":
       return sendOnboardingDay8Estimates(baseArgs);
@@ -187,6 +192,7 @@ async function dispatchTypedSender(
         taskCount: (params.payload.taskCount as number) ?? 0,
         notificationCount: (params.payload.notificationCount as number) ?? 0,
         onboardingEmailLogId,
+        userId: params.user.id,
       });
     case "onboarding_lost_you":
       return sendOnboardingLostYou({
@@ -195,6 +201,7 @@ async function dispatchTypedSender(
         daysSinceSignup: (params.payload.daysSinceSignup as number) ?? 0,
         daysSinceLastActivity: (params.payload.daysSinceLastActivity as number) ?? 0,
         onboardingEmailLogId,
+        userId: params.user.id,
       });
     default:
       throw new Error(`Unknown emailType: ${params.emailType}`);

--- a/src/lib/email/sendgrid.tsx
+++ b/src/lib/email/sendgrid.tsx
@@ -1245,6 +1245,7 @@ export async function sendOnboardingDay0Welcome(params: {
   email: string;
   firstName: string | null;
   onboardingEmailLogId: string;
+  userId?: string | null;
 }): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
@@ -1263,6 +1264,7 @@ export async function sendOnboardingDay0Welcome(params: {
     subject: "quick question",
     html,
     emailType: "onboarding_day_0_welcome",
+    userId: params.userId ?? undefined,
     list: compliance.list,
     headers: compliance.headers,
     metadata: { onboarding_email_log_id: params.onboardingEmailLogId },
@@ -1274,6 +1276,7 @@ export async function sendOnboardingDay3Inbox(params: {
   email: string;
   firstName: string | null;
   onboardingEmailLogId: string;
+  userId?: string | null;
 }): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
@@ -1292,6 +1295,7 @@ export async function sendOnboardingDay3Inbox(params: {
     subject: "the part of OPS I'm most proud of",
     html,
     emailType: "onboarding_day_3_inbox",
+    userId: params.userId ?? undefined,
     list: compliance.list,
     headers: compliance.headers,
     metadata: { onboarding_email_log_id: params.onboardingEmailLogId },
@@ -1303,6 +1307,7 @@ export async function sendOnboardingDay8Estimates(params: {
   email: string;
   firstName: string | null;
   onboardingEmailLogId: string;
+  userId?: string | null;
 }): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
@@ -1321,6 +1326,7 @@ export async function sendOnboardingDay8Estimates(params: {
     subject: "how your customers see your estimates",
     html,
     emailType: "onboarding_day_8_estimates",
+    userId: params.userId ?? undefined,
     list: compliance.list,
     headers: compliance.headers,
     metadata: { onboarding_email_log_id: params.onboardingEmailLogId },
@@ -1332,6 +1338,7 @@ export async function sendOnboardingDay14Quiet(params: {
   email: string;
   firstName: string | null;
   onboardingEmailLogId: string;
+  userId?: string | null;
 }): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
@@ -1350,6 +1357,7 @@ export async function sendOnboardingDay14Quiet(params: {
     subject: "is OPS slotting in or in the way?",
     html,
     emailType: "onboarding_day_14_quiet",
+    userId: params.userId ?? undefined,
     list: compliance.list,
     headers: compliance.headers,
     metadata: { onboarding_email_log_id: params.onboardingEmailLogId },
@@ -1364,6 +1372,7 @@ export async function sendOnboardingDay14Active(params: {
   taskCount: number;
   notificationCount: number;
   onboardingEmailLogId: string;
+  userId?: string | null;
 }): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
@@ -1385,6 +1394,7 @@ export async function sendOnboardingDay14Active(params: {
     subject: "you're 14 days in",
     html,
     emailType: "onboarding_day_14_active",
+    userId: params.userId ?? undefined,
     list: compliance.list,
     headers: compliance.headers,
     metadata: {
@@ -1403,6 +1413,7 @@ export async function sendOnboardingLostYou(params: {
   daysSinceSignup: number;
   daysSinceLastActivity: number;
   onboardingEmailLogId: string;
+  userId?: string | null;
 }): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
@@ -1423,6 +1434,7 @@ export async function sendOnboardingLostYou(params: {
     subject: "lost you?",
     html,
     emailType: "onboarding_lost_you",
+    userId: params.userId ?? undefined,
     list: compliance.list,
     headers: compliance.headers,
     metadata: {
@@ -1445,6 +1457,7 @@ export async function sendOnboardingDay1NoProject(params: {
   email: string;
   ctaUrl: string;
   onboardingEmailLogId: string;
+  userId?: string | null;
 }): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
@@ -1460,6 +1473,7 @@ export async function sendOnboardingDay1NoProject(params: {
     subject: "the move that gets OPS working",
     html,
     emailType: "onboarding_day_1_no_project",
+    userId: params.userId ?? undefined,
     list: compliance.list,
     headers: compliance.headers,
     metadata: { onboarding_email_log_id: params.onboardingEmailLogId },
@@ -1472,6 +1486,7 @@ export async function sendOnboardingDay1HasProject(params: {
   projectCount: number;
   ctaUrl: string;
   onboardingEmailLogId: string;
+  userId?: string | null;
 }): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
@@ -1491,6 +1506,7 @@ export async function sendOnboardingDay1HasProject(params: {
     subject: "you're moving",
     html,
     emailType: "onboarding_day_1_has_project",
+    userId: params.userId ?? undefined,
     list: compliance.list,
     headers: compliance.headers,
     metadata: {
@@ -1505,6 +1521,7 @@ export async function sendOnboardingDay4NoNotification(params: {
   email: string;
   ctaUrl: string;
   onboardingEmailLogId: string;
+  userId?: string | null;
 }): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
@@ -1520,6 +1537,7 @@ export async function sendOnboardingDay4NoNotification(params: {
     subject: "the notification you're working toward",
     html,
     emailType: "onboarding_day_4_no_notification",
+    userId: params.userId ?? undefined,
     list: compliance.list,
     headers: compliance.headers,
     metadata: { onboarding_email_log_id: params.onboardingEmailLogId },
@@ -1531,6 +1549,7 @@ export async function sendOnboardingDay4HasNotification(params: {
   email: string;
   ctaUrl: string;
   onboardingEmailLogId: string;
+  userId?: string | null;
 }): Promise<GatedSendResult> {
   const compliance = buildComplianceHeaders({
     email: params.email,
@@ -1546,6 +1565,7 @@ export async function sendOnboardingDay4HasNotification(params: {
     subject: "you've heard the ping",
     html,
     emailType: "onboarding_day_4_has_notification",
+    userId: params.userId ?? undefined,
     list: compliance.list,
     headers: compliance.headers,
     metadata: { onboarding_email_log_id: params.onboardingEmailLogId },

--- a/tests/unit/email/sendgrid-onboarding-jack.test.ts
+++ b/tests/unit/email/sendgrid-onboarding-jack.test.ts
@@ -65,6 +65,22 @@ describe("Jack-persona onboarding senders", () => {
     expect(call.customArgs.onboarding_email_log_id).toBe("log-uuid-123");
   });
 
+  it("threads userId through to gatedSend — regression for qa_bug 41db7c3b (email_log.user_id was null, breaking reconciliation)", async () => {
+    const { sendOnboardingDay0Welcome } = await import("@/lib/email/sendgrid");
+    await sendOnboardingDay0Welcome({
+      email: "test@example.com",
+      firstName: "Pat",
+      onboardingEmailLogId: "log-uuid-123",
+      userId: "user-uuid-789",
+    });
+    const call = (sgMail.send as any).mock.calls[0][0];
+    // gatedSend writes params.userId into BOTH customArgs.user_id and email_log.user_id.
+    // Before this fix the onboarding senders never accepted/passed userId, so
+    // email_log.user_id was null and reconcileAgainstEmailLog (.eq("user_id", ...))
+    // could never match. Asserting customArgs.user_id proves userId reaches gatedSend.
+    expect(call.customArgs.user_id).toBe("user-uuid-789");
+  });
+
   it("sendOnboardingDay3Inbox has subject 'the part of OPS I'm most proud of'", async () => {
     const { sendOnboardingDay3Inbox } = await import("@/lib/email/sendgrid");
     await sendOnboardingDay3Inbox({


### PR DESCRIPTION
## Summary

Found during the onboarding-drip production smoke test (qa_bug `41db7c3b`).

The 10 typed onboarding senders never accepted or passed a `userId`, so every onboarding `email_log` row was written with `user_id = null`. But `OnboardingDripService.reconcileAgainstEmailLog` filters **both** its primary and fallback queries on `.eq("user_id", opts.userId)` — which can never match a null row. That silently defeats the partial-success reconciliation: if a process crashed between `gatedSend` succeeding and the `onboarding_email_log` status update, the retry sweep would re-send → duplicate founder email. Sends were also unlinked from users for analytics.

## Fix

- Add optional `userId` to all 10 `sendOnboarding*` senders, forwarded to `gatedSend` (which already writes both `email_log.user_id` and `customArgs.user_id`).
- Wire the two call sites: `OnboardingDripService.dispatchTypedSender` (`params.user.id`) and the Day 0 real-time hook in `/api/setup/progress`.
- **No change to the reviewed reconciliation logic** — it works as the spec designed once `email_log.user_id` is populated.

## Test plan

- [x] New regression test asserts `userId` reaches `gatedSend` (`customArgs.user_id` set)
- [x] 303 unit + integration tests pass (`vitest tests/unit/email/ tests/unit/api/services/`)
- [x] `tsc --noEmit` clean for touched files
- [ ] Verify prod build green, then merge → deploy