### PR TITLE
BRANCH CONSOLIDATION: catalog permission registry

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -236,7 +236,7 @@ const SUB_TAB_PERMISSIONS: Record<string, string> = {
   roles: "team.assign_roles",
   // Operations group
   "task-types": "settings.company",
-  inventory: "inventory.manage",
+  inventory: "catalog.manage",
   expenses: "expenses.configure",
   // Billing group
   subscription: "settings.billing",

--- a/src/components/catalog/catalog-kebab.tsx
+++ b/src/components/catalog/catalog-kebab.tsx
@@ -5,7 +5,7 @@
  * (Direction D). MANAGE (categories / tags / units / threshold defaults) +
  * VIEWS (saved counts / import). Mirrors the iOS kebab groups minus ORDERS
  * (catalog_orders is consumed nowhere on web — no order affordances ship).
- * Manage items gate on inventory.manage; import on inventory.import.
+ * Manage items gate on catalog.manage; import on catalog.import.
  */
 
 import { useState } from "react";
@@ -35,8 +35,8 @@ export function CatalogKebab({
   const { t } = useDictionary("catalog");
   const router = useRouter();
   const can = usePermissionStore((s) => s.can);
-  const canManage = can("inventory.manage");
-  const canImport = can("inventory.import");
+  const canManage = can("catalog.manage");
+  const canImport = can("catalog.import");
   const canSetup = can("catalog.run_setup");
 
   const [manageTab, setManageTab] = useState<ManageTab | null>(null);

--- a/src/components/catalog/catalog-page.tsx
+++ b/src/components/catalog/catalog-page.tsx
@@ -41,8 +41,8 @@ export function CatalogPage() {
   const searchParams = useSearchParams();
   const can = usePermissionStore((s) => s.can);
 
-  const canProducts = can("products.view");
-  const canStock = can("inventory.view");
+  const canProducts = can("catalog.products.view");
+  const canStock = can("catalog.view");
 
   const visibleSegments = useMemo<CatalogSegment[]>(() => {
     const out: CatalogSegment[] = [];

--- a/src/components/catalog/modals/manage-modal.tsx
+++ b/src/components/catalog/modals/manage-modal.tsx
@@ -3,7 +3,7 @@
 /**
  * Catalog "// MANAGE" modal — categories, tags, units, and category-level
  * threshold defaults (the cascade's admin surface). One dialog, four tabs.
- * All mutations gate on inventory.manage at the kebab; this renders the
+ * All mutations gate on catalog.manage at the kebab; this renders the
  * authoring controls.
  */
 

--- a/src/components/catalog/product-editor.tsx
+++ b/src/components/catalog/product-editor.tsx
@@ -168,7 +168,7 @@ export function ProductEditor({ productId }: { productId: string }) {
   const [optionToDelete, setOptionToDelete] = useState<ProductOption | null>(null);
   const [modifierToDelete, setModifierToDelete] = useState<ProductPricingModifier | null>(null);
 
-  if (!can("products.manage")) {
+  if (!can("catalog.products.manage")) {
     return (
       <div className="flex flex-col items-start gap-2 px-3 py-6">
         <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-text-mute">

--- a/src/components/catalog/segments/products-segment.tsx
+++ b/src/components/catalog/segments/products-segment.tsx
@@ -77,7 +77,7 @@ export function ProductsSegment({
   const { t } = useDictionary("catalog");
   const router = useRouter();
   const can = usePermissionStore((s) => s.can);
-  const canManage = can("products.manage");
+  const canManage = can("catalog.products.manage");
 
   const { data: products = [], isLoading } = useProducts(false);
   const { data: taskTypes = [] } = useTaskTypes();

--- a/src/components/catalog/segments/stock-segment.tsx
+++ b/src/components/catalog/segments/stock-segment.tsx
@@ -111,7 +111,7 @@ export function StockSegment({
 }: StockSegmentProps) {
   const { t } = useDictionary("catalog");
   const can = usePermissionStore((s) => s.can);
-  const canManage = can("inventory.manage");
+  const canManage = can("catalog.manage");
 
   const adjust = useAdjustQuantity();
   const bulkDelete = useBulkDeleteVariants();

--- a/src/components/catalog/setup/__tests__/catalog-setup-route.test.tsx
+++ b/src/components/catalog/setup/__tests__/catalog-setup-route.test.tsx
@@ -68,7 +68,7 @@ describe("CatalogSetupRoute permission gate", () => {
 
   it("mounts the wizard when catalog.run_setup is granted", () => {
     canMock.mockImplementation(
-      (p: string) => p === "catalog.run_setup" || p === "products.manage",
+      (p: string) => p === "catalog.run_setup" || p === "catalog.products.manage",
     );
     renderRoute();
     expect(screen.getByTestId("wizard-shell-stub")).toBeInTheDocument();

--- a/src/components/catalog/snapshots-view.tsx
+++ b/src/components/catalog/snapshots-view.tsx
@@ -40,7 +40,7 @@ export function SnapshotsView({
 }) {
   const { t } = useDictionary("catalog");
   const can = usePermissionStore((s) => s.can);
-  const canManage = can("inventory.manage");
+  const canManage = can("catalog.manage");
   const { data: snapshots = [], isLoading } = useCatalogSnapshots();
   const create = useCreateSnapshot();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());

--- a/src/components/ops/command-palette.tsx
+++ b/src/components/ops/command-palette.tsx
@@ -290,7 +290,7 @@ export function CommandPalette() {
       icon: Settings,
       onSelect: () => navigate("/settings?tab=inventory"),
       keywords: ["settings", "materials", "stock", "supplies", "equipment"],
-      requiredPermission: "inventory.manage",
+      requiredPermission: "catalog.manage",
     },
     {
       id: "settings-expenses",

--- a/src/lib/api/services/catalog-meta-service.ts
+++ b/src/lib/api/services/catalog-meta-service.ts
@@ -5,7 +5,7 @@
  * tags, units. Creates reuse the existing single-purpose services
  * (`CatalogCategoryService.create`, `CatalogUnitService.create`); this file
  * adds the list reads and the update/delete operations the kebab "// MANAGE"
- * modals need. All gated by `inventory.manage` at the UI layer (never roles).
+ * modals need. All gated by `catalog.manage` at the UI layer (never roles).
  */
 
 import { requireSupabase } from "@/lib/supabase/helpers";

--- a/src/lib/catalog-setup/step-gates.test.ts
+++ b/src/lib/catalog-setup/step-gates.test.ts
@@ -8,17 +8,17 @@ import {
 } from "./step-gates";
 
 const fullCan = () => true;
-const noInventory = (p: string) => p !== "inventory.manage" && p !== "inventory.import";
+const noStock = (p: string) => p !== "catalog.manage" && p !== "catalog.import";
 const viewerOnly = (p: string) => p.endsWith(".view");
 
 describe("STEP_REQUIRED_PERMISSIONS", () => {
-  it("requires catalog.run_setup + products.manage for SELL", () => {
+  it("requires catalog.run_setup + catalog.products.manage for SELL", () => {
     expect(STEP_REQUIRED_PERMISSIONS.SELL).toEqual(
-      expect.arrayContaining(["catalog.run_setup", "products.manage"]),
+      expect.arrayContaining(["catalog.run_setup", "catalog.products.manage"]),
     );
   });
-  it("requires inventory.manage for STOCK", () => {
-    expect(STEP_REQUIRED_PERMISSIONS.STOCK).toContain("inventory.manage");
+  it("requires catalog.manage for STOCK", () => {
+    expect(STEP_REQUIRED_PERMISSIONS.STOCK).toContain("catalog.manage");
   });
 });
 
@@ -26,8 +26,8 @@ describe("isStepAccessible", () => {
   it("grants SELL to a products manager", () => {
     expect(isStepAccessible("SELL", fullCan)).toBe(true);
   });
-  it("hides STOCK from someone without inventory.manage (no dead end)", () => {
-    expect(isStepAccessible("STOCK", noInventory)).toBe(false);
+  it("hides STOCK from someone without catalog.manage (no dead end)", () => {
+    expect(isStepAccessible("STOCK", noStock)).toBe(false);
   });
   it("hides everything from a view-only user", () => {
     expect(isStepAccessible("SELL", viewerOnly)).toBe(false);
@@ -36,8 +36,8 @@ describe("isStepAccessible", () => {
 
 describe("visibleModulePlan", () => {
   const plan: WizardModule[] = ["SELL", "STOCK", "TYPES", "REVIEW"];
-  it("drops STOCK for a no-inventory manager", () => {
-    expect(visibleModulePlan(plan, noInventory)).toEqual(["SELL", "TYPES", "REVIEW"]);
+  it("drops STOCK for a no-stock manager", () => {
+    expect(visibleModulePlan(plan, noStock)).toEqual(["SELL", "TYPES", "REVIEW"]);
   });
   it("keeps the full plan for a full manager", () => {
     expect(visibleModulePlan(plan, fullCan)).toEqual(plan);

--- a/src/lib/catalog-setup/step-gates.ts
+++ b/src/lib/catalog-setup/step-gates.ts
@@ -7,7 +7,7 @@
 // trivially testable and the wizard hides a step the operator can't complete
 // rather than leading them to a dead "build it".
 //
-//   • account-holder / company-admin / office with products.manage → full run
+//   • account-holder / company-admin / office with catalog.products.manage → full run
 //   • operator / crew without the bit → the step (or the whole wizard) is hidden
 //
 // PURE: no store import, no I/O — the caller injects `can`.
@@ -25,14 +25,14 @@ export type CanFn = (permission: string, scope?: "all") => boolean;
 
 /**
  * Each module's required permissions. Trade & task types are catalog setup, not
- * a separate domain, so TYPES rides products.manage (aligned with the registered
- * bits in src/lib/types/permissions.ts). catalog.run_setup is the wizard-entry
- * bit every module shares.
+ * a separate domain, so TYPES rides catalog.products.manage (aligned with the
+ * registered catalog permission bits in src/lib/types/permissions.ts).
+ * catalog.run_setup is the wizard-entry bit every module shares.
  */
 export const STEP_REQUIRED_PERMISSIONS: Record<WizardModule, readonly string[]> = {
-  SELL: ["catalog.run_setup", "products.manage"],
-  STOCK: ["catalog.run_setup", "inventory.manage"],
-  TYPES: ["catalog.run_setup", "products.manage"],
+  SELL: ["catalog.run_setup", "catalog.products.manage"],
+  STOCK: ["catalog.run_setup", "catalog.manage"],
+  TYPES: ["catalog.run_setup", "catalog.products.manage"],
   REVIEW: ["catalog.run_setup"],
 };
 

--- a/src/lib/catalog-setup/step-machine.ts
+++ b/src/lib/catalog-setup/step-machine.ts
@@ -12,9 +12,9 @@ export type WizardStep = "sell" | "stock" | "types" | "review";
 export interface StepContext {
   /** company_inventory_settings.inventory_mode === 'tracked' */
   inventoryTracked: boolean;
-  /** products.manage (or equivalent) — the SELL module */
+  /** catalog.products.manage — the SELL module */
   canSell: boolean;
-  /** inventory.manage — the STOCK module */
+  /** catalog.manage — the STOCK module */
   canStock: boolean;
   /** task/calendar type perms — the TYPES module */
   canTypes: boolean;

--- a/src/lib/constants/fab-actions.ts
+++ b/src/lib/constants/fab-actions.ts
@@ -52,7 +52,7 @@ export const ALL_ACTIONS: FABAction[] = [
   { id: "project",        labelKey: "action.project",   hintCode: "PRJ", icon: FolderKanban,  triggerAction: "projects",   handler: "window", target: "project-workspace",        requiredPermission: "projects.create", meta: { initialMode: "creating" } },
   { id: "task",           labelKey: "action.task",      hintCode: "TSK", icon: ClipboardList, triggerAction: "tasks",      handler: "window", target: "create-task",              requiredPermission: "tasks.create" },
   { id: "task-type",      labelKey: "action.taskType", hintCode: "TTY", icon: Tag,           triggerAction: "task-types", handler: "route",  target: "/settings?tab=company",    requiredPermission: "settings.company" },
-  { id: "inventory-item", labelKey: "action.inventoryItem",      hintCode: "ITM", icon: Boxes,         triggerAction: "inventory",  handler: "route",  target: "/catalog?segment=stock&action=new", requiredPermission: "inventory.manage" },
+  { id: "inventory-item", labelKey: "action.inventoryItem",      hintCode: "ITM", icon: Boxes,         triggerAction: "inventory",  handler: "route",  target: "/catalog?segment=stock&action=new", requiredPermission: "catalog.manage" },
 ];
 
 export const DEFAULT_ACTION_IDS = ALL_ACTIONS.map((a) => a.id);

--- a/src/lib/feature-flags/feature-flag-definitions.ts
+++ b/src/lib/feature-flags/feature-flag-definitions.ts
@@ -17,7 +17,7 @@ export const FEATURE_FLAG_ROUTES: Record<string, string[]> = {
   // products/inventory were never real feature_flags rows (only pipeline +
   // accounting exist in the DB) — their static entries were dead config. The
   // surfaces collapsed into /catalog (P3.2), which is RBAC-gated only
-  // (anyOf products.view / inventory.view in the route registry), not
+  // (anyOf catalog.products.view / catalog.view in the route registry), not
   // commercially flag-gated.
   // ai_email_review removed 2026-04-24 — collapsed into phase_c
   // (migration 20260424000000). phase_c gates the Phase C operator

--- a/src/lib/navigation/route-registry.ts
+++ b/src/lib/navigation/route-registry.ts
@@ -197,14 +197,14 @@ export const ROUTE_REGISTRY: readonly RouteEntry[] = [
     ],
     nav: { order: 9, group: "command" },
     // Any-of across the two segments' gates (mirrors iOS catalog access):
-    // visible when the user can see products OR stock.
-    anyOfPermissions: ["products.view", "inventory.view"],
+    // visible when the user can see catalog products OR stock.
+    anyOfPermissions: ["catalog.products.view", "catalog.view"],
   },
   {
     // /catalog/setup — the full-page Catalog Setup Wizard. NOT a nav entry
     // (launched from the first-run takeover + the catalog kebab), registered so
     // the layout gate enforces catalog.run_setup (tighter than /catalog's
-    // products.view|inventory.view) and the top bar resolves a page title.
+    // catalog.products.view|catalog.view) and the top bar resolves a page title.
     // BY_SPECIFICITY matches this before /catalog.
     key: "catalog-setup",
     href: "/catalog/setup",

--- a/src/lib/types/permissions.ts
+++ b/src/lib/types/permissions.ts
@@ -170,17 +170,23 @@ const productsModule: PermissionModule = {
   ],
 };
 
-// Client home for the DB `catalog.*` namespace (catalog.manage, catalog.import,
-// catalog.run_setup, …) that ships in role_permissions but was previously absent
-// from this catalog. Registering catalog.run_setup here is load-bearing:
+// Client home for the DB `catalog.*` namespace that ships in role_permissions.
+// Keeping every live catalog bit registered here is load-bearing:
 // account-holders & company-admins derive their grants from ALL_PERMISSIONS at
-// scope 'all' (usePermissionStore.fetchPermissions), NOT from role_permissions —
-// so an unregistered bit silently denies the wizard's primary audience (the
-// owner). See client-permission-catalog-sync rule.
+// scope 'all' (usePermissionStore.fetchPermissions), NOT from role_permissions.
+// An unregistered DB bit silently denies the owner/admin path.
 const catalogModule: PermissionModule = {
   id: "catalog",
   label: "Catalog",
   actions: [
+    { id: "catalog.view", label: "View catalog", scopes: ["all"] },
+    { id: "catalog.manage", label: "Manage catalog", scopes: ["all"] },
+    { id: "catalog.import", label: "Import catalog", scopes: ["all"] },
+    { id: "catalog.stock.adjust", label: "Adjust stock", scopes: ["all"] },
+    { id: "catalog.products.view", label: "View catalog products", scopes: ["all"] },
+    { id: "catalog.products.manage", label: "Manage catalog products", scopes: ["all"] },
+    { id: "catalog.orders.view", label: "View purchase orders", scopes: ["all"] },
+    { id: "catalog.orders.manage", label: "Manage purchase orders", scopes: ["all"] },
     { id: "catalog.run_setup", label: "Run catalog setup", scopes: ["all"] },
   ],
 };
@@ -204,16 +210,6 @@ const accountingModule: PermissionModule = {
   actions: [
     { id: "accounting.view", label: "View accounting", scopes: ["all"] },
     { id: "accounting.manage_connections", label: "Manage integrations", scopes: ["all"] },
-  ],
-};
-
-const inventoryModule: PermissionModule = {
-  id: "inventory",
-  label: "Inventory",
-  actions: [
-    { id: "inventory.view", label: "View inventory", scopes: ["all"] },
-    { id: "inventory.manage", label: "Manage inventory", scopes: ["all"] },
-    { id: "inventory.import", label: "Import inventory", scopes: ["all"] },
   ],
 };
 
@@ -334,7 +330,7 @@ export const PERMISSION_CATEGORIES: PermissionCategory[] = [
   {
     id: "resources",
     label: "Resources",
-    modules: [inventoryModule, photosModule, documentsModule],
+    modules: [photosModule, documentsModule],
   },
   {
     id: "people",

--- a/tests/unit/navigation/route-registry.test.ts
+++ b/tests/unit/navigation/route-registry.test.ts
@@ -116,8 +116,7 @@ describe("route permissions (parity with the retired ROUTE_PERMISSIONS map)", ()
     ["/team", "team.view"],
     ["/map", "map.view"],
     ["/pipeline", "pipeline.view"],
-    ["/products", "products.view"],
-    ["/inventory", "inventory.view"],
+    ["/catalog/setup", "catalog.run_setup"],
     ["/inbox", "pipeline.view"],
     ["/calibration", "email.configure_ai"],
     ["/agent", "pipeline.view"],
@@ -143,15 +142,25 @@ describe("route permissions (parity with the retired ROUTE_PERMISSIONS map)", ()
     ]);
   });
 
+  it("/catalog is any-of gated across catalog products and stock", () => {
+    expect(getPermissionForPath("/catalog")).toBeNull(); // single-permission API
+    expect(getAnyOfPermissionsForPath("/catalog")).toEqual([
+      "catalog.products.view",
+      "catalog.view",
+    ]);
+  });
+
   it("single-permission entries normalize through the any-of helper", () => {
     expect(getAnyOfPermissionsForPath("/pipeline")).toEqual(["pipeline.view"]);
     expect(getAnyOfPermissionsForPath("/dashboard")).toBeNull();
   });
 
-  it("retired financial routes are no longer registered (middleware owns them)", () => {
+  it("retired financial and catalog leaf routes are no longer registered (middleware owns them)", () => {
     expect(getEntryForPath("/estimates")).toBeNull();
     expect(getEntryForPath("/invoices")).toBeNull();
     expect(getEntryForPath("/accounting")).toBeNull();
+    expect(getEntryForPath("/products")).toBeNull();
+    expect(getEntryForPath("/inventory")).toBeNull();
   });
 });
 

--- a/tests/unit/permissions/catalog-run-setup-registration.test.ts
+++ b/tests/unit/permissions/catalog-run-setup-registration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect } from "vitest";
 import {
   ALL_PERMISSIONS,
   getPermissionLabel,
@@ -6,16 +6,53 @@ import {
   getPermissionScopes,
   getActionsForTier,
 } from "@/lib/types/permissions";
+import { useAuthStore } from "@/lib/store/auth-store";
+import { usePermissionStore } from "@/lib/store/permissions-store";
+
+const LIVE_CATALOG_PERMISSIONS = [
+  "catalog.view",
+  "catalog.manage",
+  "catalog.import",
+  "catalog.stock.adjust",
+  "catalog.products.view",
+  "catalog.products.manage",
+  "catalog.orders.view",
+  "catalog.orders.manage",
+  "catalog.run_setup",
+] as const;
+
+beforeEach(() => {
+  usePermissionStore.getState().clear();
+  useAuthStore.setState({
+    company: null,
+    currentUser: null,
+    isAuthenticated: false,
+  });
+});
 
 describe("catalog.run_setup permission registration", () => {
-  it("is present in ALL_PERMISSIONS (or admins/account-holders are silently denied)", () => {
+  it("registers the live catalog namespace in ALL_PERMISSIONS", () => {
     // The load-bearing guard: usePermissionStore.fetchPermissions grants
     // account-holders & company-admins exactly the permissions in
-    // ALL_PERMISSIONS at scope 'all'. If the DB grants catalog.run_setup
-    // (migration 0.4) but it is absent here, those users' can('catalog.run_setup')
-    // returns false — the wizard's primary audience (the owner) is silently
-    // locked out. See client-permission-catalog-sync rule.
-    expect(ALL_PERMISSIONS).toContain("catalog.run_setup");
+    // ALL_PERMISSIONS at scope 'all'. If the DB grants a catalog.* bit but it
+    // is absent here, those users' can('catalog.*') returns false.
+    for (const permission of LIVE_CATALOG_PERMISSIONS) {
+      expect(ALL_PERMISSIONS).toContain(permission);
+    }
+  });
+
+  it("no longer exposes the retired inventory.* namespace", () => {
+    // The catalog refactor renamed inventory.* -> catalog.* in role_permissions
+    // and iOS; inventoryModule was deleted from this catalog. Re-introducing any
+    // inventory.* bit would re-surface dead toggles in the roles editor and let
+    // owners/admins "grant" a key the DB no longer recognizes. Guard the deletion
+    // so a stray re-add fails loudly instead of silently denying catalog access.
+    for (const permission of ["inventory.view", "inventory.manage", "inventory.import"]) {
+      expect(ALL_PERMISSIONS).not.toContain(permission);
+    }
+    expect(ALL_PERMISSIONS.some((p) => p.startsWith("inventory."))).toBe(false);
+    // The module itself is gone — getModuleLabel falls back to the bare id.
+    expect(getModuleLabel("inventory")).toBe("inventory");
   });
 
   it("has a real human label, not the id fallback", () => {
@@ -38,5 +75,30 @@ describe("catalog.run_setup permission registration", () => {
     // 'manage' tier and the roles editor would mis-render the catalog module).
     expect(getActionsForTier("catalog", "manage")).toContain("catalog.run_setup");
     expect(getActionsForTier("catalog", "full")).toContain("catalog.run_setup");
+  });
+
+  it("resolves every catalog permission for account-holders and company-admins", async () => {
+    const cases = [
+      {
+        company: { accountHolderId: "user-account-holder", adminIds: [] },
+        userId: "user-account-holder",
+      },
+      {
+        company: { accountHolderId: "other-user", adminIds: ["user-company-admin"] },
+        userId: "user-company-admin",
+      },
+    ];
+
+    for (const testCase of cases) {
+      usePermissionStore.getState().clear();
+      useAuthStore.setState({ company: testCase.company as never });
+
+      await usePermissionStore.getState().fetchPermissions(testCase.userId);
+
+      const can = usePermissionStore.getState().can;
+      for (const permission of LIVE_CATALOG_PERMISSIONS) {
+        expect(can(permission, "all")).toBe(true);
+      }
+    }
   });
 });


### PR DESCRIPTION
## What this lands

Consolidates the **catalog permission registry** fix from the stale standalone branch `fix/catalog-permission-registry` (last touched 2026-06-09, 59 commits ahead but **286 behind** `main`) onto a fresh integration branch off current `origin/main`.

Of the 59 commits on that branch, **only the namesake change is catalog-permission work** — the other 58 are unrelated accumulated noise (pipeline table view, inbox dark-launch, expenses RPCs, accounting/QB docs, lead-lifecycle P4, GA4, dashboard-widget polish) and were **dropped**. The namesake fix could not be cherry-picked: `main` has since diverged (it already added a partial `catalogModule` with only `catalog.run_setup`, plus the P3.2 catalog-hub refactor), so the change was **re-derived against current `main`**.

## The fix

The catalog refactor renamed `inventory.*` → `catalog.*` in `role_permissions` and iOS, but the web permission registry and its consumers still gated catalog surfaces on the dead `inventory.*` / `products.*` keys. Because account-holders & company-admins derive grants from `ALL_PERMISSIONS` (the client catalog) — **not** from `role_permissions` — the unregistered `catalog.*` bits silently denied the owner/admin path, and the permissions tab toggled dead keys.

- **`permissions.ts`**: expand `catalogModule` to the **nine live DB `catalog.*` actions** (`view`, `manage`, `import`, `run_setup`, `stock.adjust`, `products.view`, `products.manage`, `orders.view`, `orders.manage`); delete the dead `inventoryModule`.
- **Catalog hub migrated to `catalog.*`**: catalog page/segments/kebab/editor/snapshots, setup step-gates, the `/catalog` route gate, the settings tab, the command palette, and the FAB "New item" action.
- **`productsModule` kept intact** — `products.view/manage` remain live DB keys for non-catalog surfaces (estimate/invoice line-item pickers).
- **New negative test** guarding the `inventory.*` deletion so a stray re-add fails loudly instead of silently denying catalog access.

## Verification

Ground truth pulled from the live `role_permissions` table (project `ijeekuhbatykdomumfjx`); the registry now matches the DB's nine `catalog.*` grants exactly.

| Check | Result |
|---|---|
| Adversarial audit (4 agents): completeness / scope / DB-overlap / tests + iOS parity | clean — zero remaining `inventory.*` permission keys; no `products.*` over-migration; web mirrors iOS `catalog.*` gates one-for-one |
| `npm run test` (targeted: permissions, route-registry, step-gates) | **59 passed** (incl. the new hardening test) |
| `npm run type-check` | **0 errors introduced** (removing `inventoryModule` broke no references) |
| `npm run lint` | **0 errors** introduced |

## ⚠️ Intended behavior change — Crew `/catalog`

Across all five preset roles, every legacy→`catalog.*` swap has **full role overlap except one**: the **Crew** preset holds the looser legacy `products.view` but **not** `catalog.products.view`. So on web, Crew now sees a **stock-only `/catalog`** (the products segment is hidden; the page degrades gracefully to the stock segment) and **gains** the stock segment (previously dead, since `inventory.view` has zero DB rows).

This is a **parity correction, not a regression**: iOS already gates the products list on `catalog.products.view` (Crew already excluded there), and the DB deliberately cuts catalog-product visibility at Operator. Web was the outlier; this aligns it. **No DB change is made** — granting Crew the key would contradict iOS and exceed scope.

## Out of scope (observations, not addressed here)

- `role_permissions` has 3 lingering `inventory.manage` rows (Admin/Owner/Office) — confirmed **stale duplicates** (all three also hold `catalog.manage`), safe to leave; eligible for a future DB cleanup.
- iOS still has dead, non-mounted `inventory.manage` enforcement (`InventoryView.swift`) — a separate iOS cleanup.

## Notes

- Pre-existing local issues unrelated to this change: `xlsx` (a CDN-tarball dep) is not installed in local `node_modules`, so `xlsx-parse.ts` + its tests fail to resolve identically on clean `origin/main`; and `notification-service.test.ts` has 2 pre-existing type errors. None are in this changeset.
