### PR TITLE
fix(qbo): apply was non-functional in prod (42P10) — full unique indexes + loud write errors

### DIFF
--- a/src/lib/api/services/quickbooks-import-service.ts
+++ b/src/lib/api/services/quickbooks-import-service.ts
@@ -145,6 +145,25 @@ function isUnauthorizedError(err: unknown): boolean {
   return /\(401\)/.test(msg) || /unauthorized/i.test(msg);
 }
 
+/**
+ * Throw on a Supabase write error. The apply path previously did
+ * `await sb.from(...).upsert(...)` without inspecting the result, so a failed
+ * write (e.g. 42P10 against a partial-only ON CONFLICT arbiter) was swallowed
+ * and the run still reported `applied` with inflated totals — silent data loss.
+ * Every apply write now routes through this so a failure aborts the run loudly.
+ */
+function assertNoWriteError(
+  res: { error: { message?: string; code?: string } | null },
+  ctx: string
+): void {
+  if (res.error) {
+    const e = res.error;
+    throw new Error(
+      `QBO apply write failed [${ctx}]${e.code ? ` (${e.code})` : ""}: ${e.message ?? JSON.stringify(e)}`
+    );
+  }
+}
+
 export class QuickBooksImportService {
   private supabase: SupabaseClient;
 
@@ -594,6 +613,32 @@ export class QuickBooksImportService {
 
     await sb.from("qbo_import_runs").update({ status: "applying" }).eq("id", runId);
 
+    try {
+      return await this.applyStagedRows(sb, runId, companyId, decisions);
+    } catch (err) {
+      // A write failed mid-apply — mark the run errored. Never leave it stuck
+      // in 'applying', and never let a failed write masquerade as 'applied'.
+      const msg = err instanceof Error ? err.message : String(err);
+      await sb
+        .from("qbo_import_runs")
+        .update({ status: "error", error: msg, finished_at: new Date().toISOString() })
+        .eq("id", runId);
+      throw err;
+    }
+  }
+
+  /**
+   * Apply a staged run's rows into the live tables (STEP 1–5). Split out of
+   * applyImport so the latter can wrap it in a run-level error guard. Every
+   * write is checked via assertNoWriteError, so a failed upsert/insert/update
+   * aborts the run loudly instead of being swallowed and reported as success.
+   */
+  private async applyStagedRows(
+    sb: SupabaseClient,
+    runId: string,
+    companyId: string,
+    decisions: QboApplyDecision[]
+  ): Promise<QboApplyResult> {
     // ── Load all staged rows for this run ──────────────────────────────────
     const { data: stagedCustomers } = await sb
       .from("qbo_staging_customers").select("*").eq("run_id", runId);
@@ -672,11 +717,14 @@ export class QuickBooksImportService {
         }
         // Link writes ONLY qb_id — never overwrite name/email/phone/address.
         // Company-scoped (C4): never touch a row outside the caller's tenant.
-        await sb
-          .from("clients")
-          .update({ qb_id: cust.qb_id })
-          .eq("id", clientId)
-          .eq("company_id", companyId);
+        assertNoWriteError(
+          await sb
+            .from("clients")
+            .update({ qb_id: cust.qb_id })
+            .eq("id", clientId)
+            .eq("company_id", companyId),
+          "clients.link"
+        );
         clientIdByCustomerQbId.set(cust.qb_id as string, clientId);
         result.clientsLinked++;
         continue;
@@ -698,14 +746,17 @@ export class QuickBooksImportService {
 
       // Company-aware field shaping — SAME helper the webhook path uses (Task 6B).
       const newId = crypto.randomUUID();
-      await sb.from("clients").upsert(
-        {
-          id: newId,
-          company_id: companyId,
-          qb_id: cust.qb_id,
-          ...clientFieldsFromCustomer(toShape(cust)),
-        },
-        { onConflict: "company_id,qb_id" }
+      assertNoWriteError(
+        await sb.from("clients").upsert(
+          {
+            id: newId,
+            company_id: companyId,
+            qb_id: cust.qb_id,
+            ...clientFieldsFromCustomer(toShape(cust)),
+          },
+          { onConflict: "company_id,qb_id" }
+        ),
+        "clients.create"
       );
       const { data: created } = await sb
         .from("clients").select("id")
@@ -724,9 +775,12 @@ export class QuickBooksImportService {
       const clientId = clientIdByCustomerQbId.get(cust.qb_id as string);
       const fields = subClientFieldsFromCustomer(toShape(cust));
       if (!clientId || !fields) continue;
-      await sb.from("sub_clients").upsert(
-        { company_id: companyId, client_id: clientId, qb_id: cust.qb_id, ...fields },
-        { onConflict: "company_id,qb_id" }
+      assertNoWriteError(
+        await sb.from("sub_clients").upsert(
+          { company_id: companyId, client_id: clientId, qb_id: cust.qb_id, ...fields },
+          { onConflict: "company_id,qb_id" }
+        ),
+        "sub_clients.upsert"
       );
       result.subClientsCreated++;
     }
@@ -776,7 +830,10 @@ export class QuickBooksImportService {
       // issue_date is NOT NULL DEFAULT CURRENT_DATE: send the QB txn_date, or
       // omit the key entirely so the default applies — never send null (C3).
       if (est.txn_date) estimateRow.issue_date = est.txn_date;
-      await sb.from("estimates").upsert(estimateRow, { onConflict: "company_id,qb_id" });
+      assertNoWriteError(
+        await sb.from("estimates").upsert(estimateRow, { onConflict: "company_id,qb_id" }),
+        "estimates.upsert"
+      );
       const { data: row } = await sb
         .from("estimates").select("id")
         .eq("company_id", companyId).eq("qb_id", est.qb_id).maybeSingle();
@@ -833,7 +890,10 @@ export class QuickBooksImportService {
       // issue_date is NOT NULL DEFAULT CURRENT_DATE: send the QB txn_date, or
       // omit the key entirely so the default applies — never send null (C3).
       if (inv.txn_date) invoiceRow.issue_date = inv.txn_date;
-      await sb.from("invoices").upsert(invoiceRow, { onConflict: "company_id,qb_id" });
+      assertNoWriteError(
+        await sb.from("invoices").upsert(invoiceRow, { onConflict: "company_id,qb_id" }),
+        "invoices.upsert"
+      );
       const { data: row } = await sb
         .from("invoices").select("id")
         .eq("company_id", companyId).eq("qb_id", inv.qb_id).maybeSingle();
@@ -847,10 +907,16 @@ export class QuickBooksImportService {
     const appliedInvoiceIds = [...invoiceIdByQbId.values()];
     const appliedEstimateIds = [...estimateIdByQbId.values()];
     if (appliedInvoiceIds.length) {
-      await sb.from("line_items").delete().in("invoice_id", appliedInvoiceIds);
+      assertNoWriteError(
+        await sb.from("line_items").delete().in("invoice_id", appliedInvoiceIds),
+        "line_items.delete.invoice"
+      );
     }
     if (appliedEstimateIds.length) {
-      await sb.from("line_items").delete().in("estimate_id", appliedEstimateIds);
+      assertNoWriteError(
+        await sb.from("line_items").delete().in("estimate_id", appliedEstimateIds),
+        "line_items.delete.estimate"
+      );
     }
 
     for (const line of stagedLines ?? []) {
@@ -868,21 +934,24 @@ export class QuickBooksImportService {
       const opsType =
         itemType === "Inventory" || itemType === "NonInventory" ? "MATERIAL" : "OTHER";
 
-      await sb.from("line_items").insert({
-        company_id: companyId,
-        estimate_id: parentEstimateId,
-        invoice_id: parentInvoiceId,
-        product_id: null,
-        name: line.name ?? "Line item",
-        description: line.description ?? null,
-        quantity: line.quantity ?? 1,
-        unit: null,
-        unit_price: line.unit_price ?? 0,
-        // line_total intentionally omitted — GENERATED column.
-        is_taxable: line.is_taxable ?? false,
-        sort_order: line.sort_order ?? 0,
-        type: opsType,
-      });
+      assertNoWriteError(
+        await sb.from("line_items").insert({
+          company_id: companyId,
+          estimate_id: parentEstimateId,
+          invoice_id: parentInvoiceId,
+          product_id: null,
+          name: line.name ?? "Line item",
+          description: line.description ?? null,
+          quantity: line.quantity ?? 1,
+          unit: null,
+          unit_price: line.unit_price ?? 0,
+          // line_total intentionally omitted — GENERATED column.
+          is_taxable: line.is_taxable ?? false,
+          sort_order: line.sort_order ?? 0,
+          type: opsType,
+        }),
+        "line_items.insert"
+      );
       result.lineItemsInserted++;
     }
 
@@ -899,18 +968,21 @@ export class QuickBooksImportService {
         const invoiceId = invoiceIdByQbId.get(l.invoice_qb_id) ?? null;
         if (!invoiceId) continue; // payment line references a dropped/absent invoice
         const compositeQbId = `${pmt.qb_id}:${l.invoice_qb_id}`;
-        await sb.from("payments").upsert(
-          {
-            company_id: companyId,
-            qb_id: compositeQbId,
-            invoice_id: invoiceId,
-            client_id: clientId,
-            amount: l.amount,
-            payment_date: pmt.txn_date ?? null,
-            reference_number: l.reference_number ?? null,
-            payment_method: null,
-          },
-          { onConflict: "company_id,qb_id" }
+        assertNoWriteError(
+          await sb.from("payments").upsert(
+            {
+              company_id: companyId,
+              qb_id: compositeQbId,
+              invoice_id: invoiceId,
+              client_id: clientId,
+              amount: l.amount,
+              payment_date: pmt.txn_date ?? null,
+              reference_number: l.reference_number ?? null,
+              payment_method: null,
+            },
+            { onConflict: "company_id,qb_id" }
+          ),
+          "payments.upsert"
         );
         result.paymentsUpserted++;
       }
@@ -928,12 +1000,15 @@ export class QuickBooksImportService {
       const amountPaid = round2(total - balance);
       const dueDate = (inv.due_date as string | null) ?? (inv.txn_date as string | null);
       const status = deriveInvoiceStatus(balance, total, dueDate, now);
-      await sb.from("invoices").update({
-        amount_paid: amountPaid,
-        balance_due: balance,
-        status,
-        paid_at: balance <= 0 ? new Date().toISOString() : null,
-      }).eq("id", invoiceId);
+      assertNoWriteError(
+        await sb.from("invoices").update({
+          amount_paid: amountPaid,
+          balance_due: balance,
+          status,
+          paid_at: balance <= 0 ? new Date().toISOString() : null,
+        }).eq("id", invoiceId),
+        "invoices.reconcile"
+      );
       result.invoicesReconciled++;
     }
 

--- a/supabase/migrations/20260604000000_qbo_full_qb_id_unique_indexes.sql
+++ b/supabase/migrations/20260604000000_qbo_full_qb_id_unique_indexes.sql
@@ -1,0 +1,81 @@
+begin;
+
+-- ============================================================================
+-- QuickBooks read-only sync — fix: FULL unique indexes for ON CONFLICT upsert
+--
+-- The (company_id, qb_id) unique indexes added in 20260602200000 were PARTIAL
+-- (WHERE qb_id IS NOT NULL). PostgREST `.upsert({ onConflict: "company_id,
+-- qb_id" })` emits `ON CONFLICT (company_id, qb_id)` WITHOUT the partial
+-- predicate, and Postgres rejects a partial-only arbiter with 42P10 ("there is
+-- no unique or exclusion constraint matching the ON CONFLICT specification").
+-- Result: the QBO apply + inbound webhook could NEVER upsert
+-- clients/sub_clients/invoices/estimates/payments — every write failed (the
+-- code swallowed the error and the run falsely reported `applied`). Only the
+-- link path (a plain UPDATE, no ON CONFLICT) persisted. Confirmed live 2026-06-04.
+--
+-- Fix: replace each PARTIAL index with a FULL unique index on (company_id,
+-- qb_id). Postgres treats NULLs as DISTINCT by default, so unlimited non-QB
+-- rows (qb_id IS NULL) per company still coexist — exactly the property the
+-- partial index was protecting — while the index becomes a valid ON CONFLICT
+-- arbiter for `(company_id, qb_id)`.
+--
+-- Safe: the partial index already guaranteed uniqueness among non-NULL qb_id
+-- rows, and NULLs never collide, so the full index cannot fail on existing
+-- data; if it somehow did, the whole transaction rolls back (no half state).
+-- Index-only change (no data, no columns) → iOS-sync-safe. NOT CONCURRENTLY to
+-- match repo convention (low-tenant prod, small tables, brief lock is fine).
+-- The sentinel re-verifies each index exists AND is non-partial (indpred NULL).
+-- ============================================================================
+
+drop index if exists public.clients_company_qb_id_uniq;
+create unique index clients_company_qb_id_uniq
+  on public.clients (company_id, qb_id);
+
+drop index if exists public.sub_clients_company_qb_id_uniq;
+create unique index sub_clients_company_qb_id_uniq
+  on public.sub_clients (company_id, qb_id);
+
+drop index if exists public.invoices_company_qb_id_uniq;
+create unique index invoices_company_qb_id_uniq
+  on public.invoices (company_id, qb_id);
+
+drop index if exists public.estimates_company_qb_id_uniq;
+create unique index estimates_company_qb_id_uniq
+  on public.estimates (company_id, qb_id);
+
+drop index if exists public.payments_company_qb_id_uniq;
+create unique index payments_company_qb_id_uniq
+  on public.payments (company_id, qb_id);
+
+-- ── sentinel rollback guard :: qbo_full_uniq ─────────────────────────────────
+-- Each index must exist, be UNIQUE, and be NON-partial (pg_index.indpred IS
+-- NULL) — i.e. a valid bare `ON CONFLICT (company_id, qb_id)` arbiter.
+do $$
+declare
+  v_idx text;
+begin
+  foreach v_idx in array array[
+    'clients_company_qb_id_uniq',
+    'sub_clients_company_qb_id_uniq',
+    'invoices_company_qb_id_uniq',
+    'estimates_company_qb_id_uniq',
+    'payments_company_qb_id_uniq'
+  ]
+  loop
+    if not exists (
+      select 1
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      join pg_index i on i.indexrelid = c.oid
+      where n.nspname = 'public'
+        and c.relname = v_idx
+        and c.relkind = 'i'
+        and i.indisunique
+        and i.indpred is null
+    ) then
+      raise exception 'qbo_full_uniq_sentinel: % is missing, non-unique, or still partial', v_idx;
+    end if;
+  end loop;
+end $$;
+
+commit;

--- a/tests/unit/services/quickbooks-apply.test.ts
+++ b/tests/unit/services/quickbooks-apply.test.ts
@@ -35,7 +35,7 @@ const NOT_NULL_COLUMNS: Record<string, string[]> = {
  * from().update(patch).eq(). The payments insert path recomputes the parent
  * invoice exactly like trg_payment_balance -> update_invoice_balance().
  */
-function makeSupabase() {
+function makeSupabase(inject: { failUpsertOn?: string } = {}) {
   const db: Record<string, Row[]> = {
     qbo_import_runs: [{ id: RUN_ID, company_id: TEMP_COMPANY_ID, status: "staged", qb_write_calls: 0, totals: {} }],
     qbo_staging_customers: structuredClone(stagedCustomers),
@@ -80,6 +80,11 @@ function makeSupabase() {
       async single() { const m = api._match(); return { data: m[0] ?? null, error: m.length ? null : { message: "no rows" } }; },
       then(resolve: any) { return Promise.resolve({ data: api._match(), error: null }).then(resolve); },
       async upsert(payload: Row | Row[], opts?: { onConflict?: string }) {
+        // Simulate a DB write rejection (e.g. 42P10) surfaced by supabase-js as
+        // { error } rather than a throw — to verify applyImport fails loudly.
+        if (inject.failUpsertOn === table) {
+          return { data: null, error: { message: `injected write failure on ${table}`, code: "42P10" } };
+        }
         const list = Array.isArray(payload) ? payload : [payload];
         // C1: live tables upserted on (company_id, qb_id) REQUIRE that exact
         // conflict target — without a matching unique index PostgREST 42P10s.
@@ -275,6 +280,19 @@ describe("QuickBooksImportService.applyImport", () => {
     expect(supabase.__db.invoices).toHaveLength(0);
     expect(supabase.__db.line_items).toHaveLength(0);
     expect(supabase.__db.payments).toHaveLength(0);
+  });
+
+  it("aborts the run (status=error) and throws when a live-table write fails — no false success", async () => {
+    // Regression for the prod 42P10 bug: a failed upsert must NOT be swallowed
+    // and reported as a successful 'applied' run. Inject a write failure on the
+    // clients upsert (decisions create QB-CUST-1 → clients.create runs).
+    const sb = makeSupabase({ failUpsertOn: "clients" });
+    const { QuickBooksImportService } = await import("@/lib/api/services/quickbooks-import-service");
+    const svc = new QuickBooksImportService(sb);
+    await expect(svc.applyImport(RUN_ID, decisions)).rejects.toThrow(/clients\.create/);
+    const run = sb.__db.qbo_import_runs.find((r: Row) => r.id === RUN_ID);
+    expect(run.status).toBe("error"); // never 'applied'
+    expect(sb.__db.clients.filter((c: Row) => c.qb_id).length).toBe(0);
   });
 });
 

--- a/tests/unit/supabase/qbo-full-qb-id-unique-indexes.test.ts
+++ b/tests/unit/supabase/qbo-full-qb-id-unique-indexes.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const sql = readFileSync(
+  join(process.cwd(), "supabase/migrations/20260604000000_qbo_full_qb_id_unique_indexes.sql"),
+  "utf8",
+);
+
+const TABLES = ["clients", "sub_clients", "invoices", "estimates", "payments"];
+
+describe("qbo full (company_id, qb_id) unique index migration", () => {
+  it("is transaction-wrapped", () => {
+    expect(sql.trim().startsWith("begin;")).toBe(true);
+    expect(sql.trim().endsWith("commit;")).toBe(true);
+  });
+
+  it("drops the partial index and recreates a FULL (no WHERE) unique index per table", () => {
+    for (const t of TABLES) {
+      const idx = `${t}_company_qb_id_uniq`;
+      expect(sql, `drop ${idx}`).toMatch(new RegExp(`drop index if exists public\\.${idx}`, "i"));
+      // full unique index on (company_id, qb_id) with NO WHERE predicate
+      const createRe = new RegExp(
+        `create unique index ${idx}\\s+on public\\.${t} \\(company_id, qb_id\\)\\s*;`,
+        "i",
+      );
+      expect(sql, `full create ${idx}`).toMatch(createRe);
+    }
+  });
+
+  it("does NOT recreate any partial (WHERE qb_id IS NOT NULL) index", () => {
+    // The whole point of the fix: no `create unique index ... where qb_id is not null`
+    expect(sql).not.toMatch(/create unique index[\s\S]*?where\s+qb_id\s+is\s+not\s+null/i);
+  });
+
+  it("sentinel verifies the indexes are unique and NON-partial (indpred is null)", () => {
+    expect(sql).toMatch(/i\.indisunique/i);
+    expect(sql).toMatch(/i\.indpred is null/i);
+    expect(sql).toMatch(/raise exception 'qbo_full_uniq_sentinel/i);
+  });
+});


### PR DESCRIPTION
Fixes the urgent bug found in the live MAVERICK test (bug 11fbc17a): "Apply to OPS" reported success but wrote almost nothing.

## Root cause (confirmed live, then re-verified fixed)
- The (company_id, qb_id) unique indexes on clients/sub_clients/invoices/estimates/payments were **partial** (`WHERE qb_id IS NOT NULL`). PostgREST `.upsert({onConflict:"company_id,qb_id"})` emits `ON CONFLICT (company_id, qb_id)` without the predicate → Postgres `42P10` (no matching arbiter). Every apply upsert failed; only the link path (plain UPDATE) persisted.
- `applyImport` never checked the upsert `.error`, so it counted phantom successes and marked the run `applied` with inflated totals — silent data loss + false success.
- The in-memory test double simulated `onConflict` by key and never exercised real partial-index semantics → green tests, broken feature.

## Fix
1. **Migration `20260604000000`** — replace the 5 partial indexes with **full** unique indexes on `(company_id, qb_id)`. NULLs are DISTINCT, so non-QB rows (`qb_id NULL`) still coexist freely; the index is now a valid `ON CONFLICT` arbiter. **Applied to prod + verified**: the exact upsert that raised 42P10 now succeeds (rolled back).
2. **`applyImport`** — every write routes through `assertNoWriteError`; the body is wrapped so any write failure marks the run `error` and throws (never a false `applied`). Added a regression test that injects a write failure and asserts the run aborts to `error`. (Webhook apply already checks `.error`; the migration fixes its writes too.)

Gated: `tsc --noEmit` 0 errors; 206 QBO/accounting tests pass.