### PR TITLE
feat(analytics): install GA4 client tracking for visit + traffic data

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/toast";
 import { SignOutOverlay } from "@/components/ops/sign-out-overlay";
 import { UtmCaptureEffect } from "@/components/pmf/utm-capture-effect";
 import { DevBypassBanner } from "@/components/providers/dev-bypass-banner";
+import GoogleAnalytics from "@/components/layout/GoogleAnalytics";
 import { getLocale } from "@/i18n/server";
 
 export const metadata: Metadata = {
@@ -83,6 +84,7 @@ export default async function RootLayout({
           <UtmCaptureEffect />
           <DevBypassBanner />
         </Providers>
+        <GoogleAnalytics />
       </body>
     </html>
   );

--- a/src/components/layout/GoogleAnalytics.tsx
+++ b/src/components/layout/GoogleAnalytics.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+/**
+ * GoogleAnalytics — Loads the GA4 gtag.js snippet when
+ * NEXT_PUBLIC_GA_MEASUREMENT_ID is set in the environment.
+ *
+ * Scope: visit + traffic tracking only. Product analytics (feature
+ * adoption, funnels, retention) still go to Supabase analytics_events
+ * via src/lib/analytics/analytics-service.ts. Google Ads conversion
+ * attribution still goes through Firebase Analytics. See
+ * ops-software-bible/21_ANALYTICS_SYSTEM.md for the three-system layout.
+ *
+ * Privacy note: this is a logged-in product. Page URLs can contain
+ * resource UUIDs (project IDs, client IDs) which are not direct PII
+ * but should not be retained indefinitely. anonymize_ip is GA4-default.
+ * Configure query-param exclusion + IP anonymization in the GA4 admin
+ * for the OPS-Web data stream — do not encode property-level config here.
+ */
+
+import Script from "next/script";
+
+const GA_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+export default function GoogleAnalytics() {
+  if (!GA_ID) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_ID}');
+        `}
+      </Script>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `src/components/layout/GoogleAnalytics.tsx` mirroring the pattern already running on `ops-site` (same env var name: `NEXT_PUBLIC_GA_MEASUREMENT_ID`)
- Mounts `<GoogleAnalytics />` inside the root layout after `<Providers>`
- Component returns `null` when env var is unset — no leakage on local dev or env-less preview builds

## Three-system layout, going forward
- `analytics_events` (Supabase) — product analytics, primary
- GA4 gtag.js (this PR) — visit + traffic, secondary
- Firebase Analytics (existing) — Google Ads conversion attribution, narrow scope (5 events, dual-write)

## Vercel env
`NEXT_PUBLIC_GA_MEASUREMENT_ID=G-JJP5SN122V` set on production + preview + development for project `ops-web`.

## Bible
Companion docs update lands separately: ops-software-bible `docs/ga4-bible-update` branch — updates § 1 Design Principles and adds a new subsection to § 7 Web Implementation Guide.

## Test plan
- [ ] After merge + Vercel deploy, `curl -sL https://app.opsapp.co/ | grep gtag/js` should return `id=G-JJP5SN122V`
- [ ] Confirm `gtag` global is set in the browser console on any logged-in page
- [ ] Realtime view in GA4 admin (property G-JJP5SN122V) should register sessions

## Privacy note
OPS-Web URLs can contain resource UUIDs (project IDs, client IDs). `anonymize_ip` is GA4-default; configure query-param exclusion + path scrubbing for UUID segments at the GA4 admin level for the OPS-Web data stream — **not** in client-side code.