### PR TITLE
fix(catalog): persist products.unit_cost in catalog_setup_save RPC

### DIFF
--- a/supabase/migrations/20260616205309_catalog_setup_save_persist_unit_cost.sql
+++ b/supabase/migrations/20260616205309_catalog_setup_save_persist_unit_cost.sql
@@ -1,0 +1,121 @@
+-- catalog_setup_save: persist products.unit_cost (additive, body-only).
+--
+-- PROBLEM
+--   The ~6380-line public.catalog_setup_save RPC silently dropped products.unit_cost:
+--   it was absent from the products INSERT column list + VALUES AND from BOTH
+--   ON CONFLICT (id) DO UPDATE SET clauses (the create-mode block and the edit-mode
+--   block). So a wizard-created product landed with unit_cost = NULL even when the
+--   user entered a cost. The OPS-Web Catalog Setup Wizard already emits `unit_cost`
+--   in its payload doc (payload-builder.ts) — the RPC just ignored it. (iOS does NOT
+--   send a cost key through this RPC today; its Guided-Catalog cost path writes
+--   products.unit_cost directly via REST, so this change is forward-compatible for
+--   iOS and — see below — protects iOS-edited products from cost wipes.)
+--
+-- FIX (mirrors the existing minimum_charge handling)
+--   * INSERT: add `unit_cost` to the column list + a VALUES expression
+--       case when coalesce(v_product_doc->>'unit_cost','') ~ '^-?[0-9]+(\.[0-9]+)?$'
+--            then (v_product_doc->>'unit_cost')::numeric else null end
+--     -> yields NULL when the doc omits cost (NOT 0, unlike default_price/base_price
+--        which are NOT NULL default 0), so an explicit 0 is still written while an
+--        omitted key stays NULL and is preserved by the UPDATE below.
+--   * ON CONFLICT DO UPDATE: `unit_cost = coalesce(excluded.unit_cost, public.products.unit_cost)`
+--     -> a conflict-update that omits cost can never wipe an existing cost. This is a
+--        deliberate deviation from the function's uniform bare-`excluded` pattern,
+--        required because the only conflict-updating callers deliberately withhold
+--        cost: the web merge doc omits unit_cost when on-file cost is null, and the
+--        iOS Advanced "edit" flow conflict-updates products by id with no cost field
+--        at all (a bare `excluded` would NULL those products' cost). Other columns
+--        keep the bare-`excluded` form because their conflict-updating callers
+--        re-send them, so they are not a wipe vector.
+--
+-- SCOPE
+--   unit_cost ONLY. No signature/return change (still (uuid, text, jsonb) -> jsonb),
+--   so iOS — which shares this DB across App Store versions — is unaffected; no other
+--   column, trigger, RLS, or identity logic is touched.
+--
+-- APPLY STRATEGY
+--   The 6380-line body is NEVER hand-retyped. This migration fetches the live
+--   pg_get_functiondef, inserts the 12 unit_cost lines at content-anchored positions
+--   (after the bare `base_price,` column entry, before the pricing_unit VALUES entry,
+--   and after `base_price = excluded.base_price,` in each SET clause), and asserts the
+--   anchors hit exactly twice each (create + edit block) and that exactly 12 lines were
+--   added — aborting (rolling back) if the function ever drifted from this shape. The
+--   rebuilt CREATE OR REPLACE is EXECUTEd in this single transaction, so a parse error
+--   rolls back harmlessly. Idempotent: no-op if unit_cost is already present.
+--
+--   Verified on prod ijeekuhbatykdomumfjx (2026-06-16): md5(transform(pre-image)) ==
+--   md5(live def) — only the 12 intended lines changed. Sentinel (rolled back):
+--   create=12.34, preserve-after-omit=12.34, explicit-zero=0, new-value=99.
+do $mig$
+declare
+  v_src text;
+  v_lines text[];
+  v_out text[] := array[]::text[];
+  v_line text;
+  v_trim text;
+  v_indent text;
+  c_collist int := 0;
+  c_values  int := 0;
+  c_set     int := 0;
+  v_when    text := $q$when coalesce(v_product_doc->>'unit_cost', '') ~ '^-?[0-9]+(\.[0-9]+)?$' then (v_product_doc->>'unit_cost')::numeric$q$;
+  v_setline text := $q$unit_cost = coalesce(excluded.unit_cost, public.products.unit_cost),$q$;
+  v_pu_anchor text := $q$coalesce(nullif(btrim(v_product_doc->>'pricing_unit'), ''), 'each'),$q$;
+  v_new   text;
+  v_added int;
+begin
+  select pg_get_functiondef(p.oid) into v_src
+  from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'public' and p.proname = 'catalog_setup_save';
+
+  if v_src is null then
+    raise exception 'catalog_setup_save not found — aborting';
+  end if;
+
+  if position('unit_cost' in v_src) > 0 then
+    raise notice 'catalog_setup_save already references unit_cost — skipping (already migrated)';
+    return;
+  end if;
+
+  v_lines := string_to_array(v_src, E'\n');
+
+  foreach v_line in array v_lines loop
+    v_trim   := btrim(v_line);
+    v_indent := substring(v_line from '^[ ]*');
+
+    -- VALUES: insert the unit_cost case immediately BEFORE the pricing_unit value line
+    if v_trim = v_pu_anchor then
+      v_out := array_append(v_out, v_indent || 'case');
+      v_out := array_append(v_out, v_indent || '  ' || v_when);
+      v_out := array_append(v_out, v_indent || '  else null');
+      v_out := array_append(v_out, v_indent || 'end,');
+      c_values := c_values + 1;
+    end if;
+
+    v_out := array_append(v_out, v_line);
+
+    -- COLUMN LIST: after the bare `base_price,` entry
+    if v_trim = 'base_price,' then
+      v_out := array_append(v_out, v_indent || 'unit_cost,');
+      c_collist := c_collist + 1;
+    -- SET clause: after `base_price = excluded.base_price,`
+    elsif v_trim = 'base_price = excluded.base_price,' then
+      v_out := array_append(v_out, v_indent || v_setline);
+      c_set := c_set + 1;
+    end if;
+  end loop;
+
+  if c_collist <> 2 or c_values <> 2 or c_set <> 2 then
+    raise exception 'anchor count mismatch (collist=%, values=%, set=%) — function drifted, aborting',
+      c_collist, c_values, c_set;
+  end if;
+
+  v_added := array_length(v_out, 1) - array_length(v_lines, 1);
+  if v_added <> 12 then
+    raise exception 'unexpected added-line count % (expected 12) — aborting', v_added;
+  end if;
+
+  v_new := array_to_string(v_out, E'\n');
+
+  execute v_new;
+end
+$mig$;

--- a/supabase/migrations/rollbacks/20260616205309_catalog_setup_save_persist_unit_cost.rollback.sql
+++ b/supabase/migrations/rollbacks/20260616205309_catalog_setup_save_persist_unit_cost.rollback.sql
@@ -1,0 +1,74 @@
+-- ROLLBACK for 20260616205309_catalog_setup_save_persist_unit_cost.
+--
+-- Removes the 12 unit_cost lines the forward migration inserted into
+-- public.catalog_setup_save, restoring the prior body. This re-introduces the
+-- original bug (the RPC drops products.unit_cost again), so only run it to back
+-- the fix out. Not in the apply path (rollbacks/ subdir). Run as postgres.
+--
+-- Self-verifying: it reconstructs the body by removing exactly the 12 inserted
+-- lines (the 2 column-list entries, the 2 four-line VALUES case blocks, and the
+-- 2 SET clauses), asserts 12 lines were removed and no `unit_cost` remains, and
+-- asserts the result md5 equals the captured pre-image
+-- (c89e57e14e4d02091b1b17d3c6f6c6c5). If the function has been modified since the
+-- forward migration, the md5 guard makes this abort rather than clobber newer work.
+do $rb$
+declare
+  v_src text;
+  v_lines text[];
+  v_out text[] := array[]::text[];
+  v_mark boolean[];
+  n int; i int;
+  v_trim text;
+  v_removed int := 0;
+  v_when    text := $q$when coalesce(v_product_doc->>'unit_cost', '') ~ '^-?[0-9]+(\.[0-9]+)?$' then (v_product_doc->>'unit_cost')::numeric$q$;
+  v_setline text := $q$unit_cost = coalesce(excluded.unit_cost, public.products.unit_cost),$q$;
+  v_new text;
+  c_expected_md5 constant text := 'c89e57e14e4d02091b1b17d3c6f6c6c5';
+begin
+  select pg_get_functiondef(p.oid) into v_src
+  from pg_proc p join pg_namespace n2 on n2.oid = p.pronamespace
+  where n2.nspname = 'public' and p.proname = 'catalog_setup_save';
+
+  if v_src is null then raise exception 'catalog_setup_save not found — aborting'; end if;
+  if position('unit_cost' in v_src) = 0 then
+    raise notice 'catalog_setup_save has no unit_cost — nothing to roll back'; return;
+  end if;
+
+  v_lines := string_to_array(v_src, E'\n');
+  n := array_length(v_lines, 1);
+  v_mark := array_fill(false, array[n]);
+
+  for i in 1..n loop
+    v_trim := btrim(v_lines[i]);
+    if v_trim = 'unit_cost,' or v_trim = v_setline then
+      v_mark[i] := true;
+    elsif v_trim = v_when then
+      -- structural guard: the inserted VALUES block is exactly  case / when / else null / end,
+      if btrim(v_lines[i-1]) <> 'case' or btrim(v_lines[i+1]) <> 'else null' or btrim(v_lines[i+2]) <> 'end,' then
+        raise exception 'unexpected VALUES case shape around line % — aborting rollback', i;
+      end if;
+      v_mark[i-1] := true; v_mark[i] := true; v_mark[i+1] := true; v_mark[i+2] := true;
+    end if;
+  end loop;
+
+  for i in 1..n loop
+    if v_mark[i] then v_removed := v_removed + 1; else v_out := array_append(v_out, v_lines[i]); end if;
+  end loop;
+
+  if v_removed <> 12 then
+    raise exception 'expected to remove 12 lines, removed % — aborting', v_removed;
+  end if;
+
+  v_new := array_to_string(v_out, E'\n');
+
+  if position('unit_cost' in v_new) <> 0 then
+    raise exception 'unit_cost still present after reverse-transform — aborting';
+  end if;
+  if md5(v_new) <> c_expected_md5 then
+    raise exception 'reverse-transform md5 % != captured pre-image % — function changed since; aborting',
+      md5(v_new), c_expected_md5;
+  end if;
+
+  execute v_new;
+end
+$rb$;


### PR DESCRIPTION
## What

Migration `20260616205309_catalog_setup_save_persist_unit_cost` (body-only, additive) makes the shared `public.catalog_setup_save` RPC persist `products.unit_cost`. It was absent from the products INSERT (column list + VALUES) **and** from both `ON CONFLICT (id) DO UPDATE` clauses (create-mode + edit-mode blocks), so a cost entered in the OPS-Web Catalog Setup Wizard landed `NULL`.

- **INSERT** mirrors `minimum_charge` — `case … else null end` → `NULL` when the doc omits cost (not `0`, unlike the NOT-NULL `default_price`/`base_price`), so an explicit `0` still writes while omission stays `NULL`.
- **DO UPDATE** uses `coalesce(excluded.unit_cost, public.products.unit_cost)` — a conflict-update that omits cost can never wipe an existing value.

No signature/return change (still `(uuid, text, jsonb) -> jsonb`). `database.types.ts` unchanged.

## Why coalesce-preserve (the landmine)

The function's uniform `<col> = excluded.<col>` pattern would `NULL` an existing cost on any conflict-update that omits it. Two callers do exactly that: the web merge doc withholds cost when on-file cost is null, and the **iOS Advanced "edit" flow conflict-updates products by id with no cost field at all**. The coalesce-preserve is a deliberate, scoped deviation that prevents the wipe.

## Scope / iOS note

- Correction to the original premise: iOS does **not** send a cost key through this RPC (its `CatalogSetupSavePayload.ProductPayload` has no cost field); iOS Guided-Catalog cost writes go straight to `products.unit_cost` via REST (`ProductRepository.create`). So this changes **no current iOS behavior** — it fixes the **web wizard** and protects REST-set costs from the iOS-edit wipe above.
- Scoped strictly to `unit_cost`; other bare-`excluded` columns aren't a wipe vector (their conflict-updating callers re-send them). Body-only → safe across all live iOS App Store versions sharing this DB.

## Applied + verified

Already applied to prod `ijeekuhbatykdomumfjx` (ledger: `catalog_setup_save_persist_unit_cost`) via a transform-in-place migration — the 6380-line body is never hand-retyped (anchored line insertion + drift-abort assertions; idempotent). Verified `md5(transform(pre-image)) == md5(live)` (only the 12 intended lines changed) and behavior via a rolled-back sentinel: create=12.34, **preserve-after-omit=12.34**, explicit-zero=0, new-value=99. Self-verifying rollback under `supabase/migrations/rollbacks/`. Merging brings `main`'s migration history in line with deployed prod state.

## Follow-up

Once this lands in `main` and is pulled into `feat/catalog-setup-wizard`, the now-redundant post-commit `cost-stamp.ts` workaround is removed (the RPC persists cost directly). Tracked separately.
