### PR TITLE
chore(db): mirror leads-review migration drift (2 files PR #63 missed)

### DIFF
--- a/supabase/migrations/20260531195501_harden_convert_lead_to_project_authz.sql
+++ b/supabase/migrations/20260531195501_harden_convert_lead_to_project_authz.sql
@@ -1,0 +1,195 @@
+-- ============================================================================
+-- MIGRATION (leads-review C-6 / C-12) — SHIP-BLOCKER
+-- Harden convert_lead_to_project authorization
+-- Authored 2026-05-31 by the LEADS pre-merge review. APPLIED to prod 2026-05-31
+-- (schema_migrations version 20260531195501) and verified across all four auth
+-- paths against live data. This file mirrors the already-applied migration into
+-- the repo for repo<->DB parity (applied via the Supabase MCP, same as the
+-- 06-01 security-sweep migrations mirrored in PR #63).
+--
+-- WHY: The RPC is SECURITY DEFINER (runs as postgres, bypasses RLS), EXECUTE is
+-- granted to anon + PUBLIC, and its ONLY authorization was a membership check on
+-- the CLIENT-SUPPLIED p_user_id. It never read the JWT. A caller (even
+-- unauthenticated, with just the anon key) who knows/leaks a same-company
+-- (opportunity_id, user_id) pair could mark that lead won with an arbitrary
+-- actual_value, create a project, and cascade project_tasks/project_photos rows.
+--
+-- FIX: authorize the SERVER-DERIVED caller (JWT email -> users, the exact path
+-- that backs the company_isolation RLS already governing this table) and require
+-- pipeline.manage, mirroring the proven projects/clients role_scope_* pattern.
+--
+-- BACKWARD-COMPATIBLE (verified against live data, 2026-05-31):
+--   * Signature unchanged -> the shipped iOS app keeps calling it as-is (no App
+--     Store release required).
+--   * private.get_user_company_id() resolves for the iOS app: 124 stage_transitions
+--     in the last 120 days (latest yesterday) were written via move_opportunity_stage,
+--     which relies on the same company_isolation/JWT-email path.
+--   * Every live actor that can convert holds pipeline.manage at scope 'all'
+--     (only the Admin/Office/Owner preset roles touch pipeline; zero
+--     pipeline.* user_permission_overrides), so current_user_has_permission(...,'all')
+--     returns true for all of them. No legitimate caller is newly rejected.
+--   * anon retains EXECUTE but is now rejected by the NULL-company guard, so no
+--     GRANT change is needed (avoids breaking the app if it executes as anon).
+--
+-- SMOKE TEST after applying (no data is mutated):
+--   select public.convert_lead_to_project(gen_random_uuid(), 1, 't', 'a', gen_random_uuid());
+--   -- expect: ERROR 'opportunity_not_found' (function compiles + runs)
+--   Then convert one real lead from the iOS app as an Admin/Office/Owner user and
+--   confirm it still succeeds.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.convert_lead_to_project(
+  p_opportunity_id uuid,
+  p_actual_value   numeric,
+  p_title          text,
+  p_address        text,
+  p_user_id        uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_project_id        uuid;
+  v_company_id        uuid;
+  v_client_id         uuid;
+  v_from_stage        text;
+  v_stage_entered_at  timestamptz;
+  v_actor_company     uuid;
+  v_now               timestamptz := now();
+BEGIN
+  SELECT company_id, client_id, stage, stage_entered_at
+    INTO v_company_id, v_client_id, v_from_stage, v_stage_entered_at
+    FROM opportunities
+   WHERE id = p_opportunity_id
+     AND deleted_at IS NULL;
+
+  IF v_company_id IS NULL THEN
+    RAISE EXCEPTION 'opportunity_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Authorize the CALLER, not the client-supplied p_user_id. The actor's company
+  -- is derived from the JWT email claim via the same SECURITY DEFINER helper that
+  -- backs the company_isolation RLS policy on opportunities. An anon/no-JWT caller
+  -- resolves to NULL (rejected); a cross-company caller is rejected.
+  v_actor_company := private.get_user_company_id();
+  IF v_actor_company IS NULL OR v_actor_company <> v_company_id THEN
+    RAISE EXCEPTION 'access_denied' USING ERRCODE = '42501';
+  END IF;
+
+  -- Require the same permission the client gates on. RLS does not otherwise apply
+  -- inside this SECURITY DEFINER function, so the check must be explicit here.
+  IF NOT private.current_user_has_permission('pipeline.manage', 'all') THEN
+    RAISE EXCEPTION 'access_denied' USING ERRCODE = '42501';
+  END IF;
+
+  -- The audit user (created_by / transitioned_by) must belong to the company.
+  IF NOT EXISTS (
+    SELECT 1 FROM users
+     WHERE id = p_user_id
+       AND company_id = v_company_id
+  ) THEN
+    RAISE EXCEPTION 'access_denied' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT id INTO v_project_id
+    FROM projects
+   WHERE opportunity_id = p_opportunity_id::text
+     AND deleted_at IS NULL
+   LIMIT 1;
+
+  IF v_project_id IS NOT NULL THEN
+    RETURN v_project_id;
+  END IF;
+
+  v_project_id := gen_random_uuid();
+
+  INSERT INTO projects (
+    id, company_id, client_id, opportunity_id,
+    title, address, status, created_by, created_at, updated_at
+  ) VALUES (
+    v_project_id, v_company_id, v_client_id, p_opportunity_id::text,
+    p_title, p_address, 'accepted', p_user_id, v_now, v_now
+  );
+
+  UPDATE estimates
+     SET project_id  = v_project_id::text,
+         project_ref = v_project_id,
+         updated_at  = v_now
+   WHERE opportunity_id = p_opportunity_id
+     AND project_id IS NULL
+     AND deleted_at IS NULL;
+
+  INSERT INTO project_tasks (
+    id, company_id, project_id, task_type_id,
+    custom_title, source_line_item_id, source_estimate_id,
+    status, display_order, duration, task_color, created_at, updated_at
+  )
+  SELECT
+    gen_random_uuid(),
+    v_company_id,
+    v_project_id,
+    li.task_type_ref,
+    li.name,
+    li.id::text,
+    li.estimate_id::text,
+    'active',
+    COALESCE(li.sort_order, 0),
+    COALESCE(tt.default_duration, 1),
+    COALESCE(tt.color, '#417394'),
+    v_now,
+    v_now
+  FROM line_items li
+  LEFT JOIN task_types tt ON tt.id = li.task_type_ref
+  WHERE li.estimate_id IN (
+          SELECT id FROM estimates
+           WHERE opportunity_id = p_opportunity_id
+             AND deleted_at IS NULL
+        )
+    AND li.type = 'LABOR';
+
+  -- Site-visit photo auto-attach (added 2026-05-20).
+  INSERT INTO project_photos (
+    id, project_id, company_id, url, source,
+    site_visit_id, uploaded_by, taken_at, created_at
+  )
+  SELECT
+    gen_random_uuid(),
+    v_project_id::text,
+    v_company_id::text,
+    photo_url,
+    'site_visit',
+    sv.id,
+    sv.created_by,
+    NULL,
+    v_now
+  FROM site_visits sv
+  CROSS JOIN LATERAL unnest(sv.photos) AS photo_url
+  WHERE sv.opportunity_id = p_opportunity_id
+    AND sv.deleted_at IS NULL
+    AND photo_url IS NOT NULL
+    AND photo_url <> '';
+
+  UPDATE opportunities
+     SET stage              = 'won',
+         stage_entered_at   = v_now,
+         stage_manually_set = true,
+         actual_value       = p_actual_value,
+         actual_close_date  = v_now::date,
+         project_id         = v_project_id,
+         project_ref        = v_project_id,
+         updated_at         = v_now
+   WHERE id = p_opportunity_id;
+
+  INSERT INTO stage_transitions (
+    company_id, opportunity_id, from_stage, to_stage,
+    transitioned_at, transitioned_by, duration_in_stage
+  ) VALUES (
+    v_company_id, p_opportunity_id, v_from_stage, 'won',
+    v_now, p_user_id, v_now - v_stage_entered_at
+  );
+
+  RETURN v_project_id;
+END;
+$function$;

--- a/supabase/migrations/20260601191354_pipeline_tables_role_scope_write_rls.sql
+++ b/supabase/migrations/20260601191354_pipeline_tables_role_scope_write_rls.sql
@@ -1,0 +1,69 @@
+-- ============================================================================
+-- MIGRATION (leads-review C-7) — defense-in-depth, latent today
+-- Make pipeline.manage a real SERVER-SIDE write boundary on the pipeline-owned
+-- tables, mirroring the proven projects/clients role_scope_* pattern.
+-- Authored 2026-05-31 by the LEADS pre-merge review. APPLIED to prod 2026-05-31
+-- (migration: pipeline_tables_role_scope_write_rls) with explicit PM authorization
+-- once leads work was confirmed solo. Verified live: opportunities + stage_transitions
+-- now carry role_scope_insert/update/delete alongside company_isolation (and the
+-- pre-existing role_scope_read on opportunities). Mirror into OPS-Web/supabase/migrations.
+--
+-- !! COORDINATE BEFORE APPLYING !!
+-- `opportunities` is the hot table of the active, push-held lead-lifecycle
+-- initiative (see the many ops-web-lead-lifecycle-* worktrees). Apply this only
+-- after confirming with that initiative's owner that it does not collide with
+-- their in-flight opportunities RLS / schema migrations. The gap this closes is
+-- LATENT: every current role with pipeline.view also has pipeline.manage at
+-- scope 'all' (verified 2026-05-31), so no live user can exploit it today — it
+-- only matters once a custom role grants view-without-manage.
+--
+-- SCOPE: gates ONLY opportunities + stage_transitions (unambiguously pipeline-
+-- owned). activities and follow_ups are DELIBERATELY EXCLUDED — they are shared
+-- across email ingestion, clients, estimates, invoices, projects and agent
+-- messages (activities has opportunity_id/client_id/estimate_id/invoice_id/
+-- project_id/email_thread_id/...; follow_ups has client_id + is_auto_generated),
+-- so gating them on pipeline.manage would break non-pipeline writers. Finer-
+-- grained gating of those tables (e.g. conditional on opportunity_id) is a
+-- separate, carefully-scoped task.
+--
+-- SAFE because (verified 2026-05-31): all client pipeline writers hold
+-- pipeline.manage='all'; server/service-role writers BYPASS RLS;
+-- convert_lead_to_project is SECURITY DEFINER (owner bypasses RLS, so its inserts
+-- are unaffected); move_opportunity_stage is SECURITY INVOKER and its caller
+-- holds pipeline.manage. SELECT is left to company_isolation so pipeline.view
+-- users keep reading.
+-- ============================================================================
+
+-- opportunities -------------------------------------------------------------
+DROP POLICY IF EXISTS role_scope_insert ON public.opportunities;
+CREATE POLICY role_scope_insert ON public.opportunities
+  AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (private.current_user_has_permission('pipeline.manage', 'all'));
+
+DROP POLICY IF EXISTS role_scope_update ON public.opportunities;
+CREATE POLICY role_scope_update ON public.opportunities
+  AS RESTRICTIVE FOR UPDATE TO public
+  USING      (private.current_user_has_permission('pipeline.manage', 'all'))
+  WITH CHECK (private.current_user_has_permission('pipeline.manage', 'all'));
+
+DROP POLICY IF EXISTS role_scope_delete ON public.opportunities;
+CREATE POLICY role_scope_delete ON public.opportunities
+  AS RESTRICTIVE FOR DELETE TO public
+  USING (private.current_user_has_permission('pipeline.manage', 'all'));
+
+-- stage_transitions (append-only audit log) ---------------------------------
+DROP POLICY IF EXISTS role_scope_insert ON public.stage_transitions;
+CREATE POLICY role_scope_insert ON public.stage_transitions
+  AS RESTRICTIVE FOR INSERT TO public
+  WITH CHECK (private.current_user_has_permission('pipeline.manage', 'all'));
+
+DROP POLICY IF EXISTS role_scope_update ON public.stage_transitions;
+CREATE POLICY role_scope_update ON public.stage_transitions
+  AS RESTRICTIVE FOR UPDATE TO public
+  USING      (private.current_user_has_permission('pipeline.manage', 'all'))
+  WITH CHECK (private.current_user_has_permission('pipeline.manage', 'all'));
+
+DROP POLICY IF EXISTS role_scope_delete ON public.stage_transitions;
+CREATE POLICY role_scope_delete ON public.stage_transitions
+  AS RESTRICTIVE FOR DELETE TO public
+  USING (private.current_user_has_permission('pipeline.manage', 'all'));


### PR DESCRIPTION
Adds the two LEADS-review migrations that are already live in prod (schema_migrations `20260531195501` + `20260601191354`) but were not captured by the drift-mirror in #63 — which mirrored the 06-01 security-sweep batch that sits between them. Purely additive record-keeping for repo↔DB parity; **no schema change** (both already applied + verified). Safe to merge standalone or fold into the ongoing migration-drift reconciliation. Files: convert_lead_to_project authz hardening (C-6/C-12) + pipeline-tables write RLS (C-7).