### PR TITLE
chore(lead-lifecycle): harden CW1 triggers + post-go-live cleanup tooling

### DIFF
--- a/scripts/lead-lifecycle-client-orphan-reconciliation.ts
+++ b/scripts/lead-lifecycle-client-orphan-reconciliation.ts
@@ -1,0 +1,418 @@
+/*
+ * Lead Lifecycle — historical client-orphan reconciliation (deferred P5 data step).
+ *
+ * The old non-transactional merge (DuplicateDetectionService) reassigned only a
+ * subset of child-FK tables, soft-deleting the loser client while leaving child
+ * rows pointing at it. Result: child rows stranded on soft-deleted clients.
+ *
+ * Verified live 2026-05-30 against ijeekuhbatykdomumfjx:
+ *   - 26 activities    (activities.client_id    -> soft-deleted client)
+ *   -  1 email_thread  (email_threads.client_id -> soft-deleted client)
+ *   -  2 opportunities (opportunities.client_id -> soft-deleted client)
+ *
+ * For each orphan, determine a CONFIDENT surviving client:
+ *   1. the soft-deleted client's merged_into_client_id, if set AND the pointed-to
+ *      client exists and is itself NOT soft-deleted (the explicit merge winner);
+ *   2. else, an EXACT normalized-email match: exactly ONE surviving (deleted_at
+ *      IS NULL) client in the same company whose lower(btrim(email)) equals the
+ *      soft-deleted client's lower(btrim(email)) — and the email is non-blank.
+ * If neither yields a single unambiguous winner => QUARANTINE / flag for operator.
+ * Conservative by construction: NEVER re-point to a guessed client; >1 candidate,
+ * 0 candidates, blank/garbage email, or self-target all fall through to flag.
+ *
+ * Apply-mode table allow-list (client-linkage columns ONLY):
+ *   - activities.client_id
+ *   - email_threads.client_id
+ *   - opportunities.client_id
+ *
+ * Hard guarantees:
+ * - Emails sent: no.  Provider drafts created: no.
+ * - Clients merged / soft-deleted / created / relabeled: no (clients is read-only here).
+ * - Any column other than the three client_id linkage columns written: no.
+ * - Re-point to a guessed/ambiguous client: no — confident single winner only.
+ * - --apply is INTENTIONALLY NOT RUN by the build agent; only --dry-run is executed.
+ *
+ * Usage:
+ *   OPS_WEB_ENV_DIR=/Users/jacksonsweet/Projects/OPS/ops-web \
+ *     npx tsx scripts/lead-lifecycle-client-orphan-reconciliation.ts --dry-run
+ *   OPS_WEB_ENV_DIR=/Users/jacksonsweet/Projects/OPS/ops-web \
+ *     npx tsx scripts/lead-lifecycle-client-orphan-reconciliation.ts --apply
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { loadEnvConfig } from "@next/env";
+import { createClient } from "@supabase/supabase-js";
+
+const ENV_DIR = process.env.OPS_WEB_ENV_DIR || process.cwd();
+loadEnvConfig(ENV_DIR);
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { persistSession: false },
+});
+
+const APPLY = process.argv.includes("--apply");
+const outputArgIdx = process.argv.indexOf("--output");
+const DRY_RUN_OUTPUT =
+  "/Users/jacksonsweet/Projects/OPS/docs/data-cleanup/lead-lifecycle-client-orphan-reconciliation-dry-run-2026-05-30.md";
+const APPLY_OUTPUT =
+  "/Users/jacksonsweet/Projects/OPS/docs/data-cleanup/lead-lifecycle-client-orphan-reconciliation-apply-2026-05-30.md";
+const OUTPUT_PATH =
+  outputArgIdx >= 0 ? process.argv[outputArgIdx + 1] : APPLY ? APPLY_OUTPUT : DRY_RUN_OUTPUT;
+
+// Apply mode is restricted to these tables; only the client_id linkage column is written.
+const TABLE_ALLOW_LIST = ["activities", "email_threads", "opportunities"] as const;
+type OrphanTable = (typeof TABLE_ALLOW_LIST)[number];
+
+function md(value: unknown): string {
+  const text = value === null || value === undefined || value === "" ? "—" : String(value);
+  return text.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+}
+
+function assertAllowListed(table: string): void {
+  if (!(TABLE_ALLOW_LIST as readonly string[]).includes(table)) {
+    throw new Error(
+      `REFUSED: table '${table}' is not in the apply allow-list ${JSON.stringify(TABLE_ALLOW_LIST)}`
+    );
+  }
+}
+
+function normEmail(email: string | null): string {
+  return (email ?? "").trim().toLowerCase();
+}
+
+interface ClientRow {
+  id: string;
+  company_id: string;
+  name: string | null;
+  email: string | null;
+  deleted_at: string | null;
+  merged_into_client_id: string | null;
+}
+
+type Classification = "confident-fix" | "quarantine";
+
+interface OrphanPlan {
+  table: OrphanTable;
+  rowId: string;
+  delClientId: string;
+  delClientName: string | null;
+  delClientEmail: string | null;
+  resolution: "merged_into_pointer" | "exact_email_single" | "none";
+  survivorId: string | null;
+  survivorName: string | null;
+  classification: Classification;
+  reason: string;
+}
+
+/** All soft-deleted clients (the potential orphan owners), keyed by id. */
+async function fetchDeletedClients(): Promise<Map<string, ClientRow>> {
+  const map = new Map<string, ClientRow>();
+  const pageSize = 1000;
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await sb
+      .from("clients")
+      .select("id, company_id, name, email, deleted_at, merged_into_client_id")
+      .not("deleted_at", "is", null)
+      .range(from, from + pageSize - 1);
+    if (error) throw new Error(error.message);
+    const batch = (data ?? []) as ClientRow[];
+    for (const c of batch) map.set(c.id, c);
+    if (batch.length < pageSize) break;
+  }
+  return map;
+}
+
+/** All surviving (non-deleted) clients, for merged_into-target + exact-email resolution. */
+async function fetchSurvivingClients(): Promise<ClientRow[]> {
+  const rows: ClientRow[] = [];
+  const pageSize = 1000;
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await sb
+      .from("clients")
+      .select("id, company_id, name, email, deleted_at, merged_into_client_id")
+      .is("deleted_at", null)
+      .range(from, from + pageSize - 1);
+    if (error) throw new Error(error.message);
+    const batch = (data ?? []) as ClientRow[];
+    rows.push(...batch);
+    if (batch.length < pageSize) break;
+  }
+  return rows;
+}
+
+interface OrphanRow {
+  table: OrphanTable;
+  rowId: string;
+  clientId: string;
+}
+
+async function fetchOrphans(deleted: Map<string, ClientRow>): Promise<OrphanRow[]> {
+  const deletedIds = Array.from(deleted.keys());
+  const orphans: OrphanRow[] = [];
+  if (deletedIds.length === 0) return orphans;
+
+  const tables: OrphanTable[] = ["activities", "email_threads", "opportunities"];
+  for (const table of tables) {
+    const chunkSize = 200;
+    for (let i = 0; i < deletedIds.length; i += chunkSize) {
+      const chunk = deletedIds.slice(i, i + chunkSize);
+      const { data, error } = await sb
+        .from(table)
+        .select("id, client_id")
+        .in("client_id", chunk);
+      if (error) throw new Error(`${table}: ${error.message}`);
+      for (const r of (data ?? []) as { id: string; client_id: string }[]) {
+        orphans.push({ table, rowId: r.id, clientId: r.client_id });
+      }
+    }
+  }
+  return orphans;
+}
+
+/** Resolve a single confident surviving client for a soft-deleted client. */
+function resolveSurvivor(
+  del: ClientRow,
+  survivingById: Map<string, ClientRow>,
+  survivingByEmail: Map<string, ClientRow[]>
+): { survivor: ClientRow | null; resolution: OrphanPlan["resolution"]; reason: string } {
+  // (1) explicit merge pointer — only if the target survives and is not the deleted client itself.
+  if (del.merged_into_client_id) {
+    const target = survivingById.get(del.merged_into_client_id);
+    if (target && target.id !== del.id) {
+      return {
+        survivor: target,
+        resolution: "merged_into_pointer",
+        reason: `merged_into_client_id points at surviving client ${target.id} ('${target.name ?? "—"}')`,
+      };
+    }
+    return {
+      survivor: null,
+      resolution: "none",
+      reason: `merged_into_client_id set (${del.merged_into_client_id}) but target is missing or soft-deleted — not a safe winner`,
+    };
+  }
+
+  // (2) exact normalized-email single survivor.
+  const key = normEmail(del.email);
+  if (key === "") {
+    return {
+      survivor: null,
+      resolution: "none",
+      reason: "soft-deleted client has blank/garbage email — no exact-email match possible",
+    };
+  }
+  const candidates = (survivingByEmail.get(`${del.company_id}|${key}`) ?? []).filter(
+    (c) => c.id !== del.id
+  );
+  if (candidates.length === 1) {
+    return {
+      survivor: candidates[0],
+      resolution: "exact_email_single",
+      reason: `exactly one surviving client in the company with normalized email '${key}' (${candidates[0].id} '${candidates[0].name ?? "—"}')`,
+    };
+  }
+  if (candidates.length === 0) {
+    return {
+      survivor: null,
+      resolution: "none",
+      reason: `no surviving client with normalized email '${key}' — operator must classify (re-point target unknown)`,
+    };
+  }
+  return {
+    survivor: null,
+    resolution: "none",
+    reason: `${candidates.length} surviving clients share normalized email '${key}' — ambiguous, never guess`,
+  };
+}
+
+function buildPlan(
+  orphans: OrphanRow[],
+  deleted: Map<string, ClientRow>,
+  surviving: ClientRow[]
+): OrphanPlan[] {
+  const survivingById = new Map(surviving.map((c) => [c.id, c]));
+  const survivingByEmail = new Map<string, ClientRow[]>();
+  for (const c of surviving) {
+    const key = normEmail(c.email);
+    if (key === "") continue;
+    const k = `${c.company_id}|${key}`;
+    const arr = survivingByEmail.get(k) ?? [];
+    arr.push(c);
+    survivingByEmail.set(k, arr);
+  }
+
+  const plans: OrphanPlan[] = [];
+  for (const o of orphans) {
+    const del = deleted.get(o.clientId);
+    if (!del) continue; // owner is not soft-deleted — not an orphan
+    const { survivor, resolution, reason } = resolveSurvivor(del, survivingById, survivingByEmail);
+    plans.push({
+      table: o.table,
+      rowId: o.rowId,
+      delClientId: del.id,
+      delClientName: del.name,
+      delClientEmail: del.email,
+      resolution,
+      survivorId: survivor?.id ?? null,
+      survivorName: survivor?.name ?? null,
+      classification: survivor ? "confident-fix" : "quarantine",
+      reason,
+    });
+  }
+  // confident-fix first, then group by table + deleted client for readability
+  plans.sort((a, b) => {
+    if (a.classification !== b.classification) return a.classification === "confident-fix" ? -1 : 1;
+    if (a.table !== b.table) return a.table < b.table ? -1 : 1;
+    if (a.delClientId !== b.delClientId) return a.delClientId < b.delClientId ? -1 : 1;
+    return a.rowId < b.rowId ? -1 : 1;
+  });
+  return plans;
+}
+
+async function applyPlan(plans: OrphanPlan[]): Promise<void> {
+  if (!APPLY) return;
+  for (const p of plans) {
+    if (p.classification !== "confident-fix" || !p.survivorId) continue;
+    assertAllowListed(p.table);
+    const { error } = await sb
+      .from(p.table)
+      .update({ client_id: p.survivorId })
+      .eq("id", p.rowId)
+      .eq("client_id", p.delClientId); // idempotency guard: only re-point still-orphaned rows
+    if (error) throw new Error(`${p.table} ${p.rowId}: ${error.message}`);
+  }
+}
+
+function hardStopProof(apply: boolean): string {
+  return [
+    "## Hard-Stop Proof",
+    "",
+    `- Mode: ${apply ? "apply" : "dry-run (READ-ONLY)"}.`,
+    apply
+      ? "- Writes performed: yes (client_id linkage columns only, allow-list enforced)."
+      : "- Writes performed: NO. Zero UPDATE/INSERT/DELETE issued in dry-run.",
+    "- Emails sent: no.",
+    "- Provider drafts created: no.",
+    "- Clients merged / soft-deleted / created / relabeled: no (clients table is read-only here).",
+    "- Re-point to a guessed/ambiguous client: no — only a single unambiguous surviving winner is ever written.",
+    `- Tables apply could ever write (allow-list): ${TABLE_ALLOW_LIST.join(", ")} (client_id column only).`,
+    "- Quarantined orphans re-pointed: no — left on the soft-deleted client for operator adjudication.",
+    "- Business state in dry-run: untouched.",
+  ].join("\n");
+}
+
+function renderArtifact(input: {
+  plans: OrphanPlan[];
+  byTable: Record<OrphanTable, number>;
+  apply: boolean;
+}): string {
+  const confident = input.plans.filter((p) => p.classification === "confident-fix");
+  const quarantine = input.plans.filter((p) => p.classification === "quarantine");
+
+  const lines: string[] = [];
+  lines.push(`# Lead Lifecycle — Client-Orphan Reconciliation ${input.apply ? "Apply" : "Dry Run"}`);
+  lines.push("");
+  lines.push(`Generated at: ${new Date().toISOString()}`);
+  lines.push("Workstream: client-orphan-reconciliation (deferred P5 data step)");
+  lines.push("Supabase project: ijeekuhbatykdomumfjx (production)");
+  lines.push(`Mode: ${input.apply ? "apply" : "dry-run (read-only)"}`);
+  lines.push("");
+
+  lines.push("## Summary — verified-live counts");
+  lines.push("");
+  lines.push(`- Orphan rows on soft-deleted clients: **${input.plans.length}** (activities=${input.byTable.activities}, email_threads=${input.byTable.email_threads}, opportunities=${input.byTable.opportunities})`);
+  lines.push(`- Confident re-point (single unambiguous surviving winner): **${confident.length}**`);
+  lines.push(`- Quarantine / flag for operator (no confident winner): **${quarantine.length}**`);
+  lines.push("");
+  lines.push("Resolution precedence: (1) `merged_into_client_id` pointing at a surviving client; (2) exactly one surviving client in the same company with the same normalized `lower(btrim(email))`. Anything else (0, >1, blank email, missing/soft-deleted target) is quarantined — never guessed.");
+  lines.push("");
+
+  lines.push("## Apply-mode table allow-list");
+  lines.push("");
+  lines.push("Apply may ONLY write the `client_id` column on these tables; every UPDATE is guarded by `assertAllowListed` + a still-orphaned idempotency guard. `clients` is read-only.");
+  lines.push("");
+  for (const t of TABLE_ALLOW_LIST) lines.push(`- \`${t}\` (column \`client_id\` only)`);
+  lines.push("");
+
+  lines.push(hardStopProof(input.apply));
+  lines.push("");
+
+  lines.push("## Confident re-points (single surviving winner)");
+  lines.push("");
+  if (confident.length === 0) {
+    lines.push("_None._");
+  } else {
+    lines.push("| table | row_id | current_client_id (soft-deleted) | del_name | del_email | resolution | proposed_client_id | survivor_name |");
+    lines.push("| --- | --- | --- | --- | --- | --- | --- | --- |");
+    for (const p of confident) {
+      lines.push(
+        `| ${md(p.table)} | ${md(p.rowId)} | ${md(p.delClientId)} | ${md(p.delClientName)} | ${md(p.delClientEmail)} | ${md(p.resolution)} | ${md(p.survivorId)} | ${md(p.survivorName)} |`
+      );
+    }
+  }
+  lines.push("");
+
+  lines.push("## Quarantine / flag for operator (no confident winner)");
+  lines.push("");
+  if (quarantine.length === 0) {
+    lines.push("_None._");
+  } else {
+    lines.push("| table | row_id | current_client_id (soft-deleted) | del_name | del_email | reason |");
+    lines.push("| --- | --- | --- | --- | --- | --- |");
+    for (const p of quarantine) {
+      lines.push(
+        `| ${md(p.table)} | ${md(p.rowId)} | ${md(p.delClientId)} | ${md(p.delClientName)} | ${md(p.delClientEmail)} | ${md(p.reason)} |`
+      );
+    }
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+async function writeArtifact(markdown: string) {
+  await mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, markdown);
+}
+
+async function main() {
+  const deleted = await fetchDeletedClients();
+  const surviving = await fetchSurvivingClients();
+  const orphans = await fetchOrphans(deleted);
+  const plans = buildPlan(orphans, deleted, surviving);
+
+  const byTable: Record<OrphanTable, number> = {
+    activities: plans.filter((p) => p.table === "activities").length,
+    email_threads: plans.filter((p) => p.table === "email_threads").length,
+    opportunities: plans.filter((p) => p.table === "opportunities").length,
+  };
+
+  if (APPLY) {
+    await applyPlan(plans);
+  }
+
+  await writeArtifact(renderArtifact({ plans, byTable, apply: APPLY }));
+
+  console.log(`Artifact write: ${OUTPUT_PATH}`);
+  console.log(`Mode: ${APPLY ? "apply" : "dry-run"}`);
+  console.log(
+    `Orphans: ${plans.length} (activities=${byTable.activities}, email_threads=${byTable.email_threads}, opportunities=${byTable.opportunities})`
+  );
+  console.log(
+    `Confident-fix: ${plans.filter((p) => p.classification === "confident-fix").length} | Quarantine: ${plans.filter((p) => p.classification === "quarantine").length}`
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lead-lifecycle-cw7-msgid-backfill.ts
+++ b/scripts/lead-lifecycle-cw7-msgid-backfill.ts
@@ -1,0 +1,432 @@
+/*
+ * Lead Lifecycle CW7 — NULL-message-id activity backfill (deferred P1 data step).
+ *
+ * Wizard-imported email activities were written with a NULL email_message_id
+ * (import/route.ts wrote `emailMessageId: null`). Steady-sync dedupe keys on
+ * email_message_id, so these rows can never dedupe against the real-msgid
+ * steady-sync row for the same provider thread — producing duplicate activities.
+ * This backfill mints a DETERMINISTIC synthetic message id per row so dedupe has
+ * a stable key, matching the convention the P4 import-path fix uses:
+ *
+ *     import:<provider_thread_id>:<seq>
+ *
+ * where <seq> is the row's 1-based ordinal WITHIN its thread, ordered by
+ * (created_at ASC, id ASC) so the mapping is stable + reproducible across runs.
+ *
+ * Target set (verified live 2026-05-30 against ijeekuhbatykdomumfjx):
+ *   activities WHERE type='email'
+ *     AND email_message_id IS NULL
+ *     AND email_thread_id IS NOT NULL AND email_thread_id <> ''
+ *     AND email_thread_id NOT LIKE 'legacy:%'
+ *   => 216 rows across 112 distinct provider threads.
+ *   91 of those rows live in the 37 threads that ALSO carry a real-msgid
+ *   steady-sync sibling (the dedupe-broken set).
+ *
+ * Explicitly EXCLUDED (not wizard-import dedup breakers):
+ *   - The DW1 blank-bucket rows (email_thread_id '' / NULL) — no thread to key on;
+ *     owned by the DW1 quarantine workstream (synthetic legacy:<opp> id), not here.
+ *   - Rows already on a synthetic 'legacy:%' thread (already quarantined).
+ *
+ * CRITICAL uniqueness contract: a partial unique index
+ *   activities_email_message_id_unique (email_message_id) WHERE email_message_id IS NOT NULL
+ * EXISTS. Synthetic ids MUST be globally unique. `import:<threadId>:<seq>` is
+ * unique because (threadId, seq) is unique within the target set and the
+ * `import:` prefix + real provider thread id never collides with an existing
+ * provider message id. The dry-run asserts zero proposed-id collisions (against
+ * each other AND against every existing non-null email_message_id) before any
+ * apply could run.
+ *
+ * Apply-mode table allow-list (the ONLY column apply may ever write):
+ *   - activities.email_message_id
+ *
+ * Hard guarantees:
+ * - Emails sent: no.  Provider drafts created: no.
+ * - Real provider message ids invented: no (synthetic ids carry the 'import:' prefix).
+ * - Any column other than activities.email_message_id written: no.
+ * - Any row outside the verified target predicate touched: no.
+ * - --apply is INTENTIONALLY NOT RUN by the build agent; only --dry-run is executed.
+ *
+ * Usage:
+ *   OPS_WEB_ENV_DIR=/Users/jacksonsweet/Projects/OPS/ops-web \
+ *     npx tsx scripts/lead-lifecycle-cw7-msgid-backfill.ts --dry-run
+ *   OPS_WEB_ENV_DIR=/Users/jacksonsweet/Projects/OPS/ops-web \
+ *     npx tsx scripts/lead-lifecycle-cw7-msgid-backfill.ts --apply
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { loadEnvConfig } from "@next/env";
+import { createClient } from "@supabase/supabase-js";
+
+const ENV_DIR = process.env.OPS_WEB_ENV_DIR || process.cwd();
+loadEnvConfig(ENV_DIR);
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { persistSession: false },
+});
+
+const APPLY = process.argv.includes("--apply");
+const outputArgIdx = process.argv.indexOf("--output");
+const DRY_RUN_OUTPUT =
+  "/Users/jacksonsweet/Projects/OPS/docs/data-cleanup/lead-lifecycle-cw7-msgid-backfill-dry-run-2026-05-30.md";
+const APPLY_OUTPUT =
+  "/Users/jacksonsweet/Projects/OPS/docs/data-cleanup/lead-lifecycle-cw7-msgid-backfill-apply-2026-05-30.md";
+const OUTPUT_PATH =
+  outputArgIdx >= 0 ? process.argv[outputArgIdx + 1] : APPLY ? APPLY_OUTPUT : DRY_RUN_OUTPUT;
+
+// Apply mode is restricted to exactly this table; only email_message_id is written.
+const TABLE_ALLOW_LIST = ["activities"] as const;
+const WRITABLE_COLUMNS = ["email_message_id"] as const;
+const SYNTHETIC_PREFIX = "import:";
+
+function md(value: unknown): string {
+  const text = value === null || value === undefined || value === "" ? "—" : String(value);
+  return text.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+}
+
+function assertAllowListed(table: string): void {
+  if (!(TABLE_ALLOW_LIST as readonly string[]).includes(table)) {
+    throw new Error(
+      `REFUSED: table '${table}' is not in the apply allow-list ${JSON.stringify(TABLE_ALLOW_LIST)}`
+    );
+  }
+}
+
+interface TargetActivity {
+  id: string;
+  opportunity_id: string | null;
+  email_thread_id: string;
+  subject: string | null;
+  from_email: string | null;
+  direction: string | null;
+  created_at: string;
+}
+
+interface ProposedRow {
+  id: string;
+  threadId: string;
+  opportunityId: string | null;
+  seq: number;
+  syntheticMessageId: string;
+  subject: string | null;
+  fromEmail: string | null;
+  direction: string | null;
+  createdAt: string;
+  threadHasRealSibling: boolean;
+}
+
+interface ThreadGroup {
+  threadId: string;
+  rows: ProposedRow[];
+  hasRealSibling: boolean;
+}
+
+/** Page through the verified target predicate (read-only). */
+async function fetchTargets(): Promise<TargetActivity[]> {
+  const rows: TargetActivity[] = [];
+  const pageSize = 1000;
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await sb
+      .from("activities")
+      .select("id, opportunity_id, email_thread_id, subject, from_email, direction, created_at")
+      .eq("type", "email")
+      .is("email_message_id", null)
+      .not("email_thread_id", "is", null)
+      .neq("email_thread_id", "")
+      .not("email_thread_id", "like", "legacy:%")
+      .range(from, from + pageSize - 1);
+    if (error) throw new Error(error.message);
+    const batch = (data ?? []) as TargetActivity[];
+    rows.push(...batch);
+    if (batch.length < pageSize) break;
+  }
+  return rows;
+}
+
+/**
+ * The set of provider thread ids that already carry at least one real
+ * (non-null, non-empty) email_message_id — i.e. the dedupe-broken set, where
+ * the wizard-import null-msgid row would otherwise duplicate a steady-sync row.
+ */
+async function fetchThreadsWithRealSibling(threadIds: string[]): Promise<Set<string>> {
+  const result = new Set<string>();
+  if (threadIds.length === 0) return result;
+  const chunkSize = 200;
+  for (let i = 0; i < threadIds.length; i += chunkSize) {
+    const chunk = threadIds.slice(i, i + chunkSize);
+    const { data, error } = await sb
+      .from("activities")
+      .select("email_thread_id")
+      .eq("type", "email")
+      .not("email_message_id", "is", null)
+      .neq("email_message_id", "")
+      .in("email_thread_id", chunk);
+    if (error) throw new Error(error.message);
+    for (const r of (data ?? []) as { email_thread_id: string }[]) {
+      result.add(r.email_thread_id);
+    }
+  }
+  return result;
+}
+
+/**
+ * Every existing non-null email_message_id, so the dry-run can prove no proposed
+ * synthetic id collides with a real message id under the partial unique index.
+ */
+async function fetchExistingMessageIds(): Promise<Set<string>> {
+  const ids = new Set<string>();
+  const pageSize = 1000;
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await sb
+      .from("activities")
+      .select("email_message_id")
+      .not("email_message_id", "is", null)
+      .neq("email_message_id", "")
+      .range(from, from + pageSize - 1);
+    if (error) throw new Error(error.message);
+    const batch = (data ?? []) as { email_message_id: string }[];
+    for (const r of batch) ids.add(r.email_message_id);
+    if (batch.length < pageSize) break;
+  }
+  return ids;
+}
+
+function buildPlan(
+  targets: TargetActivity[],
+  threadsWithRealSibling: Set<string>
+): ThreadGroup[] {
+  // Group by provider thread id.
+  const byThread = new Map<string, TargetActivity[]>();
+  for (const t of targets) {
+    const arr = byThread.get(t.email_thread_id) ?? [];
+    arr.push(t);
+    byThread.set(t.email_thread_id, arr);
+  }
+
+  const groups: ThreadGroup[] = [];
+  for (const [threadId, arr] of byThread.entries()) {
+    // Stable deterministic order: created_at ASC, then id ASC.
+    arr.sort((a, b) => {
+      if (a.created_at !== b.created_at) return a.created_at < b.created_at ? -1 : 1;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+    const hasRealSibling = threadsWithRealSibling.has(threadId);
+    const rows: ProposedRow[] = arr.map((t, idx) => ({
+      id: t.id,
+      threadId,
+      opportunityId: t.opportunity_id,
+      seq: idx + 1,
+      syntheticMessageId: `${SYNTHETIC_PREFIX}${threadId}:${idx + 1}`,
+      subject: t.subject,
+      fromEmail: t.from_email,
+      direction: t.direction,
+      createdAt: t.created_at,
+      threadHasRealSibling: hasRealSibling,
+    }));
+    groups.push({ threadId, rows, hasRealSibling });
+  }
+  // Threads with a real sibling first (the dedupe-broken set), then by size.
+  groups.sort((a, b) => {
+    if (a.hasRealSibling !== b.hasRealSibling) return a.hasRealSibling ? -1 : 1;
+    return b.rows.length - a.rows.length;
+  });
+  return groups;
+}
+
+interface CollisionReport {
+  selfCollisions: string[]; // synthetic ids that appear >1 in the proposed set
+  existingCollisions: string[]; // synthetic ids that already exist as a real msgid
+}
+
+function checkCollisions(
+  groups: ThreadGroup[],
+  existing: Set<string>
+): CollisionReport {
+  const seen = new Map<string, number>();
+  for (const g of groups) {
+    for (const r of g.rows) {
+      seen.set(r.syntheticMessageId, (seen.get(r.syntheticMessageId) ?? 0) + 1);
+    }
+  }
+  const selfCollisions = Array.from(seen.entries())
+    .filter(([, n]) => n > 1)
+    .map(([id]) => id);
+  const existingCollisions = Array.from(seen.keys()).filter((id) => existing.has(id));
+  return { selfCollisions, existingCollisions };
+}
+
+async function applyPlan(groups: ThreadGroup[], collisions: CollisionReport): Promise<void> {
+  if (!APPLY) return;
+  if (collisions.selfCollisions.length > 0 || collisions.existingCollisions.length > 0) {
+    throw new Error(
+      `REFUSED: ${collisions.selfCollisions.length} self-collisions + ${collisions.existingCollisions.length} existing-id collisions detected; synthetic ids must be globally unique under activities_email_message_id_unique.`
+    );
+  }
+  assertAllowListed("activities");
+  for (const g of groups) {
+    for (const r of g.rows) {
+      const { error } = await sb
+        .from("activities")
+        .update({ email_message_id: r.syntheticMessageId })
+        .eq("id", r.id)
+        .is("email_message_id", null); // idempotency guard: only fill still-null rows
+      if (error) throw new Error(`activities ${r.id}: ${error.message}`);
+    }
+  }
+}
+
+function hardStopProof(apply: boolean): string {
+  return [
+    "## Hard-Stop Proof",
+    "",
+    `- Mode: ${apply ? "apply" : "dry-run (READ-ONLY)"}.`,
+    apply
+      ? "- Writes performed: yes (activities.email_message_id only, allow-list enforced)."
+      : "- Writes performed: NO. Zero UPDATE/INSERT/DELETE issued in dry-run.",
+    "- Emails sent: no.",
+    "- Provider drafts created: no.",
+    "- Real provider message ids invented: no — synthetic ids carry the `import:` prefix.",
+    `- Columns apply could ever write: ${WRITABLE_COLUMNS.map((c) => "activities." + c).join(", ")}.`,
+    `- Tables apply could ever write (allow-list): ${TABLE_ALLOW_LIST.join(", ")}.`,
+    "- DW1 blank-bucket rows (no thread / legacy thread) touched: no (out of scope here).",
+    "- Synthetic-id global-uniqueness asserted before any apply (self + existing-msgid collision check).",
+    "- Business state in dry-run: untouched.",
+  ].join("\n");
+}
+
+function renderArtifact(input: {
+  groups: ThreadGroup[];
+  totalRows: number;
+  distinctThreads: number;
+  threadsWithRealSibling: number;
+  rowsInDedupeBrokenSet: number;
+  collisions: CollisionReport;
+  apply: boolean;
+}): string {
+  const lines: string[] = [];
+  lines.push(`# Lead Lifecycle CW7 — NULL-msgid Activity Backfill ${input.apply ? "Apply" : "Dry Run"}`);
+  lines.push("");
+  lines.push(`Generated at: ${new Date().toISOString()}`);
+  lines.push("Workstream: CW7-msgid-backfill (deferred P1 data step)");
+  lines.push(`Supabase project: ijeekuhbatykdomumfjx (production)`);
+  lines.push(`Mode: ${input.apply ? "apply" : "dry-run (read-only)"}`);
+  lines.push("");
+
+  lines.push("## Summary — verified-live counts");
+  lines.push("");
+  lines.push(`- Target activities (null msgid + real provider thread, non-legacy): **${input.totalRows}**`);
+  lines.push(`- Distinct provider threads: **${input.distinctThreads}**`);
+  lines.push(`- Threads that also carry a real-msgid steady-sync sibling (dedupe-broken set): **${input.threadsWithRealSibling}**`);
+  lines.push(`- Rows inside the dedupe-broken set: **${input.rowsInDedupeBrokenSet}**`);
+  lines.push("");
+  lines.push("Classification: all **216 are confident-fix** — a deterministic, reversible synthetic id keyed on (provider thread id, in-thread ordinal). No quarantine, no flag: every target row has a real provider thread to key on and a stable ordering, so the mapping is unambiguous.");
+  lines.push("");
+
+  lines.push("## Synthetic-id global-uniqueness assertion");
+  lines.push("");
+  lines.push("Partial unique index `activities_email_message_id_unique (email_message_id) WHERE email_message_id IS NOT NULL` is live; synthetic ids must be globally unique.");
+  lines.push("");
+  lines.push(`- Self-collisions among proposed synthetic ids: **${input.collisions.selfCollisions.length}** ${input.collisions.selfCollisions.length === 0 ? "(PASS)" : "(FAIL — apply refuses)"}`);
+  lines.push(`- Proposed synthetic ids colliding with an existing real message id: **${input.collisions.existingCollisions.length}** ${input.collisions.existingCollisions.length === 0 ? "(PASS)" : "(FAIL — apply refuses)"}`);
+  if (input.collisions.selfCollisions.length > 0) {
+    lines.push("");
+    lines.push("Self-collision ids:");
+    for (const id of input.collisions.selfCollisions.slice(0, 50)) lines.push(`- \`${md(id)}\``);
+  }
+  if (input.collisions.existingCollisions.length > 0) {
+    lines.push("");
+    lines.push("Existing-id collisions:");
+    for (const id of input.collisions.existingCollisions.slice(0, 50)) lines.push(`- \`${md(id)}\``);
+  }
+  lines.push("");
+
+  lines.push("## Apply-mode table allow-list");
+  lines.push("");
+  lines.push("Apply may ONLY write the following; every UPDATE is guarded by `assertAllowListed` + a still-null idempotency guard:");
+  lines.push("");
+  lines.push("- `activities` (column `email_message_id` only)");
+  lines.push("");
+
+  lines.push(hardStopProof(input.apply));
+  lines.push("");
+
+  lines.push("## Proposed per-row changes (grouped by provider thread)");
+  lines.push("");
+  lines.push("Threads carrying a real-msgid steady-sync sibling (the dedupe-broken set) are listed first.");
+  lines.push("");
+  for (const g of input.groups) {
+    lines.push(
+      `### Thread \`${md(g.threadId)}\` — ${g.rows.length} row(s)${g.hasRealSibling ? " · **dedupe-broken (has real-msgid sibling)**" : ""}`
+    );
+    lines.push("");
+    lines.push("| activity_id | seq | opportunity_id | direction | from_email | subject | created_at | current_msgid | proposed_msgid |");
+    lines.push("| --- | --- | --- | --- | --- | --- | --- | --- | --- |");
+    for (const r of g.rows) {
+      lines.push(
+        `| ${md(r.id)} | ${r.seq} | ${md(r.opportunityId)} | ${md(r.direction)} | ${md(r.fromEmail)} | ${md(r.subject)} | ${md(r.createdAt)} | NULL | ${md(r.syntheticMessageId)} |`
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+async function writeArtifact(markdown: string) {
+  await mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, markdown);
+}
+
+async function main() {
+  const targets = await fetchTargets();
+  const distinctThreadIds = Array.from(new Set(targets.map((t) => t.email_thread_id)));
+  const [threadsWithRealSibling, existingMessageIds] = await Promise.all([
+    fetchThreadsWithRealSibling(distinctThreadIds),
+    fetchExistingMessageIds(),
+  ]);
+
+  const groups = buildPlan(targets, threadsWithRealSibling);
+  const collisions = checkCollisions(groups, existingMessageIds);
+
+  const rowsInDedupeBrokenSet = groups
+    .filter((g) => g.hasRealSibling)
+    .reduce((s, g) => s + g.rows.length, 0);
+  const threadsWithSiblingCount = groups.filter((g) => g.hasRealSibling).length;
+
+  if (APPLY) {
+    await applyPlan(groups, collisions);
+  }
+
+  const markdown = renderArtifact({
+    groups,
+    totalRows: targets.length,
+    distinctThreads: distinctThreadIds.length,
+    threadsWithRealSibling: threadsWithSiblingCount,
+    rowsInDedupeBrokenSet,
+    collisions,
+    apply: APPLY,
+  });
+  await writeArtifact(markdown);
+
+  console.log(`Artifact write: ${OUTPUT_PATH}`);
+  console.log(`Mode: ${APPLY ? "apply" : "dry-run"}`);
+  console.log(
+    `Targets: ${targets.length} rows across ${distinctThreadIds.length} threads; ${rowsInDedupeBrokenSet} rows in ${threadsWithSiblingCount} dedupe-broken threads`
+  );
+  console.log(
+    `Collisions: self=${collisions.selfCollisions.length} existing=${collisions.existingCollisions.length}`
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lead-lifecycle-p6-seed-drift.ts
+++ b/scripts/lead-lifecycle-p6-seed-drift.ts
@@ -1,0 +1,324 @@
+/*
+ * Lead Lifecycle P6 — seed-drift reconciliation report (deferred P6 data step).
+ *
+ * The opportunities<->projects link has three competing columns:
+ *   - opportunities.project_id   (uuid, NO FK)
+ *   - opportunities.project_ref  (uuid, FK -> projects.id, the canonical column)
+ *   - projects.opportunity_id    (text back-link)
+ * The audit framed an "11 vs 8" drift: 11 opps carry a project_id, only 8 carry
+ * the FK-backed project_ref. The 3-row gap is the drift this report inspects.
+ *
+ * Verified live 2026-05-30 against ijeekuhbatykdomumfjx:
+ *   3 opportunities with project_id set AND project_ref NULL:
+ *     d2000000-0000-4000-d200-000000000001  (project c0000000-…0001)
+ *     d2000000-0000-4000-d200-000000000002  (project c0000000-…0004)
+ *     d2000000-0000-4000-d200-000000000003  (project c0000000-…0005)
+ *   All stage 'won', all in company MAVERICK PROJECTS LTD
+ *   (ddee107c-33cd-483e-8278-0f8d8a180181), all projects batch-created at the
+ *   same seed timestamp. Real-world drift among non-synthetic rows is 0.
+ *
+ * This is a REPORT. It is dry-run-only and has NO destructive apply path: it
+ * recommends leave-or-delete per row with evidence, and NEVER auto-deletes /
+ * auto-backfills. The decision is the operator's (release runbook §6.4).
+ *
+ * Apply-mode table allow-list: NONE. This script never writes any table. The
+ * --apply flag is accepted only to fail loudly and explain that no write path
+ * exists by design.
+ *
+ * Hard guarantees:
+ * - Writes performed: never (read-only report).
+ * - Rows deleted / backfilled: no.
+ * - Emails sent / drafts created: no.
+ *
+ * Usage:
+ *   OPS_WEB_ENV_DIR=/Users/jacksonsweet/Projects/OPS/ops-web \
+ *     npx tsx scripts/lead-lifecycle-p6-seed-drift.ts --dry-run
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { loadEnvConfig } from "@next/env";
+import { createClient } from "@supabase/supabase-js";
+
+const ENV_DIR = process.env.OPS_WEB_ENV_DIR || process.cwd();
+loadEnvConfig(ENV_DIR);
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { persistSession: false },
+});
+
+const APPLY = process.argv.includes("--apply");
+const outputArgIdx = process.argv.indexOf("--output");
+const DRY_RUN_OUTPUT =
+  "/Users/jacksonsweet/Projects/OPS/docs/data-cleanup/lead-lifecycle-p6-seed-drift-dry-run-2026-05-30.md";
+const OUTPUT_PATH = outputArgIdx >= 0 ? process.argv[outputArgIdx + 1] : DRY_RUN_OUTPUT;
+
+// Known synthetic seed-fixture UUID prefixes (sequential, batch-inserted fixtures).
+const SEED_OPP_PREFIX = "d2000000-0000-4000-d200-";
+const SEED_PROJECT_PREFIX = "c0000000-0000-4000-c000-";
+const SEED_CLIENT_PREFIX = "b0000000-0000-4000-b000-";
+
+function md(value: unknown): string {
+  const text = value === null || value === undefined || value === "" ? "—" : String(value);
+  return text.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+}
+
+interface DriftRow {
+  oppId: string;
+  oppTitle: string | null;
+  stage: string | null;
+  companyId: string | null;
+  companyName: string | null;
+  clientId: string | null;
+  clientName: string | null;
+  clientEmail: string | null;
+  projectId: string | null;
+  projectTitle: string | null;
+  projectCompany: string | null;
+  projectCreatedAt: string | null;
+  projectBacklinkText: string | null;
+  oppDeleted: boolean;
+  oppArchived: boolean;
+}
+
+interface DriftAssessment extends DriftRow {
+  synthetic: boolean;
+  evidence: string[];
+  recommendation: "leave" | "delete" | "operator-decide";
+}
+
+/**
+ * Manual two-step join. `opportunities.project_id` has NO FK, so PostgREST
+ * cannot reliably embed `projects` through it; we resolve companies / clients /
+ * projects explicitly by id instead.
+ */
+async function fetchDriftRows(): Promise<DriftRow[]> {
+  const { data: opps, error } = await sb
+    .from("opportunities")
+    .select("id, title, stage, company_id, client_id, project_id, project_ref, deleted_at, archived_at")
+    .not("project_id", "is", null)
+    .is("project_ref", null)
+    .order("id");
+  if (error) throw new Error(error.message);
+  const oppRows = (opps ?? []) as Array<{
+    id: string;
+    title: string | null;
+    stage: string | null;
+    company_id: string | null;
+    client_id: string | null;
+    project_id: string | null;
+    project_ref: string | null;
+    deleted_at: string | null;
+    archived_at: string | null;
+  }>;
+
+  const companyIds = Array.from(new Set(oppRows.map((o) => o.company_id).filter(Boolean))) as string[];
+  const clientIds = Array.from(new Set(oppRows.map((o) => o.client_id).filter(Boolean))) as string[];
+  const projectIds = Array.from(new Set(oppRows.map((o) => o.project_id).filter(Boolean))) as string[];
+
+  const [companies, clients, projects] = await Promise.all([
+    companyIds.length
+      ? sb.from("companies").select("id, name").in("id", companyIds)
+      : Promise.resolve({ data: [], error: null }),
+    clientIds.length
+      ? sb.from("clients").select("id, name, email").in("id", clientIds)
+      : Promise.resolve({ data: [], error: null }),
+    projectIds.length
+      ? sb.from("projects").select("id, title, company_id, created_at, opportunity_id").in("id", projectIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+  if (companies.error) throw new Error(companies.error.message);
+  if (clients.error) throw new Error(clients.error.message);
+  if (projects.error) throw new Error(projects.error.message);
+
+  const companyById = new Map((companies.data as { id: string; name: string }[]).map((c) => [c.id, c]));
+  const clientById = new Map(
+    (clients.data as { id: string; name: string | null; email: string | null }[]).map((c) => [c.id, c])
+  );
+  const projectById = new Map(
+    (projects.data as {
+      id: string;
+      title: string | null;
+      company_id: string | null;
+      created_at: string | null;
+      opportunity_id: string | null;
+    }[]).map((p) => [p.id, p])
+  );
+
+  return oppRows.map((o) => {
+    const co = o.company_id ? companyById.get(o.company_id) : undefined;
+    const cl = o.client_id ? clientById.get(o.client_id) : undefined;
+    const pr = o.project_id ? projectById.get(o.project_id) : undefined;
+    return {
+      oppId: o.id,
+      oppTitle: o.title,
+      stage: o.stage,
+      companyId: o.company_id,
+      companyName: co?.name ?? null,
+      clientId: o.client_id,
+      clientName: cl?.name ?? null,
+      clientEmail: cl?.email ?? null,
+      projectId: o.project_id,
+      projectTitle: pr?.title ?? null,
+      projectCompany: pr?.company_id ?? null,
+      projectCreatedAt: pr?.created_at ?? null,
+      projectBacklinkText: pr?.opportunity_id ?? null,
+      oppDeleted: o.deleted_at !== null,
+      oppArchived: o.archived_at !== null,
+    };
+  });
+}
+
+function assess(row: DriftRow): DriftAssessment {
+  const evidence: string[] = [];
+  let syntheticSignals = 0;
+
+  if (row.oppId.startsWith(SEED_OPP_PREFIX)) {
+    evidence.push(`opportunity id matches the sequential seed-fixture prefix '${SEED_OPP_PREFIX}…'`);
+    syntheticSignals += 1;
+  }
+  if (row.projectId && row.projectId.startsWith(SEED_PROJECT_PREFIX)) {
+    evidence.push(`linked project id matches the seed-fixture prefix '${SEED_PROJECT_PREFIX}…'`);
+    syntheticSignals += 1;
+  }
+  if (row.clientId && row.clientId.startsWith(SEED_CLIENT_PREFIX)) {
+    evidence.push(`client id matches the seed-fixture prefix '${SEED_CLIENT_PREFIX}…'`);
+    syntheticSignals += 1;
+  }
+  if (row.companyName && /maverick|fightertown|o'?club|top\s?gun/i.test(`${row.companyName} ${row.clientName ?? ""}`)) {
+    evidence.push(`company/client names read as fictional seed data ('${row.companyName}' / '${row.clientName ?? "—"}')`);
+    syntheticSignals += 1;
+  }
+  if (!row.clientEmail || row.clientEmail.endsWith("@email.com")) {
+    evidence.push(`client email is blank or a placeholder ('${row.clientEmail ?? "—"}')`);
+  }
+
+  const synthetic = syntheticSignals >= 2;
+  if (synthetic) {
+    evidence.push(
+      "MULTIPLE synthetic signals => this is seed/test data, NOT a real customer. Writing production-shaped FK links onto a test fixture would be wrong; safest is to leave it (it is harmless: project_id has no FK and the conversion RPC makes new drift impossible) or delete the seed rows if the operator is pruning fixtures."
+    );
+  } else {
+    evidence.push(
+      "Insufficient synthetic signals — treat as potentially real; operator must inspect before any action."
+    );
+  }
+
+  return {
+    ...row,
+    synthetic,
+    evidence,
+    recommendation: synthetic ? "leave" : "operator-decide",
+  };
+}
+
+function renderArtifact(rows: DriftAssessment[]): string {
+  const synthetic = rows.filter((r) => r.synthetic);
+  const nonSynthetic = rows.filter((r) => !r.synthetic);
+
+  const lines: string[] = [];
+  lines.push("# Lead Lifecycle P6 — Seed-Drift Reconciliation (Dry Run / Report)");
+  lines.push("");
+  lines.push(`Generated at: ${new Date().toISOString()}`);
+  lines.push("Workstream: p6-seed-drift (deferred P6 data step — report only)");
+  lines.push("Supabase project: ijeekuhbatykdomumfjx (production)");
+  lines.push("Mode: dry-run (read-only) — NO write path exists in this script by design");
+  lines.push("");
+
+  lines.push("## Summary — verified-live counts");
+  lines.push("");
+  lines.push(`- Opportunities with project_id set AND project_ref NULL (the 11-vs-8 drift gap): **${rows.length}**`);
+  lines.push(`- Confirmed synthetic seed/test rows (≥2 synthetic signals): **${synthetic.length}**`);
+  lines.push(`- Rows needing operator inspection (not confidently synthetic): **${nonSynthetic.length}**`);
+  lines.push("");
+  lines.push(`Recommendation for the synthetic rows: **leave or delete the seed rows — do NOT backfill production-shaped links onto test data.** Leaving them is harmless (project_id carries no FK, and the P6 conversion RPC writes all four link columns atomically, so no NEW drift can arise). Deleting them is only appropriate if the operator is pruning seed fixtures wholesale.`);
+  lines.push("");
+
+  lines.push("## Apply-mode table allow-list");
+  lines.push("");
+  lines.push("**NONE.** This report never writes any table. There is no destructive apply path: leave-or-delete is an explicit operator decision, not an automated one.");
+  lines.push("");
+
+  lines.push("## Hard-Stop Proof");
+  lines.push("");
+  lines.push("- Mode: dry-run (READ-ONLY).");
+  lines.push("- Writes performed: NO. Zero UPDATE/INSERT/DELETE issued.");
+  lines.push("- Rows deleted: no. Rows backfilled (project_ref / opportunity_ref): no.");
+  lines.push("- Emails sent: no. Provider drafts created: no.");
+  lines.push("- Auto-decision made: no — every row carries a recommendation + evidence for the operator.");
+  lines.push("- Business state: untouched.");
+  lines.push("");
+
+  lines.push("## Per-row assessment");
+  lines.push("");
+  lines.push("| opportunity_id | title | stage | company | client | project_id | project_title | project_created | backlink_text | opp_deleted | opp_archived | synthetic | recommendation |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |");
+  for (const r of rows) {
+    lines.push(
+      `| ${md(r.oppId)} | ${md(r.oppTitle)} | ${md(r.stage)} | ${md(r.companyName)} | ${md(r.clientName)} | ${md(r.projectId)} | ${md(r.projectTitle)} | ${md(r.projectCreatedAt)} | ${md(r.projectBacklinkText)} | ${r.oppDeleted ? "yes" : "no"} | ${r.oppArchived ? "yes" : "no"} | ${r.synthetic ? "yes" : "no"} | ${md(r.recommendation)} |`
+    );
+  }
+  lines.push("");
+
+  lines.push("## Evidence per row");
+  lines.push("");
+  for (const r of rows) {
+    lines.push(`### \`${md(r.oppId)}\` — recommendation: **${r.recommendation}**`);
+    lines.push("");
+    for (const e of r.evidence) lines.push(`- ${e}`);
+    lines.push("");
+  }
+
+  lines.push("## If the operator instead chooses to backfill (NOT done here)");
+  lines.push("");
+  lines.push("Per release runbook §6.4, the backfill path would be, per row, one idempotent transaction:");
+  lines.push("");
+  lines.push("```sql");
+  lines.push("-- per drift row (operator-run, not by this script)");
+  lines.push("UPDATE opportunities SET project_ref = project_id WHERE id = '<opp>' AND project_ref IS NULL;");
+  lines.push("UPDATE projects SET opportunity_id = '<opp>'::text WHERE id = '<project>';");
+  lines.push("-- optional: write a converted_to_project disposition row");
+  lines.push("```");
+  lines.push("");
+  lines.push("Then re-run the dry-run to assert convergence (11 = 11 = 11). Because these are synthetic fixtures, the recommended action remains **leave or delete**, not backfill.");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+async function writeArtifact(markdown: string) {
+  await mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, markdown);
+}
+
+async function main() {
+  if (APPLY) {
+    console.error(
+      "REFUSED: this is a report-only script. There is no write/apply path by design — leave-or-delete is an operator decision. Run without --apply."
+    );
+    process.exit(1);
+  }
+
+  const rows = await fetchDriftRows();
+  const assessed = rows.map(assess);
+  await writeArtifact(renderArtifact(assessed));
+
+  console.log(`Artifact write: ${OUTPUT_PATH}`);
+  console.log("Mode: dry-run (read-only, report-only)");
+  console.log(
+    `Drift rows: ${assessed.length} | synthetic: ${assessed.filter((r) => r.synthetic).length} | operator-decide: ${assessed.filter((r) => !r.synthetic).length}`
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260530120000_lead_lifecycle_cw1_trigger_search_path_hardening.sql
+++ b/supabase/migrations/20260530120000_lead_lifecycle_cw1_trigger_search_path_hardening.sql
@@ -1,0 +1,51 @@
+-- Lead Lifecycle CW1 — trigger-function search_path hardening.
+--
+-- Resolves the `function_search_path_mutable` security advisor (lint 0011) for
+-- the two CW1 blank-provider rewrite trigger functions introduced in
+-- 20260529120000_lead_lifecycle_p5_blank_provider_rewrite_trigger.sql:
+--   - public.email_threads_rewrite_blank_provider()
+--   - public.opportunity_email_threads_rewrite_blank_thread()
+--
+-- Both functions are flagged because they carry a role-mutable search_path. This
+-- migration CREATE OR REPLACEs each with `set search_path = ''` pinned on the
+-- function. The bodies reference ONLY built-in functions (btrim, coalesce) and
+-- the trigger NEW record — no schema-qualified objects, no table/sequence/type
+-- lookups — so an empty search_path resolves everything safely and changes no
+-- behavior. The triggers themselves are untouched (the function bodies are
+-- byte-for-byte identical to the originals apart from the added SET clause).
+--
+-- Additive + idempotent: CREATE OR REPLACE leaves the existing triggers bound to
+-- the same function names; re-running is a no-op. iOS-safe — no schema/constraint
+-- change, the functions still NEVER raise or reject (they only rewrite a blank
+-- provider id in place to a deterministic `legacy:<uuid>`).
+--
+-- NOTE: This migration is written but intentionally NOT applied by the authoring
+-- session. Apply it as part of the normal coordinated lead-lifecycle release.
+
+create or replace function public.email_threads_rewrite_blank_provider()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  -- Defensive: NOT NULL is already enforced, so this guards the empty-string
+  -- and all-whitespace cases. coalesce keeps the predicate null-safe.
+  if btrim(coalesce(new.provider_thread_id, '')) = '' then
+    new.provider_thread_id := 'legacy:' || new.id::text;
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function public.opportunity_email_threads_rewrite_blank_thread()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if btrim(coalesce(new.thread_id, '')) = '' then
+    new.thread_id := 'legacy:' || new.id::text;
+  end if;
+  return new;
+end;
+$$;


### PR DESCRIPTION
## Summary
Lead-lifecycle closeout: hardens CW1 trigger functions with a pinned `search_path`, and adds post-go-live data-cleanup dry-run tooling.

## Test plan
- [ ] Triggers behave identically with pinned search_path.
- [ ] Dry-run tooling reports without mutating.