### PR TITLE
fix(security): enable RLS on onboarding_email_log

### DIFF
--- a/supabase/migrations/20260529000000_onboarding_email_log_enable_rls.sql
+++ b/supabase/migrations/20260529000000_onboarding_email_log_enable_rls.sql
@@ -1,0 +1,41 @@
+-- 20260529000000_onboarding_email_log_enable_rls.sql
+-- Lock down public.onboarding_email_log. The table shipped with RLS DISABLED
+-- (created in 20260527150000_onboarding_email_log.sql), so the default anon +
+-- authenticated grants let any caller read/write every row via the Data API.
+-- get_advisors flags this as ERROR 0013_rls_disabled_in_public. This migration
+-- is purely additive (enable RLS + one read policy); it changes no columns and
+-- drops nothing, so it is safe to ship between iOS App Store releases — the iOS
+-- app never touches this table (web/cron backend state only).
+--
+-- Access model (verified against the codebase):
+--   * Writes are exclusively service-role. The drip cron
+--     (api/cron/onboarding-drip), the OnboardingDripService claim/update path,
+--     and the Day-0 send in api/setup/progress all use getServiceRoleClient().
+--     service_role bypasses RLS unconditionally, so NO insert/update/delete
+--     policy is required for the app to keep functioning. Leaving those
+--     commands without a policy means RLS denies them by default for
+--     anon/authenticated — exactly what we want.
+--   * Reads: nothing client-side reads this table today. We grant a
+--     company-scoped SELECT to authenticated so an operator can legitimately
+--     inspect their own company's onboarding drip state (and to mirror the
+--     peer backend log table opportunity_lifecycle_action_audit, which uses
+--     this identical posture). anon gets no policy at all → zero access.
+
+alter table public.onboarding_email_log enable row level security;
+
+-- Authenticated callers may read only their own company's rows. Scoping uses
+-- the canonical security-definer helper (returns the caller's company_id as
+-- uuid); company_id is NOT NULL on this table so every row is covered.
+drop policy if exists onboarding_email_log_company_select
+  on public.onboarding_email_log;
+
+create policy onboarding_email_log_company_select
+  on public.onboarding_email_log
+  for select
+  to authenticated
+  using (company_id = (select private.get_user_company_id()));
+
+-- No anon policy and no authenticated write policy by design:
+--   anon            -> no policy  -> denied for all commands.
+--   authenticated   -> SELECT only (above); insert/update/delete denied.
+--   service_role    -> bypasses RLS, retains full access for the cron + routes.


### PR DESCRIPTION
## Summary
Enables Row Level Security on `public.onboarding_email_log`, which shipped with RLS **disabled** — `get_advisors` flags it ERROR `0013_rls_disabled_in_public` (current anon + authenticated grants expose every row via the Data API).

Additive migration (enable RLS + one company-scoped SELECT policy for `authenticated`); drops/changes nothing, and the iOS app never touches this table → safe between App Store releases.

**Access model after this change**
- `service_role` (drip cron, OnboardingDripService, Day-0 send) — bypasses RLS, full access retained → no app breakage.
- `authenticated` — SELECT only, scoped to own `company_id`.
- `anon` — no policy → denied.

> Branch `fix/onboarding-email-log-rls`; the original `fix/onboarding-email-log-user-id` name was already taken by merged PR #60 (unrelated change).
> Note: migration timestamp is `20260529000000`, which predates some migrations already on main — confirm it applies in order at merge (or bump the prefix) per the repo's migration-drift practice.

## Test plan
- [ ] Apply migration; confirm `onboarding_email_log` has RLS enabled and the advisor finding clears.
- [ ] Confirm onboarding-drip cron + send paths (service-role) still read/write normally.