### PR TITLE
feat(lead-lifecycle): archive-first auto-cleanup of stale leads

### DIFF
--- a/src/app/api/cron/lead-lifecycle/route.ts
+++ b/src/app/api/cron/lead-lifecycle/route.ts
@@ -23,13 +23,16 @@ export const dynamic = "force-dynamic";
  * structured run summary and logs a single result line for Vercel
  * observability.
  *
- * Boundary: AUTO-EXECUTES only the non-destructive actions (local template
+ * Boundary: ALWAYS auto-executes the non-destructive actions (local template
  * follow-up draft + operator follow-up-miss notification + lifecycle-state
  * updates + inbound supersede), all idempotent via the open-template unique
  * index and the notification dedupe_key. DESTRUCTIVE decisions (archive / lost
- * / reactivate) are surfaced as dry-run candidates only and never applied — the
- * guarded RPC is never called from this route. No emails, no provider drafts,
- * no provider sends.
+ * / reactivate) auto-execute ONLY for companies that have opted in via their
+ * lifecycle settings (`auto_archive_enabled` gates archive + reactivate,
+ * `auto_lost_enabled` gates move-to-lost); the guarded RPC fires for those and
+ * every structural guard is enforced by the action-service. Companies that have
+ * not opted in get a dry-run review notification instead and are never mutated.
+ * No emails, no provider drafts, no provider sends.
  */
 export async function GET(request: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
@@ -65,6 +68,11 @@ export async function GET(request: NextRequest) {
         draftsSuperseded: result.draftsSuperseded,
         destructiveDryRun: result.destructiveDryRun,
         destructiveSkippedFragmented: result.destructiveSkippedFragmented,
+        destructiveArchived: result.destructiveArchived,
+        destructiveMovedToLost: result.destructiveMovedToLost,
+        destructiveReactivated: result.destructiveReactivated,
+        destructiveExecutionSkippedGuarded:
+          result.destructiveExecutionSkippedGuarded,
         destructiveReviewNotificationsCreated:
           result.destructiveReviewNotificationsCreated,
         destructiveReviewNotificationsSkippedExisting:

--- a/src/lib/api/services/lead-lifecycle-cron-service.ts
+++ b/src/lib/api/services/lead-lifecycle-cron-service.ts
@@ -21,11 +21,24 @@
  *
  *   - DESTRUCTIVE decisions (`archive_after_two_unanswered_followups`,
  *     `archive_no_meaningful_correspondence`, `move_to_lost_operator_no_response`,
- *     `reactivate_on_related_inbound`) are NEVER executed. The cron does not
- *     call `executeOpportunityLifecycleAction` for these at all, so the guarded
- *     RPC `execute_opportunity_lifecycle_guarded_action` can never be invoked
- *     from the schedule. They are surfaced as DRY-RUN candidates only, for
- *     operator review.
+ *     `reactivate_on_related_inbound`) AUTO-EXECUTE only when the owning company
+ *     has opted in via its lifecycle settings — `auto_archive_enabled` gates the
+ *     two archive actions and the reactivate action (reactivate is the inverse
+ *     of archive: a lead the cron auto-archived that then gets a meaningful
+ *     related inbound is auto-restored under the same opt-in), and
+ *     `auto_lost_enabled` gates `move_to_lost_operator_no_response`. When opted
+ *     in, the cron calls `executeOpportunityLifecycleAction({ mode: "apply" })`,
+ *     which enforces every structural guard (terminal/protected stage, deleted,
+ *     converted/project-linked, already-archived, lost-stage allow-list,
+ *     related-inbound requirement, snapshot mismatch), writes the audit row, and
+ *     fires the guarded RPC `execute_opportunity_lifecycle_guarded_action`. The
+ *     cron supplies the opportunity snapshot + a deterministic per-day approval
+ *     key (`<opportunityId>:<action>:<YYYY-MM-DD>`) so the action-service's
+ *     apply-mode approval + duplicate-applied guards are satisfied and re-runs in
+ *     the same day cannot double-apply. When the company has NOT opted in, the
+ *     destructive decision is surfaced as a DRY-RUN candidate only (a deduped
+ *     persistent operator review notification) and never applied — the guarded
+ *     RPC is not called for that opportunity.
  *
  *   - Meaningful inbound supersede (`resetStaleLifecycleAfterMeaningfulInbound`)
  *     is non-destructive (it supersedes local drafts + resolves local
@@ -88,6 +101,57 @@ const DESTRUCTIVE_ACTIONS = new Set<OpportunityLifecycleDecisionAction>([
 
 const DEFAULT_MAX_OPPORTUNITIES = 2000;
 const CHUNK = 100;
+
+/**
+ * Per-company opt-in gate for auto-executing a destructive disposition. The
+ * action-service applies these structurally but does NOT consult the
+ * per-company `auto_archive_enabled` / `auto_lost_enabled` flags, so the cron
+ * owns that policy decision here:
+ *   - both archive actions AND `reactivate_on_related_inbound` are gated on
+ *     `autoArchiveEnabled`. Reactivate is the inverse of archive — a lead the
+ *     cron auto-archived that then receives a meaningful related inbound is
+ *     auto-restored under the same opt-in, so the operator who enabled
+ *     auto-archive never loses a re-engaged lead to a stale archive.
+ *   - `move_to_lost_operator_no_response` is gated on `autoLostEnabled`.
+ * Any other action is never auto-executed by this gate.
+ */
+function destructiveActionAutoEnabled(
+  action: OpportunityLifecycleDecisionAction,
+  settings: LeadLifecycleSettings
+): boolean {
+  switch (action) {
+    case "archive_after_two_unanswered_followups":
+    case "archive_no_meaningful_correspondence":
+    case "reactivate_on_related_inbound":
+      return settings.autoArchiveEnabled;
+    case "move_to_lost_operator_no_response":
+      return settings.autoLostEnabled;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Deterministic approval key for an auto-executed destructive disposition,
+ * mirroring the manual operator script's `defaultApprovedActionKey`
+ * (`<opportunityId>:<action>:<YYYY-MM-DD>`). Two roles:
+ *   1. It is non-null, so the action-service's apply-mode `missing_approval`
+ *      guard passes (the cron, gated on the company opt-in, IS the approver).
+ *   2. It is stable within a UTC day, so the action-service's
+ *      `duplicate_applied_action` guard short-circuits a second run on the same
+ *      day even though the structural state already changed — belt-and-braces
+ *      idempotency on top of the structural guards (e.g. already-archived).
+ * Keyed on the cron's own `now` so a single run uses one day boundary for every
+ * opportunity it touches.
+ */
+function destructiveApprovalKey(
+  opportunityId: string,
+  action: OpportunityLifecycleDecisionAction,
+  now: Date
+): string {
+  const day = now.toISOString().slice(0, 10);
+  return `${opportunityId}:${action}:${day}`;
+}
 
 /**
  * Prefix family for synthetic / quarantined thread ids produced by the DW1
@@ -179,8 +243,12 @@ export interface DestructiveCandidate {
   companyId: string;
   action: OpportunityLifecycleDecisionAction;
   reason: string;
-  /** "dry-run" = actionable for operator review; "skipped-fragmented" = quarantined. */
-  status: "dry-run" | "skipped-fragmented";
+  /**
+   * "applied" = the destructive disposition was auto-executed (company opted in);
+   * "dry-run" = surfaced for operator review (company not opted in);
+   * "skipped-fragmented" = quarantined, never acted on.
+   */
+  status: "applied" | "dry-run" | "skipped-fragmented";
   evidence: Record<string, unknown>;
 }
 
@@ -196,6 +264,20 @@ export interface LeadLifecycleCronResult {
   draftsSuperseded: number;
   destructiveDryRun: number;
   destructiveSkippedFragmented: number;
+  /** Destructive dispositions auto-executed (company opted in): archived. */
+  destructiveArchived: number;
+  /** Destructive dispositions auto-executed (company opted in): moved to lost. */
+  destructiveMovedToLost: number;
+  /** Destructive dispositions auto-executed (company opted in): reactivated. */
+  destructiveReactivated: number;
+  /**
+   * Auto-execution attempts that the action-service's structural guards
+   * declined (terminal/protected stage, already-archived, snapshot mismatch,
+   * converted/linked, lost-stage not allowed, missing related inbound, etc.) —
+   * i.e. an `opportunity` op of any non-failure `skipped_*`. Not an error: the
+   * guard fired exactly as designed and the opportunity was left untouched.
+   */
+  destructiveExecutionSkippedGuarded: number;
   /** Review notifications inserted for dry-run destructive candidates. */
   destructiveReviewNotificationsCreated: number;
   /** Review notifications skipped because an unread/unresolved one already exists. */
@@ -220,6 +302,12 @@ interface OpportunityRow {
   created_at: string | null;
   stage_entered_at: string | null;
   contact_name: string | null;
+  // Lost-disposition audit context, only read for the move-to-lost beforeValues.
+  // Mirrors the manual operator script's opportunity snapshot so the audit row
+  // the action-service writes is byte-for-byte the same shape as a manual apply.
+  lost_reason: string | null;
+  lost_notes: string | null;
+  actual_close_date: string | null;
   updated_at: string | null;
 }
 
@@ -363,7 +451,7 @@ async function fetchOpportunities(
     const { data } = await supabase
       .from("opportunities")
       .select(
-        "id, company_id, title, stage, archived_at, deleted_at, project_id, project_ref, created_at, stage_entered_at, contact_name, updated_at"
+        "id, company_id, title, stage, archived_at, deleted_at, project_id, project_ref, created_at, stage_entered_at, contact_name, lost_reason, lost_notes, actual_close_date, updated_at"
       )
       .is("deleted_at", null)
       .in("company_id", ids)
@@ -689,6 +777,10 @@ export async function runLeadLifecycleCron(
     draftsSuperseded: 0,
     destructiveDryRun: 0,
     destructiveSkippedFragmented: 0,
+    destructiveArchived: 0,
+    destructiveMovedToLost: 0,
+    destructiveReactivated: 0,
+    destructiveExecutionSkippedGuarded: 0,
     destructiveReviewNotificationsCreated: 0,
     destructiveReviewNotificationsSkippedExisting: 0,
     destructiveReviewNotificationsSkippedMissingOperator: 0,
@@ -815,21 +907,103 @@ export async function runLeadLifecycleCron(
         result.errors += 1;
       }
     } else if (DESTRUCTIVE_ACTIONS.has(decision.action)) {
-      // DRY-RUN candidates only. The cron NEVER calls
-      // executeOpportunityLifecycleAction for destructive actions, so the
-      // guarded RPC can never fire from the schedule.
+      // Three mutually-exclusive sub-cases:
+      //   1. fragmented  → quarantined, never acted on (no execute, no notify).
+      //   2. auto-enabled → company opted in → APPLY the disposition via the
+      //      action-service (guarded RPC fires; every structural guard enforced).
+      //   3. else        → not opted in → surface a dry-run review notification
+      //      only (the prior behaviour); the guarded RPC is never called.
+      let status: DestructiveCandidate["status"];
       const fragmented = fragmentedIds.has(opportunity.id);
-      const status: DestructiveCandidate["status"] = fragmented
-        ? "skipped-fragmented"
-        : "dry-run";
       if (fragmented) {
+        status = "skipped-fragmented";
         result.destructiveSkippedFragmented += 1;
+      } else if (destructiveActionAutoEnabled(decision.action, settings)) {
+        // AUTO-EXECUTE. Same argument shape as the non-destructive branch, plus
+        // the two fields the destructive apply path additionally requires:
+        //   - `opportunity` snapshot: without it the action-service guards with
+        //     `missing_opportunity_snapshot` and never touches the row.
+        //   - `approvedActionKey`: a deterministic per-day key so the apply-mode
+        //     `missing_approval` guard passes (the cron is the approver, gated
+        //     on the company opt-in) and a same-day re-run hits the
+        //     `duplicate_applied_action` guard instead of re-applying.
+        // The action-service still independently enforces terminal/protected
+        // stage, deleted, converted/linked, already-archived, lost-stage
+        // allow-list, related-inbound, and snapshot-mismatch guards.
+        status = "applied";
+        const latestEvent = latestMeaningfulEvent(eventRows);
+        try {
+          const execution = await executeOpportunityLifecycleAction({
+            supabase,
+            mode: "apply",
+            companyId: opportunity.company_id,
+            opportunityId: opportunity.id,
+            opportunityTitle: opportunity.title,
+            decision,
+            lifecycleState,
+            settings,
+            latestMeaningfulEvent: latestEvent
+              ? {
+                  id: latestEvent.id,
+                  direction: latestEvent.direction,
+                  isMeaningful: latestEvent.is_meaningful,
+                  occurredAt: latestEvent.occurred_at,
+                  connectionId: latestEvent.connection_id,
+                  providerThreadId: latestEvent.provider_thread_id,
+                  linkedContactKind: latestEvent.linked_contact_kind,
+                }
+              : null,
+            operatorUserId: operators.get(opportunity.company_id) ?? null,
+            contactName: opportunity.contact_name,
+            opportunity: {
+              id: opportunity.id,
+              companyId: opportunity.company_id,
+              stage: opportunity.stage,
+              archivedAt: opportunity.archived_at,
+              deletedAt: opportunity.deleted_at,
+              projectId: opportunity.project_id,
+              projectRef: opportunity.project_ref,
+              lostReason: opportunity.lost_reason,
+              lostNotes: opportunity.lost_notes,
+              actualCloseDate: opportunity.actual_close_date,
+            },
+            approvedActionKey: destructiveApprovalKey(
+              opportunity.id,
+              decision.action,
+              now
+            ),
+            runId: `cron:${now.toISOString()}`,
+            now,
+          });
+
+          const op = execution.operations.opportunity;
+          if (op === "archived") {
+            result.destructiveArchived += 1;
+          } else if (op === "moved_to_lost") {
+            result.destructiveMovedToLost += 1;
+          } else if (op === "reactivated") {
+            result.destructiveReactivated += 1;
+          } else if (op === "skipped_update_failed") {
+            // The mutation/audit write itself failed (RPC error, missing
+            // snapshot/approval, or audit insert failure) — a real error.
+            result.errors += 1;
+          } else if (op.startsWith("skipped_")) {
+            // A structural guard declined the action by design — not an error.
+            result.destructiveExecutionSkippedGuarded += 1;
+          }
+          if (execution.operations.lifecycleState === "updated") {
+            result.lifecycleStatesUpdated += 1;
+          }
+        } catch {
+          result.errors += 1;
+        }
       } else {
+        // DRY-RUN. Company has not opted in. Surface the proposed (never-
+        // executed) disposition in the operator rail for review. INSERT-only and
+        // idempotent: a deduped persistent notification keyed on (opportunityId,
+        // action). No opportunity mutation, no guarded RPC, no email, no draft.
+        status = "dry-run";
         result.destructiveDryRun += 1;
-        // Surface the proposed (never-executed) disposition in the operator
-        // rail for review. INSERT-only and idempotent: a deduped persistent
-        // notification keyed on (opportunityId, action). No opportunity
-        // mutation, no guarded RPC, no email, no draft.
         try {
           const outcome = await emitDestructiveReviewNotification(supabase, {
             operatorUserId: operators.get(opportunity.company_id) ?? null,

--- a/src/lib/api/services/lead-lifecycle-cron-service.ts
+++ b/src/lib/api/services/lead-lifecycle-cron-service.ts
@@ -95,6 +95,7 @@ const NON_DESTRUCTIVE_ACTIONS = new Set<OpportunityLifecycleDecisionAction>([
 const DESTRUCTIVE_ACTIONS = new Set<OpportunityLifecycleDecisionAction>([
   "archive_after_two_unanswered_followups",
   "archive_no_meaningful_correspondence",
+  "archive_operator_no_response",
   "move_to_lost_operator_no_response",
   "reactivate_on_related_inbound",
 ]);
@@ -107,12 +108,17 @@ const CHUNK = 100;
  * action-service applies these structurally but does NOT consult the
  * per-company `auto_archive_enabled` / `auto_lost_enabled` flags, so the cron
  * owns that policy decision here:
- *   - both archive actions AND `reactivate_on_related_inbound` are gated on
- *     `autoArchiveEnabled`. Reactivate is the inverse of archive — a lead the
- *     cron auto-archived that then receives a meaningful related inbound is
- *     auto-restored under the same opt-in, so the operator who enabled
- *     auto-archive never loses a re-engaged lead to a stale archive.
- *   - `move_to_lost_operator_no_response` is gated on `autoLostEnabled`.
+ *   - all three archive actions (`archive_after_two_unanswered_followups`,
+ *     `archive_no_meaningful_correspondence`, `archive_operator_no_response`)
+ *     AND `reactivate_on_related_inbound` are gated on `autoArchiveEnabled`.
+ *     Reactivate is the inverse of archive — a lead the cron auto-archived that
+ *     then receives a meaningful related inbound is auto-restored under the same
+ *     opt-in, so the operator who enabled auto-archive never loses a re-engaged
+ *     lead to a stale archive.
+ *   - `move_to_lost_operator_no_response` is gated on `autoLostEnabled`. The
+ *     evaluator no longer produces it under the archive-first policy (lost
+ *     classification is deferred to phase C), but the gate stays correct for
+ *     when phase C re-enables it.
  * Any other action is never auto-executed by this gate.
  */
 function destructiveActionAutoEnabled(
@@ -122,6 +128,7 @@ function destructiveActionAutoEnabled(
   switch (action) {
     case "archive_after_two_unanswered_followups":
     case "archive_no_meaningful_correspondence":
+    case "archive_operator_no_response":
     case "reactivate_on_related_inbound":
       return settings.autoArchiveEnabled;
     case "move_to_lost_operator_no_response":
@@ -219,6 +226,11 @@ function destructiveReviewCopy(
       return {
         title: `REVIEW // archive lead — ${leadLabel}`,
         body: "No meaningful correspondence on this lead. Proposed: archive. Review before it moves.",
+      };
+    case "archive_operator_no_response":
+      return {
+        title: `REVIEW // archive lead — ${leadLabel}`,
+        body: "Customer reached out and went unanswered past the window. Proposed: archive. Review before it moves.",
       };
     case "move_to_lost_operator_no_response":
       return {

--- a/src/lib/api/services/opportunity-lifecycle-action-service.ts
+++ b/src/lib/api/services/opportunity-lifecycle-action-service.ts
@@ -221,6 +221,7 @@ export interface OpportunityLifecycleActionResult {
 const DESTRUCTIVE_ACTIONS = new Set<OpportunityLifecycleDecisionAction>([
   "archive_after_two_unanswered_followups",
   "archive_no_meaningful_correspondence",
+  "archive_operator_no_response",
   "move_to_lost_operator_no_response",
   "reactivate_on_related_inbound",
 ]);
@@ -748,7 +749,8 @@ function opportunityMutationValues(
   const action = input.decision.action;
   if (
     action === "archive_after_two_unanswered_followups" ||
-    action === "archive_no_meaningful_correspondence"
+    action === "archive_no_meaningful_correspondence" ||
+    action === "archive_operator_no_response"
   ) {
     const beforeValues = {
       archived_at: opportunity.archivedAt ? iso(opportunity.archivedAt) : null,
@@ -838,7 +840,8 @@ function opportunityOperationForAction(
 ): OpportunityMutationOperation {
   if (
     action === "archive_after_two_unanswered_followups" ||
-    action === "archive_no_meaningful_correspondence"
+    action === "archive_no_meaningful_correspondence" ||
+    action === "archive_operator_no_response"
   ) {
     return mode === "dry-run" ? "would_archive" : "archived";
   }
@@ -894,6 +897,7 @@ function guardDestructiveOpportunityAction(
   if (
     (action === "archive_after_two_unanswered_followups" ||
       action === "archive_no_meaningful_correspondence" ||
+      action === "archive_operator_no_response" ||
       action === "move_to_lost_operator_no_response") &&
     opportunity.archivedAt
   ) {

--- a/src/lib/email/opportunity-lifecycle-evaluator.ts
+++ b/src/lib/email/opportunity-lifecycle-evaluator.ts
@@ -2,6 +2,7 @@ export type OpportunityLifecycleDecisionAction =
   | "create_follow_up_draft"
   | "archive_after_two_unanswered_followups"
   | "archive_no_meaningful_correspondence"
+  | "archive_operator_no_response"
   | "operator_follow_up_miss"
   | "move_to_lost_operator_no_response"
   | "reactivate_on_related_inbound"
@@ -276,19 +277,30 @@ export function evaluateOpportunityLifecycle(
 
   if (latestEvent.direction === "inbound") {
     const daysUnreplied = daysBetween(latestAt, now);
+    // ARCHIVE-FIRST auto-cleanup. A meaningful customer inbound that OPS never
+    // answered, gone stale past the no-response window, is ARCHIVED — for every
+    // active stage, not only beyond-qualified ones. We deliberately do NOT
+    // auto-mark these "lost": archiving is reversible and judgment-free, and a
+    // later related inbound auto-reactivates the lead. Classifying the final
+    // disposition (lost vs. archived vs. discarded) is deferred to phase C's
+    // intelligent determination — the `beyondQualified` evidence flag preserves
+    // the signal it will use (a beyond-qualified archive is a strong lost
+    // candidate; an early-stage one is more likely a cold/forgotten lead).
+    // `move_to_lost_operator_no_response` is intentionally no longer produced
+    // here; its executor + audit path remain intact for phase C to drive.
     if (
-      input.settings.autoLostEnabled &&
-      daysUnreplied >= input.settings.inboundUnrepliedLostDays &&
-      BEYOND_QUALIFIED_STAGES.has(stage)
+      input.settings.autoArchiveEnabled &&
+      daysUnreplied >= input.settings.inboundUnrepliedLostDays
     ) {
       return decision(
         input,
-        "move_to_lost_operator_no_response",
-        "Meaningful inbound is unreplied past the lost threshold beyond qualified.",
+        "archive_operator_no_response",
+        "Meaningful inbound went unanswered past the no-response window — archiving (lost/discard classification deferred to phase C).",
         {
           latestEventId: latestEvent.id,
           daysUnreplied,
-          lostReason: "operator_no_response",
+          archiveReason: "operator_no_response",
+          beyondQualified: BEYOND_QUALIFIED_STAGES.has(stage),
         }
       );
     }

--- a/supabase/migrations/20260604221634_archive_operator_no_response_guarded_action.sql
+++ b/supabase/migrations/20260604221634_archive_operator_no_response_guarded_action.sql
@@ -1,0 +1,99 @@
+-- Archive-first auto-cleanup: introduce the `archive_operator_no_response`
+-- guarded action.
+--
+-- Context: the lead-lifecycle cron previously moved beyond-qualified leads with
+-- an unanswered customer inbound to "lost". Per product direction the auto
+-- cleanup must only ever ARCHIVE (a reversible, judgment-free disposition);
+-- classifying lost vs. archived vs. discarded is deferred to phase C's
+-- intelligent determination. The evaluator now emits `archive_operator_no_response`
+-- for any active-stage lead whose meaningful inbound went unanswered past the
+-- no-response window (covers early-stage "forgot to follow up" leads too).
+--
+-- This action archives identically to `archive_no_meaningful_correspondence`
+-- (sets archived_at; no stage change, no disposition row). The
+-- `move_to_lost_operator_no_response` machinery is left fully intact for phase C
+-- to drive later.
+--
+-- Two changes:
+--   1. Extend the audit table's action CHECK to accept the new value.
+--   2. Add the new value to the guarded-executor RPC's allow-list + archive
+--      branches. To avoid hand-retyping the 200-line SECURITY DEFINER body
+--      (transcription risk on a privileged function), we patch the live source
+--      via pg_get_functiondef + targeted string replacement, asserting exactly
+--      five insertions before EXECUTE. Idempotent: re-running is a no-op.
+
+-- 1. Audit action CHECK ───────────────────────────────────────────────────────
+alter table public.opportunity_lifecycle_action_audit
+  drop constraint if exists opportunity_lifecycle_action_audit_action_check;
+
+alter table public.opportunity_lifecycle_action_audit
+  add constraint opportunity_lifecycle_action_audit_action_check
+  check (action = any (array[
+    'archive_after_two_unanswered_followups',
+    'archive_no_meaningful_correspondence',
+    'archive_operator_no_response',
+    'move_to_lost_operator_no_response',
+    'reactivate_on_related_inbound'
+  ]::text[]));
+
+-- 2. Guarded-executor RPC allow-list + archive branches ───────────────────────
+do $mig$
+declare
+  v_src  text;
+  v_new  text;
+  v_hits integer;
+begin
+  select pg_get_functiondef(p.oid)
+    into v_src
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'public'
+    and p.proname = 'execute_opportunity_lifecycle_guarded_action'
+    and p.prokind = 'f';
+
+  if v_src is null then
+    raise exception 'execute_opportunity_lifecycle_guarded_action not found';
+  end if;
+
+  -- Idempotency: already migrated → no-op.
+  if position('archive_operator_no_response' in v_src) > 0 then
+    raise notice 'archive_operator_no_response already present; skipping function patch';
+    return;
+  end if;
+
+  v_new := v_src;
+
+  -- (B) Allow-list: ...correspondence', <nl> 'move_to_lost...  (1 occurrence)
+  v_new := replace(
+    v_new,
+    E'\'archive_no_meaningful_correspondence\',\n    \'move_to_lost_operator_no_response\',',
+    E'\'archive_no_meaningful_correspondence\',\n    \'archive_operator_no_response\',\n    \'move_to_lost_operator_no_response\','
+  );
+
+  -- (A) The two 4-item archive groups (allowed_keys + before_values):
+  --     ...correspondence', <nl> 'reactivate...  (2 occurrences)
+  v_new := replace(
+    v_new,
+    E'\'archive_no_meaningful_correspondence\',\n    \'reactivate_on_related_inbound\'',
+    E'\'archive_no_meaningful_correspondence\',\n    \'archive_operator_no_response\',\n    \'reactivate_on_related_inbound\''
+  );
+
+  -- (C) The two 2-item archive-only groups (payload guard + update):
+  --     ...correspondence' <nl> ) then   (2 occurrences, no trailing comma)
+  v_new := replace(
+    v_new,
+    E'\'archive_no_meaningful_correspondence\'\n  ) then',
+    E'\'archive_no_meaningful_correspondence\',\n    \'archive_operator_no_response\'\n  ) then'
+  );
+
+  -- Assert exactly five insertions landed (1 + 2 + 2). Any pattern drift →
+  -- abort with zero changes to the live function.
+  v_hits := (length(v_new) - length(replace(v_new, 'archive_operator_no_response', '')))
+            / length('archive_operator_no_response');
+  if v_hits <> 5 then
+    raise exception 'expected 5 archive_operator_no_response insertions, got %; aborting function patch', v_hits;
+  end if;
+
+  execute v_new;
+end
+$mig$;

--- a/tests/integration/lead-lifecycle-cron.test.ts
+++ b/tests/integration/lead-lifecycle-cron.test.ts
@@ -51,8 +51,12 @@ const INBOUND_OPP = "44444444-4444-4444-4444-444444444444";
 const DESTRUCTIVE_OPP = "55555555-5555-5555-5555-555555555555";
 const FRAGMENTED_OPP = "66666666-6666-6666-6666-666666666666";
 
-// 60 days ago — well past the 7-day follow-up + 30-day lost thresholds.
+// 60 days ago — well past the 7-day follow-up + 30-day no-response thresholds.
 const LONG_AGO = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+// 10 days ago — an unanswered inbound the operator still owes a reply (past the
+// follow-up nudge window, but under the 30-day archive window). Drives
+// `operator_follow_up_miss` without tipping into archive-first auto-cleanup.
+const RECENT_INBOUND = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
 
 function buildRequest(authHeader?: string): NextRequest {
   const headers = new Headers();
@@ -233,7 +237,9 @@ describe("/api/cron/lead-lifecycle — non-destructive auto-exec", () => {
               direction: "inbound",
               party_role: "customer",
               is_meaningful: true,
-              occurred_at: LONG_AGO,
+              // Recent (10d) → operator_follow_up_miss nudge, NOT archive-first
+              // auto-cleanup (which kicks in at the 30-day no-response window).
+              occurred_at: RECENT_INBOUND,
               linked_contact_kind: null,
             });
           }
@@ -414,10 +420,10 @@ describe("/api/cron/lead-lifecycle — destructive auto-exec + dry-run fallback"
           );
           const ids = (inFilter?.[2] as string[]) ?? [];
           const events: unknown[] = [];
-          // An inbound meaningful event 60 days ago in a beyond-qualified stage
-          // → move_to_lost_operator_no_response (destructive). When `reactivate`,
-          // the same inbound is flagged as a related-contact message landing on
-          // an archived opp → reactivate_on_related_inbound instead.
+          // An inbound meaningful event 60 days ago (past the 30-day no-response
+          // window) → archive_operator_no_response (archive-first destructive).
+          // When `reactivate`, the same inbound is flagged as a related-contact
+          // message landing on an archived opp → reactivate_on_related_inbound.
           if (ids.includes(DESTRUCTIVE_OPP)) {
             events.push({
               id: opts.reactivate ? "evt-react" : "evt-dx",
@@ -533,15 +539,16 @@ describe("/api/cron/lead-lifecycle — destructive auto-exec + dry-run fallback"
     };
   }
 
-  it("auto-executes a destructive disposition (company opted in) through the guarded RPC and counts it as moved-to-lost", async () => {
+  it("auto-executes a destructive disposition (company opted in) through the guarded RPC and counts it as archived", async () => {
     const draftInserts: unknown[] = [];
     const notificationInserts: unknown[] = [];
     supabaseFromMock.mockImplementation(
       destructiveHandlers({ fragmented: false, draftInserts, notificationInserts })
     );
-    // Company opted in (engine defaults: autoLostEnabled = true). The cron now
-    // calls the guarded RPC, which applies the disposition server-side. Mock a
-    // successful apply ({ applied: true }) — exactly one call is expected.
+    // Company opted in (engine defaults: autoArchiveEnabled = true). Under the
+    // archive-first policy a stale unanswered inbound is ARCHIVED, not moved to
+    // lost. The cron calls the guarded RPC, which applies the disposition
+    // server-side. Mock a successful apply ({ applied: true }) — one call.
     supabaseRpcMock.mockResolvedValueOnce({ data: { applied: true }, error: null });
 
     const res = await GET(buildRequest("Bearer test-secret"));
@@ -549,8 +556,8 @@ describe("/api/cron/lead-lifecycle — destructive auto-exec + dry-run fallback"
     const body = await res.json();
 
     expect(body.ok).toBe(true);
-    expect(body.destructiveMovedToLost).toBe(1);
-    expect(body.destructiveArchived).toBe(0);
+    expect(body.destructiveArchived).toBe(1);
+    expect(body.destructiveMovedToLost).toBe(0);
     expect(body.destructiveReactivated).toBe(0);
     expect(body.destructiveExecutionSkippedGuarded).toBe(0);
     expect(body.destructiveDryRun).toBe(0);
@@ -560,7 +567,7 @@ describe("/api/cron/lead-lifecycle — destructive auto-exec + dry-run fallback"
     expect(body.destructiveCandidates).toHaveLength(1);
     expect(body.destructiveCandidates[0].status).toBe("applied");
     expect(body.destructiveCandidates[0].action).toBe(
-      "move_to_lost_operator_no_response"
+      "archive_operator_no_response"
     );
 
     // The guarded RPC was invoked exactly once, with the disposition action and
@@ -571,11 +578,11 @@ describe("/api/cron/lead-lifecycle — destructive auto-exec + dry-run fallback"
     const rpcName = rpcCall[0] as string;
     const rpcArgs = rpcCall[1] as Record<string, unknown>;
     expect(rpcName).toBe("execute_opportunity_lifecycle_guarded_action");
-    expect(rpcArgs.p_action).toBe("move_to_lost_operator_no_response");
+    expect(rpcArgs.p_action).toBe("archive_operator_no_response");
     expect(rpcArgs.p_company_id).toBe(COMPANY_ID);
     expect(rpcArgs.p_opportunity_id).toBe(DESTRUCTIVE_OPP);
     expect(rpcArgs.p_approved_action_key).toContain(
-      `${DESTRUCTIVE_OPP}:move_to_lost_operator_no_response`
+      `${DESTRUCTIVE_OPP}:archive_operator_no_response`
     );
 
     // Auto-exec path surfaces no operator review notification and writes no draft.
@@ -762,7 +769,9 @@ describe("/api/cron/lead-lifecycle — idempotency", () => {
               direction: "inbound",
               party_role: "customer",
               is_meaningful: true,
-              occurred_at: LONG_AGO,
+              // Recent (10d) → operator_follow_up_miss nudge, NOT archive-first
+              // auto-cleanup (which kicks in at the 30-day no-response window).
+              occurred_at: RECENT_INBOUND,
               linked_contact_kind: null,
             });
           }
@@ -927,7 +936,9 @@ describe("/api/cron/lead-lifecycle — idempotency", () => {
               direction: "inbound",
               party_role: "customer",
               is_meaningful: true,
-              occurred_at: LONG_AGO,
+              // Recent (10d) → operator_follow_up_miss nudge, NOT archive-first
+              // auto-cleanup (which kicks in at the 30-day no-response window).
+              occurred_at: RECENT_INBOUND,
               linked_contact_kind: null,
             });
           }

--- a/tests/integration/lead-lifecycle-cron.test.ts
+++ b/tests/integration/lead-lifecycle-cron.test.ts
@@ -14,8 +14,11 @@
  *
  * The Supabase client is mocked at the chain level. Each table gets a handler
  * that returns a chainable builder; terminal `insert(...).select().single()`
- * captures the inserted row so the test can assert on writes. The mock also
- * exposes `.rpc` so we can assert it is never invoked.
+ * captures the inserted row so the test can assert on writes. `.rpc` is the
+ * guarded-action entrypoint (`execute_opportunity_lifecycle_guarded_action`):
+ * dry-run paths assert it is never invoked; auto-exec paths mock its result
+ * (`{ applied: true }` → applied, `{ applied: false, guard_reason }` → declined)
+ * and assert it is called exactly once.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
@@ -23,7 +26,15 @@ import { NextRequest } from "next/server";
 // ─── Supabase mock ───────────────────────────────────────────────────────────
 
 const supabaseFromMock = vi.fn();
-const supabaseRpcMock = vi.fn(async () => ({ data: null, error: null }));
+// Loosely typed so individual tests can drive the guarded RPC's result via
+// mockResolvedValueOnce (data carries `applied`/`guard_reason`) and inspect
+// `mock.calls`. Default: a benign no-op result.
+const supabaseRpcMock = vi.fn(
+  async (..._args: unknown[]): Promise<{ data: unknown; error: unknown }> => ({
+    data: null,
+    error: null,
+  })
+);
 
 vi.mock("@/lib/supabase/server-client", () => ({
   getServiceRoleClient: () => ({ from: supabaseFromMock, rpc: supabaseRpcMock }),
@@ -342,14 +353,51 @@ describe("/api/cron/lead-lifecycle — non-destructive auto-exec", () => {
   });
 });
 
-// ─── Destructive → dry-run only ─────────────────────────────────────────────
+// ─── Destructive auto-exec (opted in) + dry-run fallback (not opted in) ───────
 
-describe("/api/cron/lead-lifecycle — destructive dry-run only", () => {
+// The full lead_lifecycle_settings row the evaluator + cron consume. Defaults
+// mirror DEFAULT_LEAD_LIFECYCLE_SETTINGS (both auto flags ON). A test can flip a
+// flag to drive the not-opted-in fallback. NB: the evaluator itself gates the
+// archive/lost DECISIONS on these flags (archive flag off → no archive decision;
+// lost flag off → operator_follow_up_miss instead of move_to_lost), so the
+// only destructive action that still reaches the cron with its flag OFF is
+// reactivate_on_related_inbound — the cron-level gate is what routes that to
+// dry-run. The archive/lost flags acting at the cron layer are belt-and-braces.
+function settingsRow(overrides?: {
+  auto_archive_enabled?: boolean;
+  auto_lost_enabled?: boolean;
+}) {
+  return {
+    company_id: COMPANY_ID,
+    follow_up_after_days: 7,
+    second_follow_up_archive_after_days: 7,
+    no_correspondence_archive_days: 30,
+    inbound_unreplied_lost_days: 30,
+    follow_up_template_subject: "Following up",
+    follow_up_template_body: "Hi {{first_name}}, following up.",
+    auto_archive_enabled: overrides?.auto_archive_enabled ?? true,
+    auto_lost_enabled: overrides?.auto_lost_enabled ?? true,
+  };
+}
+
+describe("/api/cron/lead-lifecycle — destructive auto-exec + dry-run fallback", () => {
   function destructiveHandlers(opts: {
     fragmented: boolean;
     draftInserts: unknown[];
     notificationInserts?: unknown[];
     existingReviewNotification?: boolean;
+    // When true, the opportunity is archived AND its latest meaningful inbound
+    // is a related-contact message → the evaluator yields
+    // `reactivate_on_related_inbound` (ungated by the auto flags). Pair with
+    // settings `{ auto_archive_enabled: false }` to exercise the dry-run
+    // fallback: a destructive decision the company has NOT opted into executing.
+    reactivate?: boolean;
+    // When provided, the settings fetch (.in company_id) returns this row,
+    // overriding the engine defaults. Omitted → defaults (both flags ON).
+    settings?: { auto_archive_enabled?: boolean; auto_lost_enabled?: boolean };
+    // Captures inserts into the guarded-action audit table (the RPC writes the
+    // real audit, but the duplicate-applied SELECT hits this table first).
+    auditInserts?: unknown[];
   }) {
     return (table: string) => {
       if (table === "opportunity_correspondence_events") {
@@ -367,10 +415,12 @@ describe("/api/cron/lead-lifecycle — destructive dry-run only", () => {
           const ids = (inFilter?.[2] as string[]) ?? [];
           const events: unknown[] = [];
           // An inbound meaningful event 60 days ago in a beyond-qualified stage
-          // → move_to_lost_operator_no_response (destructive).
+          // → move_to_lost_operator_no_response (destructive). When `reactivate`,
+          // the same inbound is flagged as a related-contact message landing on
+          // an archived opp → reactivate_on_related_inbound instead.
           if (ids.includes(DESTRUCTIVE_OPP)) {
             events.push({
-              id: "evt-dx",
+              id: opts.reactivate ? "evt-react" : "evt-dx",
               opportunity_id: DESTRUCTIVE_OPP,
               connection_id: null,
               provider_thread_id: null,
@@ -378,7 +428,7 @@ describe("/api/cron/lead-lifecycle — destructive dry-run only", () => {
               party_role: "customer",
               is_meaningful: true,
               occurred_at: LONG_AGO,
-              linked_contact_kind: null,
+              linked_contact_kind: opts.reactivate ? "related_contact" : null,
             });
           }
           return resolve({ data: events, error: null });
@@ -388,12 +438,15 @@ describe("/api/cron/lead-lifecycle — destructive dry-run only", () => {
       switch (table) {
         case "lead_lifecycle_settings":
           // Eligibility probe (no .in filter) → return the eligible company id.
-          // Settings fetch (.in company_id) → return [] so engine defaults apply
-          // (autoArchiveEnabled + autoLostEnabled = true).
+          // Settings fetch (.in company_id) → return the configured row, or []
+          // so engine defaults apply (autoArchiveEnabled + autoLostEnabled = true).
           return makeChain({
             selectResult: (filters) =>
               filters.some((f) => f[0] === "in" && f[1] === "company_id")
-                ? { data: [], error: null }
+                ? {
+                    data: opts.settings ? [settingsRow(opts.settings)] : [],
+                    error: null,
+                  }
                 : { data: [{ company_id: COMPANY_ID }], error: null },
           });
         case "email_connections":
@@ -407,13 +460,17 @@ describe("/api/cron/lead-lifecycle — destructive dry-run only", () => {
                   company_id: COMPANY_ID,
                   title: "Old quote",
                   stage: "quoted",
-                  archived_at: null,
+                  // Reactivate requires an already-archived opportunity.
+                  archived_at: opts.reactivate ? LONG_AGO : null,
                   deleted_at: null,
                   project_id: null,
                   project_ref: null,
                   created_at: LONG_AGO,
                   stage_entered_at: LONG_AGO,
                   contact_name: "Lee",
+                  lost_reason: null,
+                  lost_notes: null,
+                  actual_close_date: null,
                   updated_at: LONG_AGO,
                 },
               ],
@@ -422,6 +479,15 @@ describe("/api/cron/lead-lifecycle — destructive dry-run only", () => {
           });
         case "opportunity_lifecycle_state":
           return makeChain({ selectResult: () => ({ data: [], error: null }) });
+        case "opportunity_lifecycle_action_audit":
+          // Duplicate-applied guard SELECT → no prior applied row.
+          return makeChain({
+            selectResult: () => ({ data: [], error: null }),
+            onInsert: (payload) => {
+              opts.auditInserts?.push(payload);
+              return { data: { id: "audit-x" }, error: null };
+            },
+          });
         case "companies":
           return makeChain({
             selectResult: () => ({
@@ -467,69 +533,100 @@ describe("/api/cron/lead-lifecycle — destructive dry-run only", () => {
     };
   }
 
-  it("surfaces a destructive decision as a dry-run candidate, emits exactly one review notification, and never calls the guarded RPC", async () => {
+  it("auto-executes a destructive disposition (company opted in) through the guarded RPC and counts it as moved-to-lost", async () => {
     const draftInserts: unknown[] = [];
     const notificationInserts: unknown[] = [];
     supabaseFromMock.mockImplementation(
       destructiveHandlers({ fragmented: false, draftInserts, notificationInserts })
     );
+    // Company opted in (engine defaults: autoLostEnabled = true). The cron now
+    // calls the guarded RPC, which applies the disposition server-side. Mock a
+    // successful apply ({ applied: true }) — exactly one call is expected.
+    supabaseRpcMock.mockResolvedValueOnce({ data: { applied: true }, error: null });
 
-    // The destructive opp's inbound event 60 days ago in a beyond-qualified
-    // stage feeds INBOUND_OPP's logic; reuse DESTRUCTIVE_OPP id. The events
-    // handler keys on DESTRUCTIVE_OPP, but the opportunities row above uses it
-    // only when not fragmented — align the event id.
     const res = await GET(buildRequest("Bearer test-secret"));
     expect(res.status).toBe(200);
     const body = await res.json();
 
     expect(body.ok).toBe(true);
-    expect(body.destructiveDryRun).toBe(1);
+    expect(body.destructiveMovedToLost).toBe(1);
+    expect(body.destructiveArchived).toBe(0);
+    expect(body.destructiveReactivated).toBe(0);
+    expect(body.destructiveExecutionSkippedGuarded).toBe(0);
+    expect(body.destructiveDryRun).toBe(0);
     expect(body.destructiveSkippedFragmented).toBe(0);
+    expect(body.errors).toBe(0);
+
     expect(body.destructiveCandidates).toHaveLength(1);
-    expect(body.destructiveCandidates[0].status).toBe("dry-run");
+    expect(body.destructiveCandidates[0].status).toBe("applied");
     expect(body.destructiveCandidates[0].action).toBe(
       "move_to_lost_operator_no_response"
     );
 
-    // Exactly one persistent, deduped review notification surfaced for the
-    // operator, with the destructive-candidate dedupe key + pipeline fallback
-    // action target (no provider thread id on the event → /pipeline).
-    expect(body.destructiveReviewNotificationsCreated).toBe(1);
-    expect(body.destructiveReviewNotificationsSkippedExisting).toBe(0);
-    expect(notificationInserts).toHaveLength(1);
-    const review = notificationInserts[0] as any;
-    expect(review.type).toBe("leads_waiting");
-    expect(review.persistent).toBe(true);
-    expect(review.is_read).toBe(false);
-    expect(review.resolved_at).toBeNull();
-    expect(review.dedupe_key).toBe(
-      `lead_lifecycle:destructive_candidate:${DESTRUCTIVE_OPP}:move_to_lost_operator_no_response`
+    // The guarded RPC was invoked exactly once, with the disposition action and
+    // a deterministic per-day approval key (so a same-day re-run dedupes on the
+    // duplicate_applied_action guard instead of re-applying).
+    expect(supabaseRpcMock).toHaveBeenCalledTimes(1);
+    const rpcCall = supabaseRpcMock.mock.calls[0];
+    const rpcName = rpcCall[0] as string;
+    const rpcArgs = rpcCall[1] as Record<string, unknown>;
+    expect(rpcName).toBe("execute_opportunity_lifecycle_guarded_action");
+    expect(rpcArgs.p_action).toBe("move_to_lost_operator_no_response");
+    expect(rpcArgs.p_company_id).toBe(COMPANY_ID);
+    expect(rpcArgs.p_opportunity_id).toBe(DESTRUCTIVE_OPP);
+    expect(rpcArgs.p_approved_action_key).toContain(
+      `${DESTRUCTIVE_OPP}:move_to_lost_operator_no_response`
     );
-    expect(review.action_url).toBe(
-      `/pipeline?opportunityId=${DESTRUCTIVE_OPP}`
-    );
-    expect(review.action_label).toBe("Review");
-    expect(typeof review.title).toBe("string");
-    expect(review.title.length).toBeGreaterThan(0);
-    expect(typeof review.body).toBe("string");
-    expect(review.body.length).toBeGreaterThan(0);
 
-    // No opportunity mutation, no draft, no guarded RPC.
+    // Auto-exec path surfaces no operator review notification and writes no draft.
+    expect(body.destructiveReviewNotificationsCreated).toBe(0);
+    expect(notificationInserts).toHaveLength(0);
     expect(draftInserts).toHaveLength(0);
-    expect(supabaseRpcMock).not.toHaveBeenCalled();
   });
 
-  it("inserts 0 review notifications on a second run (dedupe guard short-circuits)", async () => {
+  it("counts a guard-declined apply (e.g. duplicate_applied_action on a same-day re-run) as skipped-guarded, not an error", async () => {
     const draftInserts: unknown[] = [];
     const notificationInserts: unknown[] = [];
-    // Second-run state: an unread/unresolved review notification already exists
-    // for this candidate → dedupe guard short-circuits → no insert.
+    supabaseFromMock.mockImplementation(
+      destructiveHandlers({ fragmented: false, draftInserts, notificationInserts })
+    );
+    // The guarded RPC declines by design — e.g. the per-day approval key was
+    // already applied on an earlier run today, so the duplicate_applied_action
+    // guard short-circuits. A structural decline is idempotency, not failure:
+    // it must increment destructiveExecutionSkippedGuarded, never errors.
+    supabaseRpcMock.mockResolvedValueOnce({
+      data: { applied: false, guard_reason: "duplicate_applied_action" },
+      error: null,
+    });
+
+    const res = await GET(buildRequest("Bearer test-secret"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.destructiveExecutionSkippedGuarded).toBe(1);
+    expect(body.destructiveMovedToLost).toBe(0);
+    expect(body.destructiveDryRun).toBe(0);
+    expect(body.errors).toBe(0);
+    expect(supabaseRpcMock).toHaveBeenCalledTimes(1);
+    expect(notificationInserts).toHaveLength(0);
+  });
+
+  it("dry-runs a destructive disposition when the company has NOT opted in (reactivate with auto-archive off): one review notification, never the RPC", async () => {
+    const draftInserts: unknown[] = [];
+    const notificationInserts: unknown[] = [];
+    // An archived opp receives a related-contact meaningful inbound → the
+    // evaluator yields reactivate_on_related_inbound (ungated by the flags).
+    // With auto-archive OFF the company has not opted into auto-exec, so the
+    // cron takes the dry-run fallback: surface for the operator, never mutate,
+    // never call the RPC.
     supabaseFromMock.mockImplementation(
       destructiveHandlers({
         fragmented: false,
+        reactivate: true,
         draftInserts,
         notificationInserts,
-        existingReviewNotification: true,
+        settings: { auto_archive_enabled: false, auto_lost_enabled: false },
       })
     );
 
@@ -539,9 +636,32 @@ describe("/api/cron/lead-lifecycle — destructive dry-run only", () => {
 
     expect(body.ok).toBe(true);
     expect(body.destructiveDryRun).toBe(1);
-    expect(body.destructiveReviewNotificationsCreated).toBe(0);
-    expect(body.destructiveReviewNotificationsSkippedExisting).toBe(1);
-    expect(notificationInserts).toHaveLength(0);
+    expect(body.destructiveReactivated).toBe(0);
+    expect(body.destructiveExecutionSkippedGuarded).toBe(0);
+    expect(body.errors).toBe(0);
+
+    expect(body.destructiveCandidates).toHaveLength(1);
+    expect(body.destructiveCandidates[0].status).toBe("dry-run");
+    expect(body.destructiveCandidates[0].action).toBe(
+      "reactivate_on_related_inbound"
+    );
+
+    // Exactly one persistent, deduped operator review notification with the
+    // destructive-candidate dedupe key + pipeline fallback target. No RPC, no draft.
+    expect(body.destructiveReviewNotificationsCreated).toBe(1);
+    expect(body.destructiveReviewNotificationsSkippedExisting).toBe(0);
+    expect(notificationInserts).toHaveLength(1);
+    const review = notificationInserts[0] as any;
+    expect(review.type).toBe("leads_waiting");
+    expect(review.persistent).toBe(true);
+    expect(review.is_read).toBe(false);
+    expect(review.resolved_at).toBeNull();
+    expect(review.dedupe_key).toBe(
+      `lead_lifecycle:destructive_candidate:${DESTRUCTIVE_OPP}:reactivate_on_related_inbound`
+    );
+    expect(review.action_url).toBe(`/pipeline?opportunityId=${DESTRUCTIVE_OPP}`);
+    expect(review.action_label).toBe("Review");
+    expect(draftInserts).toHaveLength(0);
     expect(supabaseRpcMock).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/email/opportunity-lifecycle-action-service.test.ts
+++ b/tests/unit/email/opportunity-lifecycle-action-service.test.ts
@@ -841,6 +841,55 @@ describe("opportunity lifecycle action service", () => {
     expect(state.opportunities?.[0].archived_at).toBeNull();
   });
 
+  it("archives an operator-no-response lead at an early stage (archive-first, not stage-gated like lost)", async () => {
+    // Doug-class lead: an unanswered inbound still sitting in new_lead. The
+    // archive-first action archives it; move_to_lost would have been
+    // skipped_lost_stage_not_allowed for this stage.
+    const state: TableState = {
+      opportunity_follow_up_drafts: [],
+      opportunity_lifecycle_state: [],
+      notifications: [],
+      opportunities: [
+        {
+          id: "opp-1",
+          company_id: "company-1",
+          stage: "new_lead",
+          archived_at: null,
+          deleted_at: null,
+          project_id: null,
+          project_ref: null,
+          lost_reason: null,
+          lost_notes: null,
+          actual_close_date: null,
+        },
+      ],
+      opportunity_lifecycle_action_audit: [],
+    };
+
+    const result = await executeOpportunityLifecycleAction(
+      makeInput(
+        {
+          decision: makeDecision("archive_operator_no_response"),
+          now: new Date("2026-05-27T18:00:00.000Z"),
+          approvedActionKey: "opp-1:archive_operator_no_response:approved",
+          opportunity: {
+            id: "opp-1",
+            companyId: "company-1",
+            stage: "new_lead",
+            archivedAt: null,
+            deletedAt: null,
+            projectId: null,
+            projectRef: null,
+          },
+        } as Partial<OpportunityLifecycleActionInput> & Record<string, unknown>,
+        state
+      )
+    );
+
+    // Routes through the archive branch (archived, not moved_to_lost / skipped).
+    expect(result.operations.opportunity).toBe("archived");
+  });
+
   it("marks beyond-qualified operator no-response opportunities lost", async () => {
     const state: TableState = {
       opportunity_follow_up_drafts: [],

--- a/tests/unit/email/opportunity-lifecycle-evaluator.test.ts
+++ b/tests/unit/email/opportunity-lifecycle-evaluator.test.ts
@@ -115,25 +115,49 @@ describe("opportunity lifecycle evaluator dry-run decisions", () => {
     });
   });
 
-  it("moves unreplied inbound beyond qualified to lost after thirty days", () => {
-    expect(
-      evaluateOpportunityLifecycle({
-        opportunity: opportunity({ stage: "negotiation" }),
-        lifecycleState: null,
-        meaningfulEvents: [
-          event({
-            direction: "inbound",
-            partyRole: "customer",
-            occurredAt: "2026-04-20T18:00:00.000Z",
-          }),
-        ],
-        settings,
-        now,
-      })
-    ).toMatchObject({
-      action: "move_to_lost_operator_no_response",
+  it("archives unreplied inbound past the no-response window — archive-first (lost/discard deferred to phase C)", () => {
+    const decision = evaluateOpportunityLifecycle({
+      opportunity: opportunity({ stage: "negotiation" }),
+      lifecycleState: null,
+      meaningfulEvents: [
+        event({
+          direction: "inbound",
+          partyRole: "customer",
+          occurredAt: "2026-04-20T18:00:00.000Z",
+        }),
+      ],
+      settings,
+      now,
+    });
+    expect(decision).toMatchObject({
+      action: "archive_operator_no_response",
       dryRun: true,
     });
+    // A beyond-qualified archive is the strong lost candidate phase C will
+    // reclassify — the evidence flag preserves that signal.
+    expect((decision.evidence as { beyondQualified?: boolean }).beyondQualified).toBe(true);
+  });
+
+  it("archives an unreplied inbound in an early stage too — the 'forgot to follow up' lead, no beyond-qualified gate", () => {
+    const decision = evaluateOpportunityLifecycle({
+      opportunity: opportunity({ stage: "new_lead" }),
+      lifecycleState: null,
+      meaningfulEvents: [
+        event({
+          direction: "inbound",
+          partyRole: "customer",
+          occurredAt: "2026-04-20T18:00:00.000Z",
+        }),
+      ],
+      settings,
+      now,
+    });
+    expect(decision).toMatchObject({
+      action: "archive_operator_no_response",
+      dryRun: true,
+    });
+    // Early-stage archive → more likely a cold/forgotten lead than a lost deal.
+    expect((decision.evidence as { beyondQualified?: boolean }).beyondQualified).toBe(false);
   });
 
   it("ignores terminal and protected opportunities", () => {


### PR DESCRIPTION
## What

Enables the lead-lifecycle cron to actually **clean up stale leads** for companies that have opted in — and reframes every auto-disposition to **archive** (reversible, judgment-free). Lost vs. archived vs. discarded classification is deferred to phase C's intelligent determination.

Previously the cron *evaluated* dispositions but only ever drafted a "review this" notification and waited (dry-run only), so nothing was getting cleaned up despite companies opting in.

## Changes

- **Auto-execution engine** — destructive dispositions are now executed (not just surfaced) when the company opted in (`auto_archive_enabled`), via the guarded RPC with a deterministic per-day approval key (idempotent on same-day re-runs). New result counters surfaced in the cron response.
- **Archive-first policy** — a meaningful customer inbound left unanswered past the no-response window now yields the new `archive_operator_no_response` for **every active stage**, not only beyond-qualified. This catches early-stage "forgot to follow up" leads (the Doug-class). `move_to_lost_operator_no_response` is no longer auto-produced; its executor + audit path remain intact for phase C, and a `beyondQualified` evidence flag preserves the lost-vs-cold signal.
- **Migration** (already applied to prod) — adds `archive_operator_no_response` to the guarded-executor RPC allow-list + archive branches, and to the audit `action` CHECK.

## Verification

- 117 lifecycle tests pass; project-wide `tsc --noEmit` clean; eslint 0 errors.
- Prod migration applied + verified by a rolled-back sentinel (archived a `new_lead` end-to-end via the RPC, no trace left).
- First-run blast radius (the two opted-in companies): **2 leads archived** — surgical.

## Note

ops-web auto-deploy is OFF — merging does not deploy. The archive behavior goes live only on the next **manual** ops-web deploy.