### PR TITLE
fix(ci): green lint-and-test on main (72 lint errors + 4 unmasked test failures)

### DIFF
--- a/src/components/ops/inbox/__tests__/thread-detail.test.tsx
+++ b/src/components/ops/inbox/__tests__/thread-detail.test.tsx
@@ -232,7 +232,7 @@ describe("<ThreadDetail>", () => {
     render(
       <ThreadDetail
         {...baseProps}
-        floatingBadgeSlot={<span data-testid="badge-probe">// YOUR TURN</span>}
+        floatingBadgeSlot={<span data-testid="badge-probe">{"// YOUR TURN"}</span>}
       >
         <section data-testid="commitments-probe">commitments</section>
       </ThreadDetail>,

--- a/src/components/ops/inbox/header-chip.tsx
+++ b/src/components/ops/inbox/header-chip.tsx
@@ -56,7 +56,7 @@ export const HeaderChip = forwardRef<HTMLButtonElement, HeaderChipProps>(
         )}
         style={{ fontFeatureSettings: '"tnum" 1, "zero" 1' }}
       >
-        <span aria-hidden>//</span>
+        <span aria-hidden>{"//"}</span>
         <span className="shrink-0">{count}</span>
         <span className="truncate">{label}</span>
         <span aria-hidden>▾</span>

--- a/src/components/ops/projects/workspace/atoms/text-area.tsx
+++ b/src/components/ops/projects/workspace/atoms/text-area.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils/cn";
 // 80px (suitable for short notes); callers pass `className="min-h-[Npx]"`
 // or set `rows` to override.
 
-export interface TextAreaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ className, ...props }, ref) => (

--- a/src/components/ops/projects/workspace/atoms/text-input.tsx
+++ b/src/components/ops/projects/workspace/atoms/text-input.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils/cn";
 // when wrapped in `<Field>`. This atom is pure presentation: the bare
 // styled `<input>`. Field owns label + hint + error + aria wiring.
 
-export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type TextInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
   ({ className, type, ...props }, ref) => (

--- a/src/components/ops/projects/workspace/map/map-hero.tsx
+++ b/src/components/ops/projects/workspace/map/map-hero.tsx
@@ -394,7 +394,8 @@ function MapProjectCrumb({
         }}
       />
       <span data-testid="map-crumb-id" style={{ color: "var(--text-3)" }}>
-        // {projectId}
+        {"// "}
+        {projectId}
       </span>
       <span style={{ color: "var(--text-mute)" }}>·</span>
       <span data-testid="map-crumb-name" style={{ color: "var(--text)" }}>

--- a/src/lib/email/react/templates/onboarding/Day0Welcome.tsx
+++ b/src/lib/email/react/templates/onboarding/Day0Welcome.tsx
@@ -22,11 +22,11 @@ export function Day0Welcome({ firstName, unsubscribeUrl }: Day0WelcomeProps) {
       {"\n\n"}
       My name is Jack, I built OPS.
       {"\n\n"}
-      I'm glad you signed up, and I'm looking forward to hearing what you think of it as you grow.
+      I&apos;m glad you signed up, and I&apos;m looking forward to hearing what you think of it as you grow.
       {"\n\n"}
-      What led you to join? Are you just kicking tires? Are you considering moving from another platform? Just getting into digital tools for your business? Whatever the case, I'm happy to help you get rolling. I built this tool because there was nothing on the market that worked for my crew. I got the impression those were all tech companies built by guys who have never actually worked on a jobsite. So here we are.
+      What led you to join? Are you just kicking tires? Are you considering moving from another platform? Just getting into digital tools for your business? Whatever the case, I&apos;m happy to help you get rolling. I built this tool because there was nothing on the market that worked for my crew. I got the impression those were all tech companies built by guys who have never actually worked on a jobsite. So here we are.
       {"\n\n"}
-      Again, if there's anything you need help with, you can reply to this email, it's my personal inbox.
+      Again, if there&apos;s anything you need help with, you can reply to this email, it&apos;s my personal inbox.
       {"\n\n"}
       — Jack
     </PlainTextLayout>

--- a/src/lib/email/react/templates/onboarding/Day14Active.tsx
+++ b/src/lib/email/react/templates/onboarding/Day14Active.tsx
@@ -59,13 +59,13 @@ export function Day14Active({
       {"\n\n"}
       I want to know two things:
       {"\n\n"}
-      &nbsp;&nbsp;1. What's working that you didn't expect?
+      &nbsp;&nbsp;1. What&apos;s working that you didn&apos;t expect?
       {"\n"}
-      &nbsp;&nbsp;2. What's broken, missing, or in the way?
+      &nbsp;&nbsp;2. What&apos;s broken, missing, or in the way?
       {"\n\n"}
       Hit reply — goes to my inbox. One sentence per question is enough.
       {"\n\n"}
-      The product gets better when operators tell me what's grinding their gears.
+      The product gets better when operators tell me what&apos;s grinding their gears.
       {"\n\n"}
       — Jack
     </PlainTextLayout>

--- a/src/lib/email/react/templates/onboarding/Day14Quiet.tsx
+++ b/src/lib/email/react/templates/onboarding/Day14Quiet.tsx
@@ -22,13 +22,13 @@ export function Day14Quiet({ firstName, unsubscribeUrl }: Day14QuietProps) {
       {"\n\n"}
       Jack here.
       {"\n\n"}
-      Day 14. You're halfway through your trial and it's been quiet on your account.
+      Day 14. You&apos;re halfway through your trial and it&apos;s been quiet on your account.
       {"\n\n"}
-      Could be a lot of things — you've been busy on actual work, something tripped you up during setup, OPS didn't fit how you run things, the timing's wrong, you forgot about it. No judgment either way.
+      Could be a lot of things — you&apos;ve been busy on actual work, something tripped you up during setup, OPS didn&apos;t fit how you run things, the timing&apos;s wrong, you forgot about it. No judgment either way.
       {"\n\n"}
       But I want to know which one it is. Hit reply on this email — goes to my inbox. One sentence is enough.
       {"\n\n"}
-      If something specifically didn't work, tell me. If you forgot about it, tell me that too. The product gets better when operators tell me what's grinding their gears.
+      If something specifically didn&apos;t work, tell me. If you forgot about it, tell me that too. The product gets better when operators tell me what&apos;s grinding their gears.
       {"\n\n"}
       — Jack
     </PlainTextLayout>

--- a/src/lib/email/react/templates/onboarding/Day1HasProject.tsx
+++ b/src/lib/email/react/templates/onboarding/Day1HasProject.tsx
@@ -51,10 +51,10 @@ export function Day1HasProject({
               Day 1. {countLine}
             </Text>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "0 0 16px 0" }}>
-              That's the spine. The next move puts OPS to work for you: tasks on those projects, and at least one crew member with the mobile app installed.
+              That&apos;s the spine. The next move puts OPS to work for you: tasks on those projects, and at least one crew member with the mobile app installed.
             </Text>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "0 0 24px 0" }}>
-              When a team member taps DONE in the field, a notification lands on your phone. From a job you weren't on. On a task you didn't have to chase.
+              When a team member taps DONE in the field, a notification lands on your phone. From a job you weren&apos;t on. On a task you didn&apos;t have to chase.
             </Text>
             <Section style={{ textAlign: "left", margin: "24px 0" }}>
               <Button

--- a/src/lib/email/react/templates/onboarding/Day1NoProject.tsx
+++ b/src/lib/email/react/templates/onboarding/Day1NoProject.tsx
@@ -45,10 +45,10 @@ export function Day1NoProject({ ctaUrl, unsubscribeUrl }: Day1NoProjectProps) {
               The move that puts the rest of the system to work: drop your first project in. Real client, real address, real tasks.
             </Text>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "0 0 16px 0" }}>
-              Without a project, OPS has nothing to work from. Once a project's in, the schedule, the crew, the photos, the estimates, the invoices all hang off it.
+              Without a project, OPS has nothing to work from. Once a project&apos;s in, the schedule, the crew, the photos, the estimates, the invoices all hang off it.
             </Text>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "0 0 24px 0" }}>
-              Use a job you're actually running this week. Takes two minutes.
+              Use a job you&apos;re actually running this week. Takes two minutes.
             </Text>
             <Section style={{ textAlign: "left", margin: "24px 0" }}>
               <Button

--- a/src/lib/email/react/templates/onboarding/Day3Inbox.tsx
+++ b/src/lib/email/react/templates/onboarding/Day3Inbox.tsx
@@ -21,19 +21,19 @@ export function Day3Inbox({ firstName, unsubscribeUrl }: Day3InboxProps) {
       {"\n\n"}
       Jack again.
       {"\n\n"}
-      When I was running my deck and rail crew, the thing that killed me wasn't a single big problem. It was wearing every hat at once.
+      When I was running my deck and rail crew, the thing that killed me wasn&apos;t a single big problem. It was wearing every hat at once.
       {"\n\n"}
-      One inbox. Lead emails, supplier emails, sub-trade emails, accounting questions, customer photos — all of it landing in the same spot at the same time. No office. Nobody triaging anything. Nobody nudging me when I'd missed replying to a lead from three days back.
+      One inbox. Lead emails, supplier emails, sub-trade emails, accounting questions, customer photos — all of it landing in the same spot at the same time. No office. Nobody triaging anything. Nobody nudging me when I&apos;d missed replying to a lead from three days back.
       {"\n\n"}
-      And I had no idea if my ads were working. I'd spend money on Google and Facebook and Yelp, and at the end of the month I couldn't tell you which inquiries had turned into jobs, or what those jobs were actually worth.
+      And I had no idea if my ads were working. I&apos;d spend money on Google and Facebook and Yelp, and at the end of the month I couldn&apos;t tell you which inquiries had turned into jobs, or what those jobs were actually worth.
       {"\n\n"}
       Data is power.
       {"\n\n"}
-      That's the part of OPS I'm most proud of.
+      That&apos;s the part of OPS I&apos;m most proud of.
       {"\n\n"}
       You connect your work inbox. OPS reads your inbox and separates the leads from the noise — the customer asking for a quote on a new install lands in your pipeline, tagged, with the address pulled out and the scope extracted. The supplier confirming an order goes somewhere else.
       {"\n\n"}
-      Then OPS tracks every lead from "first email" to "job won" to "invoice paid." You see what your cost per won job is, by source. You see which ads are paying back. You make decisions on numbers instead of gut.
+      Then OPS tracks every lead from &quot;first email&quot; to &quot;job won&quot; to &quot;invoice paid.&quot; You see what your cost per won job is, by source. You see which ads are paying back. You make decisions on numbers instead of gut.
       {"\n\n"}
       Connecting your inbox takes about two minutes. Hit reply if you want to tell me what your inbox chaos looks like right now — I read every reply.
       {"\n\n"}

--- a/src/lib/email/react/templates/onboarding/Day4HasNotification.tsx
+++ b/src/lib/email/react/templates/onboarding/Day4HasNotification.tsx
@@ -29,7 +29,7 @@ export function Day4HasNotification({
         <Container style={{ maxWidth: "560px", margin: "0 auto", padding: "32px 24px" }}>
           <Section>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "0 0 16px 0" }}>
-              Day 4. At least one crew member has tapped DONE in the field and you've seen the notification land.
+              Day 4. At least one crew member has tapped DONE in the field and you&apos;ve seen the notification land.
             </Text>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "0 0 16px 0" }}>
               Most operators are surprised by how good that feels — the quiet of not having to chase.
@@ -44,7 +44,7 @@ export function Day4HasNotification({
               &nbsp;&nbsp;→ Adding more crew, so the same setup covers more work
             </Text>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "0 0 24px 0" }}>
-              &nbsp;&nbsp;→ Templates so you don't rebuild the same tasks every time
+              &nbsp;&nbsp;→ Templates so you don&apos;t rebuild the same tasks every time
             </Text>
             <Section style={{ textAlign: "left", margin: "24px 0" }}>
               <Button
@@ -66,7 +66,7 @@ export function Day4HasNotification({
               </Button>
             </Section>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "16px 0 0 0" }}>
-              You're past the first hill. The next 26 days is about putting the rest of your business in.
+              You&apos;re past the first hill. The next 26 days is about putting the rest of your business in.
             </Text>
           </Section>
           <FounderFooter unsubscribeUrl={unsubscribeUrl} />

--- a/src/lib/email/react/templates/onboarding/Day4NoNotification.tsx
+++ b/src/lib/email/react/templates/onboarding/Day4NoNotification.tsx
@@ -47,7 +47,7 @@ export function Day4NoNotification({
               Day 4.
             </Text>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "0 0 16px 0" }}>
-              Here's the moment you're working toward:
+              Here&apos;s the moment you&apos;re working toward:
             </Text>
             <MockPushNotification
               completedByName="Jake"
@@ -55,7 +55,7 @@ export function Day4NoNotification({
               projectTitle="5611 Batu Rd"
             />
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "16px 0" }}>
-              That notification lands on your phone the first time someone on your crew taps DONE in the field. From a job you weren't on. On a task you didn't have to chase.
+              That notification lands on your phone the first time someone on your crew taps DONE in the field. From a job you weren&apos;t on. On a task you didn&apos;t have to chase.
             </Text>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "0 0 8px 0" }}>
               To get there:
@@ -89,7 +89,7 @@ export function Day4NoNotification({
               </Button>
             </Section>
             <Text style={{ fontSize: "15px", lineHeight: "22px", margin: "16px 0 0 0" }}>
-              The first time you hear that ping while you're somewhere else, you'll know why we built this.
+              The first time you hear that ping while you&apos;re somewhere else, you&apos;ll know why we built this.
             </Text>
           </Section>
           <FounderFooter unsubscribeUrl={unsubscribeUrl} />

--- a/src/lib/email/react/templates/onboarding/Day8Estimates.tsx
+++ b/src/lib/email/react/templates/onboarding/Day8Estimates.tsx
@@ -20,21 +20,21 @@ export function Day8Estimates({ firstName, unsubscribeUrl }: Day8EstimatesProps)
     <PlainTextLayout unsubscribeUrl={unsubscribeUrl}>
       {greeting}
       {"\n\n"}
-      Jack again, last one of these you'll get from me for a while.
+      Jack again, last one of these you&apos;ll get from me for a while.
       {"\n\n"}
-      A deck builder I know ran his estimates out of a Word doc template. Every new customer, he'd open the last one he sent, save-as, update the fields. Or try to.
+      A deck builder I know ran his estimates out of a Word doc template. Every new customer, he&apos;d open the last one he sent, save-as, update the fields. Or try to.
       {"\n\n"}
-      I was constantly on his back about it. He'd send estimates with the wrong customer name at the top. With the previous customer's address still in there. With totals that didn't match the line items because he'd updated the materials but forgot the bottom number.
+      I was constantly on his back about it. He&apos;d send estimates with the wrong customer name at the top. With the previous customer&apos;s address still in there. With totals that didn&apos;t match the line items because he&apos;d updated the materials but forgot the bottom number.
       {"\n\n"}
-      If he caught it, he'd send a follow-up: "sorry, mixed up the name." "Sorry, clerical error on the address." "Apologies for the confusion."
+      If he caught it, he&apos;d send a follow-up: &quot;sorry, mixed up the name.&quot; &quot;Sorry, clerical error on the address.&quot; &quot;Apologies for the confusion.&quot;
       {"\n\n"}
-      The one I'll never forget: he started a job on a Monday, realized halfway through the week that the estimate he'd sent was for the previous customer's project, and the price was 20% below what the new job actually cost him. He had to beg the customer mid-job to accept the higher number because he'd forgotten to update one field in a template.
+      The one I&apos;ll never forget: he started a job on a Monday, realized halfway through the week that the estimate he&apos;d sent was for the previous customer&apos;s project, and the price was 20% below what the new job actually cost him. He had to beg the customer mid-job to accept the higher number because he&apos;d forgotten to update one field in a template.
       {"\n\n"}
       You can imagine how that went over.
       {"\n\n"}
-      That's the kind of thing that kills small businesses. Not because the work is bad. Because the back-office is held together with copy-paste and good intentions.
+      That&apos;s the kind of thing that kills small businesses. Not because the work is bad. Because the back-office is held together with copy-paste and good intentions.
       {"\n\n"}
-      When you send an estimate from OPS, your customer gets a link to a branded portal — your logo, your business name, the line items pulled from your real pricing. They read it, ask questions on individual items, approve or decline, and pay through the portal directly. You don't copy-paste anything. You can't forget to update a field that doesn't exist.
+      When you send an estimate from OPS, your customer gets a link to a branded portal — your logo, your business name, the line items pulled from your real pricing. They read it, ask questions on individual items, approve or decline, and pay through the portal directly. You don&apos;t copy-paste anything. You can&apos;t forget to update a field that doesn&apos;t exist.
       {"\n\n"}
       If you want to see what your customers see, send a test estimate to your own email. Takes about three minutes from inside OPS.
       {"\n\n"}

--- a/src/lib/email/react/templates/onboarding/LostYou.tsx
+++ b/src/lib/email/react/templates/onboarding/LostYou.tsx
@@ -40,9 +40,9 @@ export function LostYou({
       {"\n\n"}
       {gapLine}
       {"\n\n"}
-      That's a long enough gap that I want to ask straight: is something stopping you, or is the timing just wrong?
+      That&apos;s a long enough gap that I want to ask straight: is something stopping you, or is the timing just wrong?
       {"\n\n"}
-      If setup tripped you up, I can usually point you at the move that gets you unstuck. If OPS isn't the right fit, no hard feelings — I'd just want to know what you were looking for.
+      If setup tripped you up, I can usually point you at the move that gets you unstuck. If OPS isn&apos;t the right fit, no hard feelings — I&apos;d just want to know what you were looking for.
       {"\n\n"}
       Hit reply with one sentence. Goes to my inbox.
       {"\n\n"}

--- a/src/lib/inbox/contact-form-thread-repair.ts
+++ b/src/lib/inbox/contact-form-thread-repair.ts
@@ -343,7 +343,7 @@ export function buildContactFormRepairDecision(
   let opportunityAction: ContactFormRepairDecision["proposed"]["opportunityAction"] =
     "keep";
   let proposedTargetClientId = targetClientId;
-  let proposedTargetOpportunityId =
+  const proposedTargetOpportunityId =
     currentOpportunityMatchesTarget && input.currentOpportunity
       ? input.currentOpportunity.id
       : (input.existingOpenOpportunityForTarget?.id ?? null);

--- a/tests/integration/uploads-presign.test.ts
+++ b/tests/integration/uploads-presign.test.ts
@@ -19,9 +19,46 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // extension inference.
 let capturedPath = "";
 
+// The route requires an authenticated caller (commit cbdaed7b): the
+// presign flow calls `resolveAuth`, which (1) verifies a Bearer token via
+// `verifyAuthToken`, (2) looks up the caller's company_id in the `users`
+// table, then (3) authorizes the folder against that company_id. The
+// stubs below satisfy that contract so requests reach the storage path
+// these tests actually exercise — exactly mirroring a valid caller.
+
+// A real UUID for the caller's company_id. `authorizeFolder` requires the
+// company_id to be UUID-shaped, so the lookup must return one.
+const TEST_COMPANY_ID = "11111111-1111-4111-8111-111111111111";
+
+// Force the legacy Supabase Storage backend so the route uses the mocked
+// `getServiceRoleClient().storage` path rather than signing against the
+// real AWS SDK. (Default backend is "s3".)
+process.env.STORAGE_BACKEND = "supabase";
+
+// ─── Auth token verification mock (Supabase iOS / Firebase web bridge) ──────
+vi.mock("@/lib/firebase/admin-verify", () => ({
+  verifyAuthToken: async (_token: string) => ({
+    uid: "test-uid",
+    email: "tester@example.com",
+    claims: {},
+  }),
+}));
+
 // ─── Supabase service-role client mock ──────────────────────────────────────
+// Provides BOTH the `users` lookup used by `resolveAuth` and the `storage`
+// surface used by the Supabase presign path.
 vi.mock("@/lib/supabase/server-client", () => ({
   getServiceRoleClient: () => ({
+    from: (_table: string) => ({
+      select: (_cols: string) => ({
+        or: (_filter: string) => ({
+          maybeSingle: async () => ({
+            data: { id: "usr_test", company_id: TEST_COMPANY_ID },
+            error: null,
+          }),
+        }),
+      }),
+    }),
     storage: {
       from: (_bucket: string) => ({
         createSignedUploadUrl: async (path: string) => {
@@ -45,7 +82,26 @@ vi.mock("@/lib/supabase/server-client", () => ({
   }),
 }));
 
-// Import AFTER mocks are registered so the route picks up the stub.
+// ─── Folder authorization mock ──────────────────────────────────────────────
+// `authorizeFolder` normally appends the caller's company_id when it isn't
+// already a path segment, which would break the exact-folder assertions in
+// these tests (they use logical folders like `projects/co_123/proj_456`).
+// Stub it to echo the folder back unchanged while keeping the rest of the
+// module — `sanitizeFilename`, `inferExtension`, `buildUniqueSuffix` — real
+// so the extension-inference and key-shape assertions still exercise the
+// actual implementations.
+vi.mock("@/lib/s3/path-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/s3/path-auth")>();
+  return {
+    ...actual,
+    authorizeFolder: (rawFolder: string | null | undefined) => ({
+      ok: true as const,
+      folder: (rawFolder ?? "uploads").replace(/^\/+|\/+$/g, ""),
+    }),
+  };
+});
+
+// Import AFTER mocks are registered so the route picks up the stubs.
 import { POST } from "@/app/api/uploads/presign/route";
 
 function makePresignRequest(params: Record<string, string>): Request {
@@ -54,6 +110,9 @@ function makePresignRequest(params: Record<string, string>): Request {
     method: "POST",
     headers: {
       "content-type": "application/x-www-form-urlencoded",
+      // Authenticated caller — `resolveAuth` reads this Bearer token and
+      // hands it to the mocked `verifyAuthToken`.
+      authorization: "Bearer test-token",
     },
     body,
   });

--- a/tests/lib/api/services/company-service-images.test.ts
+++ b/tests/lib/api/services/company-service-images.test.ts
@@ -47,7 +47,7 @@ describe("CompanyService.getPresignedUrlProfile (post-migration)", () => {
     const body = JSON.parse(
       vi.mocked(global.fetch).mock.calls[0][1]?.body as string
     );
-    expect(body.folder).toBe("profiles/co-uuid");
+    expect(body.folder).toBe("profiles");
     expect(result.publicUrl).toContain("logo.jpg");
   });
 });
@@ -77,23 +77,50 @@ describe("CompanyService.getPresignedUrlProject (post-migration)", () => {
 });
 
 describe("CompanyService.registerProjectImages (post-migration)", () => {
-  it("updates project_images in Supabase directly", async () => {
+  it("appends to project_images in Supabase directly (read-modify-write)", async () => {
     // This should call Supabase, not fetch — mock fetch to throw so we'd know
     vi.mocked(global.fetch).mockImplementation(() => {
       throw new Error("Should not call fetch for registerProjectImages");
     });
 
+    const existingImage =
+      "https://s3.amazonaws.com/bucket/projects/proj-uuid/existing.jpg";
+    const newImage =
+      "https://s3.amazonaws.com/bucket/projects/proj-uuid/img1.jpg";
+
+    // Source does:
+    //   .from('projects').select('project_images').eq('id', id).single()
+    //   .from('projects').update({ project_images }).eq('id', id)
+    // .eq() terminates two distinct chains: one with .single() (read),
+    // one awaited directly (write). The shared chain object supports both.
+    const updateEq = vi.fn().mockResolvedValue({ error: null });
+    const update = vi.fn().mockReturnValue({ eq: updateEq });
+
+    const single = vi
+      .fn()
+      .mockResolvedValue({
+        data: { project_images: [existingImage] },
+        error: null,
+      });
+    const selectEq = vi.fn().mockReturnValue({ single });
+    const select = vi.fn().mockReturnValue({ eq: selectEq });
+
     const mockSb = {
-      from: vi.fn().mockReturnThis(),
-      update: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockResolvedValueOnce({ error: null }),
+      from: vi.fn().mockReturnValue({ select, update }),
     };
     vi.mocked(requireSupabase).mockReturnValue(mockSb as never);
 
     await expect(
-      CompanyService.registerProjectImages("proj-uuid", [
-        "https://s3.amazonaws.com/bucket/projects/proj-uuid/img1.jpg",
-      ])
+      CompanyService.registerProjectImages("proj-uuid", [newImage])
     ).resolves.not.toThrow();
+
+    // Reads current images then writes the appended array (existing + new).
+    expect(select).toHaveBeenCalledWith("project_images");
+    expect(selectEq).toHaveBeenCalledWith("id", "proj-uuid");
+    expect(single).toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith({
+      project_images: [existingImage, newImage],
+    });
+    expect(updateEq).toHaveBeenCalledWith("id", "proj-uuid");
   });
 });

--- a/tests/unit/inbox/ai-draft-provenance.test.ts
+++ b/tests/unit/inbox/ai-draft-provenance.test.ts
@@ -9,8 +9,8 @@
  *   - recordDraftOutcome routes the edit delta through learnFromEdits (P4-D
  *     pipeline reuse).
  *   - recordLifecycleDraftOutcome bridges a never-AI template draft and learns
- *     only on SENT (P4-D machinery; invocation deferred behind a flag).
- *   - LIFECYCLE_LEARNING_ENABLED defaults false (P4-D deferral).
+ *     only on SENT (P4-D machinery; invoked from the P3 operator-send path).
+ *   - LIFECYCLE_LEARNING_ENABLED is true at go-live (P3 send-transition landed).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -287,8 +287,8 @@ describe("P4-B — recordDraftOutcome provenance stamping", () => {
 });
 
 describe("P4-D — recordLifecycleDraftOutcome (deferred machinery)", () => {
-  it("LIFECYCLE_LEARNING_ENABLED is deferred (false) until P3 send-transition lands", () => {
-    expect(LIFECYCLE_LEARNING_ENABLED).toBe(false);
+  it("LIFECYCLE_LEARNING_ENABLED is enabled (true) at go-live with the P3 send-transition landed", () => {
+    expect(LIFECYCLE_LEARNING_ENABLED).toBe(true);
   });
 
   it("bridges a never-AI template draft (creates ai_draft_history) and flips it to sent", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./tests/setup.ts"],
     include: ["tests/**/*.{test,spec}.{ts,tsx}", "src/**/*.{test,spec}.{ts,tsx}"],
-    exclude: ["tests/e2e/**", "node_modules/**"],
+    exclude: ["tests/e2e/**", "tests/visual/**", "node_modules/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
`lint-and-test` was red on `main`. `npm run lint` failed first (72 errors), which masked the `type-check` and `test` steps for months. This greens the whole job.

## 1. Lint (72 errors → 0)
All render/type-identical: `react/no-unescaped-entities` (66, escape `'`/`"` in JSX text), `jsx-no-comment-textnodes` (3, wrap `//` as `{"//"}`), `no-empty-object-type` (2, empty interface → type alias), `prefer-const` (1).

## 2. Test step (4 files, all pre-existing, all stale test/config — no src changes, nothing masked)
- **vitest.config.ts** — exclude `tests/visual/**` (a Playwright visual spec was being collected by vitest, erroring on `test.describe()`); mirrors the existing `tests/e2e/**` exclude.
- **ai-draft-provenance.test.ts** — `LIFECYCLE_LEARNING_ENABLED` was intentionally enabled at go-live (`3ddabfb4`; the P3 operator-send call site now exists). Assert `true`.
- **uploads-presign.test.ts** — the presign route added an auth gate (`cbdaed7b`); the `401`s are *correct*. The test now authenticates (Bearer + admin-verify/users/storage mocks) instead of expecting unauthenticated success. **Not a real bug** — confirmed by triage.
- **company-service-images.test.ts** — source now sends a flat `"profiles"` folder (company scoping enforced server-side) and appends `project_images` via read-modify-write; assertion + mock updated to match.

## Verified locally
`npm run lint` (0 errors), `npm run type-check` (0 errors), all 4 previously-failing files pass. CI here runs the full `lint → type-check → test` chain with secrets.