### PR TITLE
fix(auth): create_progress_invoice Firebase-safe caller resolution (CRIT-3)

### DIFF
--- a/supabase/migrations/20260615220000_crit3_create_progress_invoice_firebase_subject.sql
+++ b/supabase/migrations/20260615220000_crit3_create_progress_invoice_firebase_subject.sql
@@ -1,0 +1,70 @@
+-- create_progress_invoice: resolve the caller via the Firebase-safe identity
+-- helper instead of raw auth.uid().
+--
+-- public.create_progress_invoice authorized the caller with
+--   SELECT company_id INTO v_caller_company FROM users WHERE auth_id = auth.uid();
+-- auth.uid() casts the request.jwt 'sub' claim to uuid. Post
+-- crit3_phase_c_rekey_rls_identity_helpers (2026-06-14) 'sub' is the Firebase
+-- subject (a non-uuid) for every bridged client session, so the cast raises
+-- 22P02 ("invalid input syntax for type uuid") and the RPC throws before doing
+-- any work. This is the same class of regression fixed for the QBO acceptance
+-- bridge; create_progress_invoice is a user-callable RPC (granted to
+-- anon/authenticated) so it is reachable by Firebase-subject sessions.
+--
+-- FIX: resolve the caller's company through private.get_user_company_id(), the
+-- canonical crit3 helper that matches 'sub' against public.users.auth_id OR
+-- firebase_uid (and filters deleted_at / null company). Identical authorization
+-- intent, no uuid cast. Idempotent + sentinel-guarded. Grants unchanged.
+
+begin;
+
+do $do$
+declare
+  v_functiondef text;
+begin
+  v_functiondef := pg_get_functiondef(
+    'public.create_progress_invoice(uuid, jsonb)'::regprocedure
+  );
+
+  if v_functiondef ~ 'auth\.uid\(\)' then
+    v_functiondef := replace(
+      v_functiondef,
+$old$  SELECT company_id INTO v_caller_company
+  FROM users
+  WHERE auth_id = auth.uid();$old$,
+$new$  -- CRIT-3: resolve the caller's company via the Firebase-safe identity helper
+  -- instead of the uid() builtin, which casts the request.jwt subject to uuid
+  -- and throws 22P02 for Firebase-bridge (non-uuid) sessions.
+  v_caller_company := private.get_user_company_id();$new$
+    );
+
+    if v_functiondef ~ 'auth\.uid\(\)' then
+      raise exception
+        'crit3_progress_invoice_sentinel: failed to remove auth.uid() from create_progress_invoice';
+    end if;
+
+    if v_functiondef not like '%v_caller_company := private.get_user_company_id();%' then
+      raise exception
+        'crit3_progress_invoice_sentinel: helper resolution patch did not apply';
+    end if;
+
+    execute v_functiondef;
+  end if;
+end
+$do$;
+
+-- Post-condition: assert the live definition reflects the fix.
+do $do$
+declare
+  v_def text := pg_get_functiondef('public.create_progress_invoice(uuid, jsonb)'::regprocedure);
+begin
+  if v_def ~ 'auth\.uid\(\)' then
+    raise exception 'crit3_progress_invoice_sentinel: create_progress_invoice still calls auth.uid() after migration';
+  end if;
+  if v_def not like '%v_caller_company := private.get_user_company_id();%' then
+    raise exception 'crit3_progress_invoice_sentinel: caller company not resolved via private.get_user_company_id()';
+  end if;
+end
+$do$;
+
+commit;

--- a/supabase/migrations/rollbacks/20260615220000_crit3_create_progress_invoice_firebase_subject.rollback.sql
+++ b/supabase/migrations/rollbacks/20260615220000_crit3_create_progress_invoice_firebase_subject.rollback.sql
@@ -1,0 +1,34 @@
+-- ROLLBACK for 20260615220000_crit3_create_progress_invoice_firebase_subject.
+--
+-- Restores the original auth.uid()-based caller authorization in
+-- public.create_progress_invoice. This re-introduces the crit3 regression
+-- (the RPC will throw 22P02 for Firebase-bridge sessions), so only run it to
+-- back the fix out. Not in the apply path (rollbacks/ subdir). Run as postgres.
+
+begin;
+
+do $do$
+declare
+  v_functiondef text;
+begin
+  v_functiondef := pg_get_functiondef(
+    'public.create_progress_invoice(uuid, jsonb)'::regprocedure
+  );
+
+  if v_functiondef like '%v_caller_company := private.get_user_company_id();%' then
+    v_functiondef := replace(
+      v_functiondef,
+$new$  -- CRIT-3: resolve the caller's company via the Firebase-safe identity helper
+  -- instead of the uid() builtin, which casts the request.jwt subject to uuid
+  -- and throws 22P02 for Firebase-bridge (non-uuid) sessions.
+  v_caller_company := private.get_user_company_id();$new$,
+$old$  SELECT company_id INTO v_caller_company
+  FROM users
+  WHERE auth_id = auth.uid();$old$
+    );
+    execute v_functiondef;
+  end if;
+end
+$do$;
+
+commit;

--- a/tests/unit/supabase/crit3-create-progress-invoice-firebase-subject-migration.test.ts
+++ b/tests/unit/supabase/crit3-create-progress-invoice-firebase-subject-migration.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sql = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260615220000_crit3_create_progress_invoice_firebase_subject.sql"
+  ),
+  "utf8"
+);
+
+describe("crit3 create_progress_invoice firebase subject migration", () => {
+  it("is sentinel-guarded", () => {
+    expect(sql).toContain("crit3_progress_invoice_sentinel");
+  });
+
+  it("removes the auth.uid() caller lookup and resolves via the helper", () => {
+    // the replacement (new) fragment must not cast auth.uid(); it calls the helper
+    const parts = sql.split("$new$");
+    expect(parts.length).toBeGreaterThan(1);
+    const newFragment = parts[1];
+    expect(newFragment).not.toContain("auth.uid()");
+    expect(newFragment).toContain(
+      "v_caller_company := private.get_user_company_id();"
+    );
+    // post-apply sentinel enforces the live definition is auth.uid()-free
+    expect(sql).toContain(
+      "crit3_progress_invoice_sentinel: create_progress_invoice still calls auth.uid() after migration"
+    );
+  });
+
+  it("targets the create_progress_invoice(uuid, jsonb) RPC", () => {
+    expect(sql).toContain(
+      "public.create_progress_invoice(uuid, jsonb)'::regprocedure"
+    );
+  });
+
+  it("is idempotent (only rewrites while auth.uid() is still present)", () => {
+    expect(sql).toContain("if v_functiondef ~ 'auth\\.uid\\(\\)' then");
+  });
+});


### PR DESCRIPTION
## Problem

`public.create_progress_invoice` authorized the caller with
`SELECT company_id FROM users WHERE auth_id = auth.uid()`. `auth.uid()` casts the
request.jwt `sub` to uuid; post `crit3_phase_c_rekey_rls_identity_helpers` that
claim is the Firebase subject (a non-uuid) for bridged sessions, so the cast
raised `22P02` and the user-callable (`anon`/`authenticated`) RPC threw before
doing any work.

## Fix

Resolve the caller's company via `private.get_user_company_id()` (matches `sub`
against `auth_id`/`firebase_uid`). Identical authorization intent, no uuid cast.
Idempotent + sentinel-guarded; grants and `SECURITY DEFINER` unchanged. Companion
rollback under `supabase/migrations/rollbacks/`.

## State

- Migration already applied to prod (ledger: `crit3_create_progress_invoice_firebase_subject`) — do not re-apply.
- Verified live: definition is `auth.uid()`-free, resolves via the helper.
- `tests/unit/supabase` green.

Part of the crit3 `sub::uuid` regression sweep.