### PR TITLE
fix(onboarding): route company-less signups to account-type, not /setup

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useAuthStore } from "@/lib/store/auth-store";
+import { useSetupGate } from "@/hooks/useSetupGate";
 import { AuthProvider } from "@/components/providers/auth-provider";
 import { useDictionary } from "@/i18n/client";
 import { OpsLockup, LogoLoader } from "@/components/brand";
@@ -26,6 +27,7 @@ function AuthRouteGate({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const { isAuthenticated, isLoading } = useAuthStore();
+  const { onboardingRoute } = useSetupGate();
   const { t } = useDictionary("auth");
 
   const isAllowedWhenAuthenticated = authenticatedAllowedRoutes.some(
@@ -38,11 +40,16 @@ function AuthRouteGate({ children }: { children: React.ReactNode }) {
 
   const isFullScreen = pathname === "/account-type";
 
+  // An authenticated user who lands on a non-allowed (auth) route (e.g. /login,
+  // /register) is forwarded to where they actually belong. For a not-yet-
+  // onboarded user that's their onboarding step (/account-type for company-less
+  // signups), matching the destination the register/login pages push to — so
+  // the two never race to different routes. Completed users go to /dashboard.
   useEffect(() => {
     if (!isLoading && isAuthenticated && !isAllowedWhenAuthenticated) {
-      router.replace("/dashboard");
+      router.replace(onboardingRoute ?? "/dashboard");
     }
-  }, [isLoading, isAuthenticated, isAllowedWhenAuthenticated, router]);
+  }, [isLoading, isAuthenticated, isAllowedWhenAuthenticated, onboardingRoute, router]);
 
   if (isLoading) {
     return (

--- a/src/components/layouts/dashboard-layout.tsx
+++ b/src/components/layouts/dashboard-layout.tsx
@@ -195,7 +195,7 @@ function FloatingWindows() {
 }
 
 export function DashboardLayout({ children }: { children: React.ReactNode }) {
-  const { needsWebSetup, needsEmployeeOnboarding } = useSetupGate();
+  const { needsWebSetup, needsEmployeeOnboarding, onboardingRoute } = useSetupGate();
   const router = useRouter();
   const pathname = usePathname();
   const needsOnboarding = needsEmployeeOnboarding || needsWebSetup;
@@ -203,14 +203,13 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
   const fullHeightMode = resolveFullHeightMode(pathname);
   const isFullHeight = fullHeightMode !== null;
 
-  // Redirect to the appropriate onboarding flow if incomplete.
+  // Redirect to the appropriate onboarding flow if incomplete. A company-less
+  // user lands on /account-type (decision screen), never straight into /setup.
   useEffect(() => {
-    if (needsEmployeeOnboarding) {
-      router.push("/employee-setup");
-    } else if (needsWebSetup) {
-      router.push("/setup");
+    if (onboardingRoute) {
+      router.push(onboardingRoute);
     }
-  }, [needsEmployeeOnboarding, needsWebSetup, router]);
+  }, [onboardingRoute, router]);
 
   // Block all dashboard rendering while onboarding is needed.
   if (needsOnboarding) {

--- a/src/hooks/useSetupGate.ts
+++ b/src/hooks/useSetupGate.ts
@@ -14,6 +14,11 @@ import { useAuthStore } from "@/lib/store/auth-store";
  * - `needsWebSetup` — true when EMPLOYER should be redirected to /setup
  * - `needsEmployeeOnboarding` — true when EMPLOYEE should be redirected to /employee-setup
  * - `missingSteps` — granular steps missing (for SetupInterceptionModal on action-gated pages)
+ * - `onboardingRoute` — the single destination a not-yet-onboarded user belongs at,
+ *   or null when onboarding is complete. Both the (auth) AuthRouteGate and the
+ *   DashboardLayout gate consume this so the redirect target can never drift.
+ *   A company-less user lands on /account-type (the "Run a Crew" vs "Join a Crew"
+ *   decision screen) — NOT /setup, which would skip the choice.
  */
 export function useSetupGate() {
   const { currentUser } = useAuthStore();
@@ -50,10 +55,22 @@ export function useSetupGate() {
     if (!hasCompany) missingSteps.push("company");
   }
 
+  // Single source of truth for the onboarding destination. A company-less user
+  // must choose an account type first (/account-type); only once a company
+  // exists does the employer resume the wizard at /setup.
+  const onboardingRoute: string | null = needsEmployeeOnboarding
+    ? "/employee-setup"
+    : needsWebSetup
+      ? currentUser?.companyId
+        ? "/setup"
+        : "/account-type"
+      : null;
+
   return {
     isComplete: webComplete,
     needsWebSetup,
     missingSteps,
     needsEmployeeOnboarding,
+    onboardingRoute,
   };
 }

--- a/tests/unit/hooks/use-setup-gate.test.tsx
+++ b/tests/unit/hooks/use-setup-gate.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * useSetupGate — onboarding routing decision.
+ *
+ * Guards the regression where a fresh, company-less user was routed straight
+ * into company setup (/setup), skipping the documented /account-type decision
+ * screen ("Run a Crew" vs "Join a Crew"). The intended flow is:
+ *   register → /account-type → (Run a Crew → /setup) | (Join a Crew → /employee-setup)
+ *
+ * `onboardingRoute` is the single source of truth consumed by both the
+ * (auth) AuthRouteGate and the DashboardLayout gate, so the destination can
+ * never drift between the two redirect sites.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useSetupGate } from "@/hooks/useSetupGate";
+import { useAuthStore } from "@/lib/store/auth-store";
+import { UserRole } from "@/lib/types/models";
+import type { User } from "@/lib/types/models";
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "u-1",
+    firstName: "Jordan",
+    lastName: "Reyes",
+    email: "jordan@test.co",
+    phone: null,
+    profileImageURL: null,
+    role: UserRole.Unassigned,
+    companyId: null,
+    userType: null,
+    latitude: null,
+    longitude: null,
+    locationName: null,
+    homeAddress: null,
+    clientId: null,
+    isActive: true,
+    userColor: null,
+    devPermission: false,
+    onboardingCompleted: {},
+    hasCompletedAppTutorial: false,
+    isCompanyAdmin: false,
+    specialPermissions: [],
+    setupProgress: null,
+    stripeCustomerId: null,
+    deviceToken: null,
+    emergencyContactName: null,
+    emergencyContactPhone: null,
+    emergencyContactRelationship: null,
+    lastSyncedAt: null,
+    needsSync: false,
+    deletedAt: null,
+    ...overrides,
+  } as User;
+}
+
+beforeEach(() => {
+  useAuthStore.setState({
+    currentUser: null,
+    company: null,
+    isAuthenticated: false,
+    isLoading: false,
+    role: UserRole.Unassigned,
+  });
+});
+
+describe("useSetupGate — onboardingRoute", () => {
+  it("routes a fresh company-less user to /account-type (NOT /setup)", () => {
+    // The bug: this user was being sent straight to /setup, skipping the
+    // account-type decision screen.
+    useAuthStore.setState({
+      currentUser: makeUser({ companyId: null, onboardingCompleted: {} }),
+    });
+
+    const { result } = renderHook(() => useSetupGate());
+
+    expect(result.current.needsWebSetup).toBe(true);
+    expect(result.current.onboardingRoute).toBe("/account-type");
+    expect(result.current.onboardingRoute).not.toBe("/setup");
+  });
+
+  it("routes an employee (has company, not admin, employee onboarding pending) to /employee-setup", () => {
+    useAuthStore.setState({
+      currentUser: makeUser({
+        companyId: "co-1",
+        isCompanyAdmin: false,
+        onboardingCompleted: {},
+        setupProgress: { steps: {} } as User["setupProgress"],
+      }),
+    });
+
+    const { result } = renderHook(() => useSetupGate());
+
+    expect(result.current.needsEmployeeOnboarding).toBe(true);
+    expect(result.current.onboardingRoute).toBe("/employee-setup");
+  });
+
+  it("routes a resuming account holder (has company, web setup incomplete) to /setup", () => {
+    // Once a company exists (created on the 'company' step), the admin should
+    // resume the employer wizard rather than re-pick an account type.
+    useAuthStore.setState({
+      currentUser: makeUser({
+        companyId: "co-1",
+        isCompanyAdmin: true,
+        onboardingCompleted: {},
+      }),
+    });
+
+    const { result } = renderHook(() => useSetupGate());
+
+    expect(result.current.needsWebSetup).toBe(true);
+    expect(result.current.onboardingRoute).toBe("/setup");
+  });
+
+  it("returns null onboardingRoute when web onboarding is complete", () => {
+    useAuthStore.setState({
+      currentUser: makeUser({
+        companyId: "co-1",
+        isCompanyAdmin: true,
+        onboardingCompleted: { web: true },
+      }),
+    });
+
+    const { result } = renderHook(() => useSetupGate());
+
+    expect(result.current.isComplete).toBe(true);
+    expect(result.current.onboardingRoute).toBeNull();
+  });
+
+  it("does not require onboarding for a completed employee", () => {
+    useAuthStore.setState({
+      currentUser: makeUser({
+        companyId: "co-1",
+        isCompanyAdmin: false,
+        onboardingCompleted: { web: true },
+        setupProgress: { steps: { employee_onboarding: true } } as User["setupProgress"],
+      }),
+    });
+
+    const { result } = renderHook(() => useSetupGate());
+
+    expect(result.current.needsEmployeeOnboarding).toBe(false);
+    expect(result.current.onboardingRoute).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Routes a newly signed-up user who has no company to the account-type step instead of /setup.

## Test plan
- [ ] New signup with no company → lands on account-type selection.