### PR TITLE
test(projects-table): fix stale keyboard-nav read-only assertion (client is editable)

### DIFF
--- a/tests/unit/hooks/use-table-keyboard-nav.test.tsx
+++ b/tests/unit/hooks/use-table-keyboard-nav.test.tsx
@@ -161,7 +161,7 @@ describe("useTableKeyboardNav", () => {
   });
 
   it("begins edit on enter only when the active column is editable", () => {
-    const { result } = renderNav({ columns: columns(["name", "client"]) });
+    const { result } = renderNav({ columns: columns(["name", "next_task"]) });
 
     act(() => {
       result.current.setActiveCell({ rowId: "p-1", columnId: "name" });
@@ -175,11 +175,11 @@ describe("useTableKeyboardNav", () => {
 
     act(() => {
       result.current.cancelEdit();
-      result.current.setActiveCell({ rowId: "p-1", columnId: "client" });
+      result.current.setActiveCell({ rowId: "p-1", columnId: "next_task" });
     });
     const readOnlyEnter = keyEvent("Enter");
     act(() => {
-      result.current.handleCellKeyDown("p-1", "client", readOnlyEnter);
+      result.current.handleCellKeyDown("p-1", "next_task", readOnlyEnter);
     });
     expect(result.current.editingCell).toBeNull();
     expect(readOnlyEnter.preventDefault).not.toHaveBeenCalled();


### PR DESCRIPTION
## Problem

The unit test `tests/unit/hooks/use-table-keyboard-nav.test.tsx` ("begins edit on enter only when the active column is editable") asserted that pressing **Enter** on the `client` column does *not* begin editing — i.e. it treated `client` as a read-only column.

But `client` is in `PROJECT_TABLE_EDITABLE_COLUMN_IDS` and marked `editable: true` (inline client editing shipped with the projects table v2 "complex cells" work). The keyboard-nav hook gates Enter-to-edit purely on that set (`use-table-keyboard-nav.ts` → `isProjectTableEditableColumn`), so it correctly begins editing on `client`. The assertion was stale, and this test has been failing on `main` independently of the in-flight work that surfaced it.

## Fix

Switch the read-only case to `next_task` — a `kind: "text"` column that is genuinely **not** in `PROJECT_TABLE_EDITABLE_COLUMN_IDS` — restoring a valid editable-vs-read-only contrast (a clean parallel to the editable, also-`text` `name` column). Test-only change; no production behavior changes.

## Verification

`npx vitest run tests/unit/hooks/use-table-keyboard-nav.test.tsx`

- Before: **1 failed / 5 passed** — `expected { columnId: 'client' } to be null`
- After: **6 passed**

Verified against the current `main` tip.
