### PR TITLE
test(calendar): align typeLabel null-taskType fallback with "Unmapped type"

### DIFF
--- a/tests/unit/calendar/map-task-to-event.test.ts
+++ b/tests/unit/calendar/map-task-to-event.test.ts
@@ -162,10 +162,15 @@ describe("mapTaskToInternalEvent", () => {
       expect(event?.typeLabel).toBe("Site Visit");
     });
 
-    it("typeLabel falls back to 'Task' when taskType is null", () => {
+    it("typeLabel falls back to 'Unmapped type' when taskType is null", () => {
+      // bug-d789ff9a (011d6bbd) deliberately replaced the generic "Task"
+      // fallback with the explicit "Unmapped type" label, routed through
+      // cleanTaskTypeLabel() so a null taskType — or a UUID-like / blank
+      // taskType.display — surfaces the same tactical badge instead of
+      // leaking a meaningless value into the calendar UI.
       const task = makeTask({ taskType: null });
       const event = mapTaskToInternalEvent(task);
-      expect(event?.typeLabel).toBe("Task");
+      expect(event?.typeLabel).toBe("Unmapped type");
     });
   });
 


### PR DESCRIPTION
## What

Corrects a stale unit-test assertion in `mapTaskToInternalEvent`. The test still expected the pre-fix generic `"Task"` label for a null `taskType`; the shipped code returns `"Unmapped type"`.

## Why

`011d6bbd` (`fix(bug-d789ff9a): resolve calendar task type labels`) deliberately replaced the `?? "Task"` fallback with `cleanTaskTypeLabel(...) ?? "Unmapped type"`, so a null / UUID-like / blank task type surfaces an explicit "Unmapped type" badge instead of leaking a meaningless value into the calendar UI. That commit did not update this test, leaving it red on `main`.

This aligns the expectation (plus the `it(...)` description and a tracing comment) with the shipped behavior. **Test-only — no production code changes.**

## Verification

`npx vitest run tests/unit/calendar/map-task-to-event.test.ts` → **22 passed (22)**.