### PR TITLE
fix(accounting): map QB customer matches to camelCase + show display name

### DIFF
--- a/src/components/accounting/qbo/customer-match-table.tsx
+++ b/src/components/accounting/qbo/customer-match-table.tsx
@@ -34,17 +34,13 @@ function resolveDecision(
 }
 
 /**
- * The QB customer's display label. The `qbo_customer_matches` row carries no
- * display name, so we resolve it from the candidate the row points at
- * (decided/proposed client first, then the highest-ranked candidate), falling
- * back to the QB customer id so every row is always identifiable.
+ * The QB customer's display label — the QuickBooks DisplayName carried on the
+ * match, falling back to the QB customer id so every row is always
+ * identifiable. (The matched OPS client, if any, is shown separately in the
+ * OPS-client column, not here.)
  */
-function resolveName(m: QboCustomerMatch, decision: RowDecision): string {
-  const targetId = decision.client_id ?? m.matchedClientId ?? null;
-  const matched =
-    (targetId && m.candidates.find((c) => c.clientId === targetId)) ||
-    m.candidates[0];
-  return matched?.name ?? m.customerQbId;
+function resolveName(m: QboCustomerMatch): string {
+  return m.displayName ?? m.customerQbId;
 }
 
 function candidateLabel(c: QboMatchCandidate): string {
@@ -97,7 +93,7 @@ export function CustomerMatchTable({
                 className="border-b border-border last:border-0 hover:bg-[rgba(255,255,255,0.02)]"
               >
                 <td className="px-1.5 py-1 font-mono text-caption text-text-2 truncate max-w-[220px]">
-                  {resolveName(m, decision)}
+                  {resolveName(m)}
                 </td>
                 <td
                   data-testid={`match-basis-${m.customerQbId}`}

--- a/src/lib/api/services/__tests__/quickbooks-import-service.test.ts
+++ b/src/lib/api/services/__tests__/quickbooks-import-service.test.ts
@@ -205,5 +205,21 @@ describe("QuickBooksImportService.getImportReview", () => {
     expect(review.reconciliation.openInvoiceCount).toBe(1);
     expect(review.reconciliation.collectedInWindow).toBe(362.07);
     expect(review.reconciliation.arMatched).toBe(true);
+
+    // Regression: getImportReview previously cast raw snake_case rows straight
+    // to QboCustomerMatch (`as unknown as`), so customerQbId/proposedAction were
+    // undefined and the review table rendered blank rows. Assert the matches are
+    // mapped to camelCase AND carry the QB customer's display name joined from
+    // staging.
+    review.matches.forEach((m) => {
+      expect(m.customerQbId).toBeTruthy();
+      expect(m.displayName).toBeTruthy();
+    });
+    const cool = review.matches.find((m) => m.customerQbId === "58");
+    expect(cool?.proposedAction).toBe("link");
+    const stagedCool = supabase._tables.qbo_staging_customers.find(
+      (c) => c.qb_id === "58"
+    );
+    expect(cool?.displayName).toBe(stagedCool?.display_name);
   });
 });

--- a/src/lib/api/services/quickbooks-import-service.ts
+++ b/src/lib/api/services/quickbooks-import-service.ts
@@ -79,6 +79,40 @@ function mapRun(row: Record<string, unknown>): QboImportRun {
   };
 }
 
+/**
+ * Map a raw qbo_customer_matches row (snake_case) to the camelCase
+ * QboCustomerMatch the review UI consumes, joining the QB customer's
+ * display_name (the matches table doesn't carry it) and normalizing the
+ * candidates jsonb (stored as client_id/similarity) to clientId/score.
+ */
+function mapCustomerMatch(
+  r: Record<string, unknown>,
+  displayNameByQbId: Map<string, string | null>
+): QboCustomerMatch {
+  const rawCandidates = (r.candidates as Record<string, unknown>[] | null) ?? [];
+  return {
+    id: r.id as string,
+    runId: r.run_id as string,
+    companyId: r.company_id as string,
+    customerQbId: r.customer_qb_id as string,
+    displayName: displayNameByQbId.get(r.customer_qb_id as string) ?? null,
+    proposedAction: r.proposed_action as QboCustomerMatch["proposedAction"],
+    matchedClientId: (r.matched_client_id as string | null) ?? null,
+    matchBasis: (r.match_basis as QboCustomerMatch["matchBasis"]) ?? null,
+    confidence: (r.confidence as QboCustomerMatch["confidence"]) ?? null,
+    candidates: rawCandidates.map((c) => ({
+      clientId: (c.client_id ?? c.clientId) as string,
+      name: (c.name as string | null) ?? null,
+      basis: (c.basis ??
+        r.match_basis ??
+        "none") as QboCustomerMatch["candidates"][number]["basis"],
+      score: Number(c.score ?? c.similarity ?? 0),
+    })),
+    decidedAction: (r.decided_action as QboCustomerMatch["decidedAction"]) ?? null,
+    decidedClientId: (r.decided_client_id as string | null) ?? null,
+  };
+}
+
 function cutoffISODate(): string {
   const d = new Date();
   d.setMonth(d.getMonth() - HISTORY_MONTHS);
@@ -486,19 +520,30 @@ export class QuickBooksImportService {
       sb.from("qbo_staging_invoices").select("*").eq("run_id", runId),
       sb.from("qbo_staging_payments").select("*").eq("run_id", runId),
       sb.from("qbo_staging_estimates").select("qb_id").eq("run_id", runId),
-      sb.from("qbo_staging_customers").select("qb_id").eq("run_id", runId),
+      sb.from("qbo_staging_customers").select("qb_id, display_name").eq("run_id", runId),
       sb.from("qbo_staging_line_items").select("id").eq("run_id", runId),
     ]);
 
-    const matches = (matchData ?? []) as unknown as QboCustomerMatch[];
+    const rawMatches = (matchData ?? []) as Record<string, unknown>[];
     const invoices = (invoiceData ?? []) as unknown as QboStagedInvoice[];
     const payments = (paymentData ?? []) as unknown as QboStagedPayment[];
-    const customerCount = (customerData ?? []).length;
+    const customerRows = (customerData ?? []) as Record<string, unknown>[];
+    const customerCount = customerRows.length;
+
+    // Join each match to its QB customer display_name and map snake_case ->
+    // camelCase for the UI. buildMatchCounts reads the raw snake rows, so it is
+    // fed rawMatches (unchanged behaviour).
+    const displayNameByQbId = new Map<string, string | null>(
+      customerRows.map((c) => [c.qb_id as string, (c.display_name as string) ?? null])
+    );
+    const matches: QboCustomerMatch[] = rawMatches.map((r) =>
+      mapCustomerMatch(r, displayNameByQbId)
+    );
 
     return {
       run,
       matches,
-      matchCounts: buildMatchCounts(matches),
+      matchCounts: buildMatchCounts(rawMatches as unknown as QboCustomerMatch[]),
       stagedCounts: buildStagedCounts({
         customers: customerCount,
         estimates: (estimateData ?? []).length,

--- a/src/lib/types/qbo-import.ts
+++ b/src/lib/types/qbo-import.ts
@@ -157,6 +157,8 @@ export interface QboCustomerMatch {
   runId: string;
   companyId: string;
   customerQbId: string;
+  /** QB customer DisplayName (joined from staging) — what the review table shows. */
+  displayName: string | null;
   proposedAction: MatchAction;
   matchedClientId: string | null;
   matchBasis: MatchBasis | null;

--- a/tests/unit/components/qbo-customer-match-table.test.tsx
+++ b/tests/unit/components/qbo-customer-match-table.test.tsx
@@ -8,17 +8,16 @@ vi.mock("@/i18n/client", () => ({
 import { CustomerMatchTable } from "@/components/accounting/qbo/customer-match-table";
 import type { QboCustomerMatch } from "@/lib/types/qbo-import";
 
-// NOTE: shape reconciled to the A0-owned `QboCustomerMatch` type (the plan's
-// A4.4 draft predates the canonical type and referenced a non-existent
-// `displayName` / candidate `{ email, similarity }`). The real row carries no
-// display name, so the name column falls back to the matched/first candidate
-// name (or the QB id), and candidates use `{ clientId, name, basis, score }`.
+// QboCustomerMatch carries displayName (the QB customer's DisplayName, joined
+// from staging by getImportReview). The name column renders displayName; the
+// matched/candidate OPS client is shown separately in the OPS-client column.
 const matches: QboCustomerMatch[] = [
   {
     id: "m1",
     runId: "run-1",
     companyId: "co",
     customerQbId: "QB1",
+    displayName: "Sonnenschein Family Store",
     proposedAction: "link",
     matchedClientId: "c-1",
     matchBasis: "email",
@@ -32,6 +31,7 @@ const matches: QboCustomerMatch[] = [
     runId: "run-1",
     companyId: "co",
     customerQbId: "QB2",
+    displayName: "Adwin Ko",
     proposedAction: "create",
     matchedClientId: null,
     matchBasis: "none",
@@ -47,10 +47,10 @@ describe("CustomerMatchTable", () => {
     render(
       <CustomerMatchTable matches={matches} decisions={{}} onDecisionChange={vi.fn()} />
     );
-    // QB1 resolves its name from the matched candidate; QB2 (no candidate) falls
-    // back to its QB id.
-    expect(screen.getByText("Acme Decks")).toBeInTheDocument();
-    expect(screen.getByText("QB2")).toBeInTheDocument();
+    // The name column shows the QB customer's DisplayName (not the matched
+    // OPS client, which appears in the OPS-client picker).
+    expect(screen.getByText("Sonnenschein Family Store")).toBeInTheDocument();
+    expect(screen.getByText("Adwin Ko")).toBeInTheDocument();
     expect(screen.getByTestId("match-confidence-QB1").textContent).toContain(
       "qbo.confidence.high"
     );

--- a/tests/unit/lib/types/qbo-import.test.ts
+++ b/tests/unit/lib/types/qbo-import.test.ts
@@ -91,6 +91,7 @@ describe("qbo-import types", () => {
   it("QboCustomerMatch carries proposal + owner decision fields", () => {
     const match: QboCustomerMatch = {
       id: "m1", runId: "r1", companyId: "co", customerQbId: "1",
+      displayName: "Sonnenschein Family Store",
       proposedAction: "link", matchedClientId: "client-1",
       matchBasis: "email", confidence: "high",
       candidates: [{ clientId: "client-1", name: "Acme", basis: "email", score: 1 }],


### PR DESCRIPTION
Review table rendered 29 blank customer rows (action stuck on 'Link') after a successful QuickBooks pull. Root cause: getImportReview cast raw snake_case rows to the camelCase QboCustomerMatch type via 'as unknown as', so every UI field was undefined; and the table never sourced the QB customer's display_name. Fix: map snake->camel + join display_name from qbo_staging_customers + render displayName. buildMatchCounts keeps reading raw rows. +regression test. Read-side only — no re-pull needed after deploy. Gate: 0 tsc, 34 tests.