### PR TITLE
Nightly Bug Sweep — web — 2026-06-05 — Batch 01

### DIFF
--- a/src/components/ops/create-lead-modal.tsx
+++ b/src/components/ops/create-lead-modal.tsx
@@ -321,7 +321,47 @@ export function CreateLeadForm({ onSuccess, onCancel }: CreateLeadFormProps) {
 
         <ClientSelector
           value={watch("clientId")}
-          onChange={(id) => setValue("clientId", id)}
+          onChange={(id) => {
+            setValue("clientId", id, { shouldDirty: true });
+            // When a client is linked, prefill the contact fields with the
+            // client's saved details so the operator doesn't have to retype
+            // information that already lives in the client record. Empty
+            // form fields are filled in; fields the user has already touched
+            // (i.e. non-empty) are preserved so we never overwrite work.
+            if (!id) return;
+            const client = clients.find((c) => c.id === id);
+            if (!client) return;
+            const currentName = watch("contactName");
+            const currentEmail = watch("contactEmail");
+            const currentPhone = watch("contactPhone");
+            const currentAddress = watch("address");
+            const currentTitle = watch("title");
+            if (!currentName.trim() && client.name) {
+              setValue("contactName", client.name, { shouldDirty: true });
+              // Mirror the auto-title behaviour that the contactName input's
+              // onChange handler provides for typed input.
+              if (!titleManuallyEdited && !currentTitle.trim()) {
+                setValue(
+                  "title",
+                  `${client.name} - ${t("quickAdd.leadSuffix")}`,
+                  { shouldDirty: true }
+                );
+              }
+            }
+            if (!currentEmail?.trim() && client.email) {
+              setValue("contactEmail", client.email, { shouldDirty: true });
+            }
+            if (!currentPhone?.trim() && client.phoneNumber) {
+              setValue(
+                "contactPhone",
+                formatPhoneInput(client.phoneNumber),
+                { shouldDirty: true }
+              );
+            }
+            if (!currentAddress?.trim() && client.address) {
+              setValue("address", client.address, { shouldDirty: true });
+            }
+          }}
           clients={clients}
         />
 

--- a/src/components/ops/projects/workspace/inputs/address-autocomplete.tsx
+++ b/src/components/ops/projects/workspace/inputs/address-autocomplete.tsx
@@ -276,7 +276,7 @@ export function AddressAutocomplete({
       <div className="relative">
         {!isInline ? (
           <MapPin
-            size={14}
+            size={16}
             strokeWidth={1.5}
             className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
             style={{ color: "var(--text-3)" }}
@@ -324,7 +324,7 @@ export function AddressAutocomplete({
                 }
               : {
                   color: "var(--text)",
-                  paddingLeft: 32,
+                  paddingLeft: 36,
                   paddingRight: 12,
                   paddingTop: 9,
                   paddingBottom: 9,


### PR DESCRIPTION
## Bugs in this batch

- [ ] `1ff0b49e` — bug — Address input field icon/text overlap
  - Root cause: the AddressAutocomplete default variant placed a 14px MapPin icon at left-3 (12px) with paddingLeft: 32, leaving only a 6px gap that visually crashed into the typed text on the pipeline stage-transition dialog. Fix bumps the icon to 16px (matching the codebase's standard input icon size) and widens paddingLeft to 36 for a clean 8px buffer. The inline variant of the same component is untouched (it renders no icon).
- [ ] `c9297c1a` — bug — Auto-populate contact fields when linking client on new lead
  - Root cause: the ClientSelector in the New Lead modal only set `clientId` on pick; it never copied the linked client's saved name, email, phone, or address into the form, forcing the operator to retype information that already lived on the client record. Fix prefills `contactName` / `contactEmail` / `contactPhone` / `address` from the chosen Client row, but only when the matching form field is empty — operator-typed values are preserved. Phone routes through the existing `formatPhoneInput` helper, and the deal-title auto-derivation continues to honour the `titleManuallyEdited` gate.

---
Generated by nightly-bug-triage-web (2026-06-05, batch 01).