### PR TITLE
fix(permissions): register projects.manage_views in client catalog

### DIFF
--- a/src/lib/types/permissions.ts
+++ b/src/lib/types/permissions.ts
@@ -75,6 +75,7 @@ const projectsModule: PermissionModule = {
     { id: "projects.delete", label: "Delete projects", scopes: ["all"] },
     { id: "projects.archive", label: "Archive projects", scopes: ["all"] },
     { id: "projects.assign_team", label: "Assign team members", scopes: ["all"] },
+    { id: "projects.manage_views", label: "Manage shared project views", scopes: ["all"] },
   ],
 };
 


### PR DESCRIPTION
## Summary
Registers the `projects.manage_views` permission bit in the client-side permission catalog (`src/lib/types/permissions.ts`). The bit already exists in the DB (`role_permissions`), but account-holders / company-admins derive their permissions from `ALL_PERMISSIONS` in the client catalog rather than the DB — so without this entry they were silently denied the ability to manage shared project views.

## Test plan
- [ ] As an account-holder / company-admin, confirm saved-view management (share / rename / archive) is available on the projects table.
- [ ] `npx tsc --noEmit` clean (verified locally).