### PR TITLE
BRANCH CONSOLIDATION: EntityPicker system (client + team pickers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ next-env.d.ts
 
 # Supabase CLI cache
 supabase/.temp/
+.superpowers/
+.playwright-mcp/

--- a/.interface-design/system.md
+++ b/.interface-design/system.md
@@ -783,7 +783,7 @@ Any content that fades, clips, or overflows MUST use gradient transitions. Hard 
 |-------------|----------|
 | Text contrast | ≥ 4.5:1 (AA) for all body text. `text-mute` (3.4:1) decorative only. |
 | Font size floor | 11px minimum. No exceptions. |
-| Touch targets | 44×44px minimum on all interactive elements. |
+| Touch / cursor targets | 44×44px applies to **iOS/mobile only**. OPS Web is cursor-driven — there is **no touch-size minimum**; pickers, list rows, and dense controls use ~32px desktop density. |
 | Focus ring | `1.5px solid accent, offset 2px` — accent appropriate for system-level focus. |
 | Reduced motion | Every animation checks `prefers-reduced-motion`. Fallback: opacity-only at 150ms. |
 | Semantic HTML | `<button>` for buttons, `<a>` for links. No div click handlers without ARIA roles. |

--- a/docs/plans/2026-06-03-standardized-picker-system.md
+++ b/docs/plans/2026-06-03-standardized-picker-system.md
@@ -255,3 +255,25 @@
 - Atomic conventional commits as each task lands. No AI attribution. Stage files by name (never `git add -A`) — the shared tree has parallel WIP.
 - No `git push` without explicit user permission.
 - TDD where behavior is testable (selection, keyboard, commit, states); visual/token correctness verified via `audit-design-system` + the playground.
+
+---
+
+## Migration status
+
+**Branch:** `feat/picker-system` (worktree off clean `main`). **Gates green at checkpoint:** `tsc --noEmit` 0; picker (9) + entity-picker (6) unit suites; projects-table phase4 (20) + phase5 (19) + edit-core (11) integration suites.
+
+### Converted (committed)
+- **Primitive family** — `Picker` / `PickerContent` / `PickerSearch` / `PickerList` / `PickerEmpty` / `PickerGroup` / `PickerItem` / `PickerFooterAction` (`src/components/ui/picker/`). Radix Popover + cmdk, tokenized, tested.
+- **`EntityPicker`** (`src/components/ui/entity-picker.tsx`) — search + single/multi + avatars + sub-label + none-option + create-action + conflict advisory + read-only/error. Tested.
+- **Team cell** (`cell-team.tsx`) — rebuilt as `EntityPicker multiple`; assign-to-all-active-tasks / remove-all; no-tasks notice; RLS-42501 inline; **inline schedule-conflict advisory** via `useTeamScheduleConflicts`. The ~510-line two-panel is gone.
+- **Per-task team picker** — NOTE: `badge-popover.tsx`'s `MiniTeamPickerPopover` is **not yet** routed through EntityPicker (still bespoke; tokenize in a follow-up).
+- **Client cell** (`editable-cell-client.tsx`) — rebuilt as `EntityPicker single + noneOption`; portaled; controlled-edit contract preserved.
+- **Tokens / scaffold** — `popover.tsx` base z-index → `z-dropdown`; `picker` i18n namespace (en + es); `.interface-design/system.md` touch-target line clarified (web is cursor-driven). z-index utilities (`z-dropdown`) already existed in `globals.css` — no Tailwind config change needed.
+
+### Not yet converted (still on bespoke pickers)
+- **Concrete pickers to build:** `EnumPicker`, `SegmentedControl`, `DatetimePicker`.
+- **Entity cluster:** pipeline assignee (`editable-cell-assignee.tsx`), category (`category-picker.tsx`, + i18n), unit (`unit-picker.tsx`, + i18n).
+- **Enum/datetime/specialized:** project status (`editable-cell-status.tsx` → EnumPicker), `segmented-picker.tsx` → SegmentedControl, `snooze-picker.tsx` / `repeat-picker.tsx` / `badge-popover.tsx` MiniCalendar → DatetimePicker, `color-picker-popover.tsx`, `thread-picker.tsx`.
+- **Base tokenization fixes:** `select.tsx` (raw rgba borders, `z-[60]`), `command.tsx` (raw rgba selected bg + `#B5B5B5` inset), `dropdown-menu.tsx` (`z-50`).
+- **Dev playground:** `/dev/playground` borderless-canvas element gallery (not started).
+- **Docs:** canonical picker pattern into `ops-design-system/project/DESIGN.md` + `ops-software-bible/05_DESIGN_SYSTEM.md` (not started).

--- a/docs/plans/2026-06-03-standardized-picker-system.md
+++ b/docs/plans/2026-06-03-standardized-picker-system.md
@@ -1,0 +1,257 @@
+# Standardized Picker System — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Build one canonical, fully-tokenized picker/popover system for OPS Web and rebuild/migrate the 20+ bespoke pickers onto it — starting with the team (multi-select) and client rebuilds.
+
+**Architecture:** A four-part primitive family (`Picker` = Radix `Popover` + `cmdk` `Command`, plus `PickerSearch` / `PickerList` / `PickerItem` / `PickerFooterAction`) → three concrete pickers (`EntityPicker`, `EnumPicker` + `SegmentedControl`, `DatetimePicker`) → migrations. Presentation-only; all data stays in existing hooks. Plus a dev-gated `/dev/playground` borderless-canvas element gallery.
+
+**Tech Stack:** Next.js 14 App Router, TypeScript, Tailwind, `@radix-ui/react-popover` ^1.1, `cmdk` ^1.0, Framer Motion, TanStack Query, Zustand. Tests: existing Vitest/RTL setup.
+
+**Design System:** `.interface-design/system.md` (quick-ref) + spec `docs/superpowers/specs/2026-06-03-standardized-picker-system-design.md`. Every value traces to a Tailwind/CSS token.
+
+**Required Skills (executing agent must load):**
+- `frontend-design` — all component builds.
+- `animation-studio:animation-architect` → `animation-studio:web-animations` — open/close + selection motion.
+- `custom-skills:audit-design-system` — token-compliance verification on everything built/migrated.
+- `ops-copywriter` — every user-facing string (placeholders, empty states, create-actions, conflict advisory) before writing i18n entries.
+- Adhere to `.interface-design/system.md` tokens throughout.
+
+---
+
+## Platform note (do not re-litigate)
+
+**OPS Web is cursor-driven desktop. There are no touch targets.** Picker rows are compact desktop density (**~32px**, `min-h-8`, `px-2 py-1.5`), matching existing tables/pickers. The "44×44px touch target" line in `.interface-design/system.md` §Accessibility reflects the **mobile/iOS** MO and does **not** apply to web pickers. (Task 0.4 proposes a one-line clarification to that doc — do not change behavior to 44px.)
+
+## Canonical token reference (memorize)
+
+| Concern | Token / class | Value |
+|---|---|---|
+| Surface | `.glass-dense` (via `PopoverContent`) | rgba(18,18,20,.78)·blur28·sat1.3·1px rgba(255,255,255,.09)·r12 |
+| Row radius | `rounded` / `rounded-[5px]` (btn) | 5 |
+| Row height/pad | `min-h-8 px-2 py-1.5` | ~32px |
+| Row hover | `hover:bg-surface-hover` | #fff/.05 |
+| Row keyboard cursor (cmdk `data-[selected=true]`) | `bg-surface-active` | #fff/.08 |
+| Chosen check | lucide `Check` 16px `text-text` | #EDEDED |
+| Search field | `bg-surface-input border border-border` | .04 / .10 |
+| Focus | `focus-visible:ring-[1.5px] focus-visible:ring-ops-accent focus-visible:ring-offset-2 focus-visible:ring-offset-black` | accent ring only |
+| Group label | `font-mono text-micro uppercase tracking-wider text-text-3` | 11px |
+| Conflict text | `text-rose` | #B58289 |
+| z-index | `z-dropdown` (new token → `--z-dropdown:1000`) | 1000 |
+| Motion | `motion-safe:animate-anchored-in` (enter) | 150ms EASE_SMOOTH |
+| Avatar | reuse `<UserAvatar>` from `@/components/ops/user-avatar` | — |
+
+**Selected-state rule (one, everywhere):** hover→`surface-hover`; cmdk cursor→`surface-active`; chosen value→trailing monochrome `Check`; disabled→`opacity-40`. Accent only on focus ring.
+
+---
+
+## Phase 0 — Setup & tokens
+
+### Task 0.1: Create isolated worktree
+**Skills:** `superpowers:using-git-worktrees`
+- Create a dedicated worktree + branch `feat/picker-system` so picker work never tangles with the parallel inbox WIP in the shared tree or the brief's do-not-touch files (`projects-view-tabs.tsx`, `projects-view-settings-menu.tsx`, share-with-team toast).
+- All subsequent tasks run inside the worktree.
+
+### Task 0.2: Add z-index tokens to Tailwind
+**Files:** Modify `tailwind.config.ts` (`theme.extend.zIndex`).
+- Add `zIndex: { content:'var(--z-content)', interactive:'var(--z-interactive)', nav:'var(--z-nav)', dropdown:'var(--z-dropdown)', 'floating-ui':'var(--z-floating-ui)', window:'var(--z-window)', modal:'var(--z-modal)', 'map-controls':'var(--z-map-controls)', emergency:'var(--z-emergency)' }`. CSS vars already exist in `globals.css`.
+- **Verify:** `npx tsc --noEmit` (0 errors) and a throwaway `<div className="z-dropdown" />` compiles. Commit: `feat(tokens): add z-index scale utilities`.
+
+### Task 0.3: Picker i18n namespace
+**Files:** Create `src/i18n/dictionaries/en/picker.json` + `src/i18n/dictionaries/es/picker.json`.
+**Skills:** `ops-copywriter`.
+- Keys: `search`, `noResults`, `none` (`—`), `clear`, `create` (`New {entity}`), `conflict` (`Booked · {project} · {when}`), `loading`, `viewOnly`. Both languages.
+- Commit: `feat(i18n): add picker namespace (en+es)`.
+
+### Task 0.4: Design-system doc clarification (non-blocking)
+**Files:** Modify `.interface-design/system.md` §Accessibility touch-target row.
+- Add: "Touch targets (44px) apply to iOS/mobile; OPS Web is cursor-driven — pickers/rows use ~32px desktop density." (Do NOT change component behavior.)
+- Commit: `docs(design-system): clarify touch targets are mobile-only`.
+
+---
+
+## Phase 1 — Primitive family (`src/components/ui/picker/`)
+
+> **Skills:** `frontend-design`, `animation-studio:web-animations` (entrance), `custom-skills:audit-design-system` (end of phase). All UI uses §canonical tokens.
+
+### Task 1.1: `Picker` / `PickerContent`
+**Files:** Create `src/components/ui/picker/picker.tsx`; Test `tests/unit/ui/picker/picker.test.tsx`.
+- `Picker` = re-export Radix `Popover` root + `PickerTrigger` = `PopoverTrigger`.
+- `PickerContent` wraps `PopoverContent`: renders a `cmdk` `Command` root inside; props `size?: 'sm'|'md'|'lg'|'auto'` (224/256/288/auto px → `w-[...]`), `width?`, default `align='start' sideOffset={6}`, `className` merge; sets `z-dropdown`; `onOpenAutoFocus` focuses the search input if present (else first item). Reuses the shipped `.glass-dense` + `motion-safe:animate-anchored-in` already on `PopoverContent`.
+- **Step 1 (test):** renders children in a portal when open; has `role` from cmdk; applies `z-dropdown` + width class. **Step 2:** run → fail. **Step 3:** implement. **Step 4:** pass. **Step 5:** commit `feat(picker): add Picker + PickerContent base`.
+
+### Task 1.2: `PickerSearch`
+**Files:** Create `src/components/ui/picker/picker-search.tsx`; Test alongside.
+- Leading `Search` (16px `text-text-3`), `cmdk` `Command.Input`, trailing clear `X` when value non-empty. `h-8 bg-surface-input border border-border rounded-[5px]`, focus = §focus ring. Mohave `text-body-sm`, `placeholder:text-text-3`. Placeholder via prop (i18n at call site).
+- **Tests:** typing filters (cmdk), clear button resets + refocuses, focus ring class present. Commit `feat(picker): add PickerSearch`.
+
+### Task 1.3: `PickerList` + `PickerEmpty` + `PickerGroupLabel`
+**Files:** Create `src/components/ui/picker/picker-list.tsx`.
+- `PickerList` = `cmdk` `Command.List`, `max-h-[280px]` (prop-override), `overflow-y-auto scrollbar-hide`, scroll contained. `PickerEmpty` = `Command.Empty` → `—`/no-results (`font-mono text-micro uppercase text-text-3`, centered). `PickerGroupLabel` = `// section` micro label.
+- **Tests:** empty renders when no matches; group label renders. Commit `feat(picker): add PickerList, PickerEmpty, PickerGroupLabel`.
+
+### Task 1.4: `PickerItem` + `PickerFooterAction`
+**Files:** Create `src/components/ui/picker/picker-item.tsx`.
+- `PickerItem` = `cmdk` `Command.Item`. Props: `value`, `selected?`, `disabled?`, `onSelect`, `leading?` (avatar/checkbox/dot/icon slot), `children` (label), `subLabel?`, `trailing?`. Styling per §selected-state rule; `min-h-8 px-2 py-1.5 rounded-[5px] gap-2.5`. When `selected` and not multi → trailing `Check` (16px `text-text`). `aria-selected` for single (`role=option`), `aria-checked` for multi.
+- `PickerFooterAction` = divided footer row (`border-t border-border-subtle`), shared row styling, `destructive?` → `text-rose`.
+- **Tests:** click fires `onSelect`; selected shows check; disabled is non-interactive + `opacity-40`; keyboard `Enter` on cursor commits; cursor highlight class = `data-[selected=true]:bg-surface-active`. Commit `feat(picker): add PickerItem + PickerFooterAction`.
+
+### Task 1.5: Barrel + phase audit
+**Files:** Create `src/components/ui/picker/index.ts`.
+- Export all primitives. Run `custom-skills:audit-design-system` over `src/components/ui/picker/*` → zero hardcoded values. `npx tsc --noEmit` 0. Commit `feat(picker): barrel export + token audit pass`.
+
+---
+
+## Phase 2 — Concrete pickers (`src/components/ui/`)
+
+> **Skills:** same as Phase 1.
+
+### Task 2.1: `EntityPicker`
+**Files:** Create `src/components/ui/entity-picker.tsx`; Test `tests/unit/ui/entity-picker.test.tsx`.
+- Props (generic `<T>`): `items`, `value: string|string[]`, `multiple?`, `onChange`, `getId`, `getLabel`, `getSubLabel?`, `getAvatar?` (returns props for `<UserAvatar>`), `searchable?=true`, `placeholder?`, `emptyLabel?`, `noneOption?`, `createAction?:{label;onCreate}`, `conflictFor?:(id)=>string|null`, `loading?`, `disabled?`, `error?`, `triggerLabel`.
+- Single → `onChange(id)` + close. Multi → leading checkbox, `onChange(nextIds[])` optimistic, stays open. `noneOption` → leading `— {none}` row committing null/empty. `conflictFor` → render advisory line (`text-rose font-mono text-micro`) under the row.
+- Avatars via `<UserAvatar>`. Strings via call-site i18n.
+- **Tests:** single select commits+closes; multi toggles + stays open; none-option; create-action fires; conflict line renders; disabled. Commit `feat(picker): add EntityPicker`.
+
+### Task 2.2: `EnumPicker`
+**Files:** Create `src/components/ui/enum-picker.tsx`; Test alongside.
+- Props: `options:{value;label;dotColor?;icon?;disabled?}[]`, `value`, `onChange`, no search, instant commit + close. Leading dot/icon slot (status thermal colors). Reuses `PickerItem`.
+- **Tests:** renders options, commits on click, dot color applied. Commit `feat(picker): add EnumPicker`.
+
+### Task 2.3: `SegmentedControl`
+**Files:** Create `src/components/ui/segmented-control.tsx`; Test alongside.
+**Skills:** `animation-studio:web-animations` (glider).
+- Inline (non-popover) toggle group. Inactive `text-text-3`; hover `text-text-2 bg-[rgba(255,255,255,0.03)]`; active `text-text bg-surface-active border-[rgba(255,255,255,0.18)]` — **no accent** (Toggles spec). Animated glider via Framer Motion `layout`/transform, `EASE_SMOOTH` 200ms, `useReducedMotion` fallback. `iconOnly?` option support.
+- **Tests:** active state, onChange, reduced-motion path. Commit `feat(picker): add SegmentedControl`.
+
+### Task 2.4: `DatetimePicker`
+**Files:** Create `src/components/ui/datetime-picker.tsx`; Test alongside.
+- Props: `presets:{label;sub?;value:()=>Date}[]`, `onSelect`, `customMode?:'datetime'|'range'|'none'`, `footerAction?`. Preset list = `PickerItem`s (instant commit). Custom footer = `datetime-local` input + Set, or a `<CalendarScheduler>` for range (reuse existing). Accent only on selected calendar endpoints.
+- **Tests:** preset commits; custom datetime commits; range uses CalendarScheduler. Commit `feat(picker): add DatetimePicker`.
+
+---
+
+## Phase 3 — Priority rebuilds
+
+> **Skills:** `frontend-design`, `ops-copywriter`, `custom-skills:audit-design-system`. Preserve all behavior; simplify UI only.
+
+### Task 3.0: VERIFY team RPC semantics (do first — no guessing)
+**Files:** read Supabase migrations for `assign_project_team_member` / `remove_project_team_member` (via Supabase MCP `list_migrations`/`execute_sql` on project `ijeekuhbatykdomumfjx`, or `supabase/migrations/`).
+- Determine: (a) does `p_task_ids=[]` have a project-level meaning, or must we pass all active task ids? (b) Is `P0001` (conflict) a hard reject or advisory? (c) what `remove(..., null)` does (remove from all — confirm).
+- **Output:** write findings into the plan/spec as a short "RPC semantics" note. This decides the project-cell `onChange` mapping. **Do not implement 3.1 until resolved.**
+
+### Task 3.1: Rebuild team picker (multi-select) — `cell-team.tsx`
+**Files:** Rewrite `src/app/(dashboard)/projects/_components/table-v2/cells/cell-team.tsx`; reuse `useProjectTableTeam`; Test `tests/integration/...cell-team.test.tsx`.
+- `<EntityPicker multiple>` of company members. Checked = on the job. `onChange` diff → `assignTeamMember`/`removeTeamMember` per the Task 3.0 semantics, optimistic, **no Apply**.
+- `conflictFor` wired from `useTeamScheduleConflicts` (verify availability in this context per spec §11.2; if not cheaply available, scope conflict advisory to the per-task surface this phase and log the deferral).
+- Trigger: avatar stack (≤3, via `<UserAvatar>`) + count, or `UserPlus` + count when empty (parity).
+- States: read-only (RLS `42501`) → disabled rows + `[ view only ]`; error → inline message; loading.
+- Delete the two-panel/drill code entirely.
+- **Tests:** toggle assigns/removes optimistically; conflict advisory renders; read-only/error/empty. `tsc` 0. Commit `feat(projects): rebuild team cell as multi-select EntityPicker`.
+
+### Task 3.2: Unify per-task team picker
+**Files:** Replace `MiniTeamPickerPopover` body in `src/components/ops/badge-popover.tsx` with `<EntityPicker multiple>` (same props it already exposes: `selectedIds`, `members`, `onSave`).
+- **Tests:** existing callers compile; toggle still instant. Commit `refactor(team): route per-task picker through EntityPicker`.
+
+### Task 3.3: Rebuild client picker — `editable-cell-client.tsx`
+**Files:** Rewrite `src/app/(dashboard)/projects/_components/table-v2/cells/editable-cell-client.tsx`; reuse `useClients`; Test alongside.
+- `<EntityPicker single noneOption>`; reuse `useClients` (`enabled: open`). Preserve the controlled `editing`/`onBeginEdit`/`onCancelEdit`/`onCommit` contract + trigger `saving`/`saved` states. Sentence-case rows.
+- Delete hand-rolled div + manual `mousedown`.
+- **Tests:** none-option commits null; client commits; controlled-editing parity; outside-click closes. Commit `feat(projects): rebuild client cell on EntityPicker`.
+
+### Task 3.4: Phase-3 regression gate
+- Run `tests/integration/projects-table-v2-phase4.test.tsx`, `…phase5.test.tsx` → green. `tsc` 0. `audit-design-system` on the two cells. Commit if any fixups.
+
+---
+
+## Phase 4 — Entity-cluster migration
+
+> Pattern: swap bespoke picker → `<EntityPicker>`, preserve hook + behavior, add i18n where missing, audit.
+
+### Task 4.1: Pipeline assignee
+**Files:** `src/app/(dashboard)/pipeline/_components/table/cells/editable-cell-assignee.tsx` → `<EntityPicker single>` + `getAvatar` (gains avatars). Reuse `useTeamMembers`. Tests + `tsc`. Commit `refactor(pipeline): assignee on EntityPicker`.
+
+### Task 4.2: Category (+ i18n)
+**Files:** `src/components/ops/category-picker.tsx` → `<EntityPicker single createAction>`. Reuse `useCatalogLookups`. **Add i18n** (was hardcoded EN) → strings to `picker.json` / a `catalog` namespace. Tests. Commit `refactor(catalog): category picker on EntityPicker + i18n`.
+
+### Task 4.3: Unit (+ i18n)
+**Files:** `src/components/ops/unit-picker.tsx` → `<EntityPicker single createAction>` + `getSubLabel` (abbreviation). Reuse `useCatalogLookups`. **Add i18n.** Tests. Commit `refactor(catalog): unit picker on EntityPicker + i18n`.
+
+---
+
+## Phase 5 — Remaining migrations + tokenization fixes
+
+### Task 5.1: Project status → `EnumPicker`
+**Files:** `src/app/(dashboard)/projects/_components/table-v2/cells/editable-cell-status.tsx` → `<EnumPicker>` with thermal dots. Tests; projects-table phase4/5 stay green. Commit `refactor(projects): status cell on EnumPicker`.
+
+### Task 5.2: Segmented picker → `SegmentedControl`
+**Files:** Replace `src/components/ops/segmented-picker.tsx` usages with `SegmentedControl`; delete old. Tokenize raw px/easing. Commit `refactor(ui): migrate segmented-picker to SegmentedControl`.
+
+### Task 5.3: Snooze → `DatetimePicker`
+**Files:** `src/components/ops/inbox/snooze-picker.tsx`. Preserve `useThreadActions` snooze/unsnooze. Commit `refactor(inbox): snooze on DatetimePicker`.
+
+### Task 5.4: Repeat → `DatetimePicker` (presets) + keep side-panel custom editor
+**Files:** `src/app/(dashboard)/calendar/_components/side-panel/repeat-picker.tsx`. Presets via picker; "Custom recurrence…" footer opens the existing RRULE editor. Tokenize raw rgba/px. Commit `refactor(calendar): repeat presets on DatetimePicker`.
+
+### Task 5.5: Badge calendar → `DatetimePicker` (range)
+**Files:** `MiniCalendarPopover` in `src/components/ops/badge-popover.tsx` → `DatetimePicker` range wrapping `CalendarScheduler`. Commit `refactor(projects): badge calendar on DatetimePicker`.
+
+### Task 5.6: Color → `Picker` (swatch grid)
+**Files:** `src/components/settings/wizard/color-picker-popover.tsx` → `Picker` + grouped swatch grid; drop `createPortal` + hardcoded `blur`/border. Selected = double-ring. Commit `refactor(settings): color picker on Picker`.
+
+### Task 5.7: Thread → `Picker` (list)
+**Files:** `src/components/ops/inbox/thread-picker.tsx` → `Picker` + `PickerList`; current = faint accent wash, state tags. Commit `refactor(inbox): thread picker on Picker`.
+
+### Task 5.8: Tokenize base primitives
+**Files:**
+- `src/components/ui/select.tsx`: `border-[rgba(255,255,255,0.10)]`→`border-border`; `focus:border-[rgba(255,255,255,0.20)]`→`focus:border-glass-border-strong`; `z-[60]`→`z-dropdown`.
+- `src/components/ui/command.tsx`: selected `bg-[rgba(255,255,255,0.04)]`→`bg-surface-active`; drop `shadow-[inset_2px_0_0_0_#B5B5B5]`.
+- `src/components/ui/popover.tsx` + `dropdown-menu.tsx`: `z-50`→`z-dropdown`.
+- Run `audit-design-system` on all four. Commit `refactor(ui): tokenize select/command/popover/dropdown`.
+
+---
+
+## Phase 6 — Dev playground (`/dev/playground`)
+
+> **Skills:** `frontend-design`, `animation-studio:web-animations` (pan/zoom), `custom-skills:audit-design-system`.
+
+### Task 6.1: Route + dev gate
+**Files:** Create `src/app/dev/playground/page.tsx`. Return `notFound()` when `process.env.NODE_ENV === 'production'`. No company scope, no i18n (dev tool). Commit `feat(dev): playground route (dev-gated)`.
+
+### Task 6.2: Borderless pan/zoom canvas
+**Files:** Create `src/app/dev/playground/_components/canvas.tsx`.
+- `overflow-hidden` viewport; large absolutely-positioned surface; pointer-drag on empty space pans (transform translate); wheel pans (shift = x); ctrl-wheel or `+/−` zoom; "reset view" control. `useReducedMotion` → no inertia. No new dependency.
+- Commit `feat(dev): borderless pan/zoom canvas`.
+
+### Task 6.3: Pickers zone (first zone)
+**Files:** `src/app/dev/playground/_components/zones/pickers.tsx`.
+- Render real `EntityPicker` (single/multi/avatar/create/conflict), `EnumPicker`, `SegmentedControl`, `DatetimePicker`, and primitive states — with mock data. Grouped, labeled. Commit `feat(dev): pickers zone`.
+
+### Task 6.4: Element zones (extensible)
+**Files:** zones for buttons, inputs, tags & badges, avatars, status, surfaces — using existing shared components. Each a draggable/positioned zone on the canvas. Commit `feat(dev): element gallery zones`.
+
+---
+
+## Phase 7 — Docs, tests, audit, migration note
+
+### Task 7.1: DESIGN.md + system.md
+**Files:** Add the canonical picker pattern (anatomy, tokens, states, motion, a11y) to `ops-design-system/project/DESIGN.md` and `.interface-design/system.md` (Component Primitives). Commit `docs(design-system): canonical picker pattern`.
+
+### Task 7.2: Bible
+**Files:** Update `ops-software-bible/05_DESIGN_SYSTEM.md` picker/popover section. Commit `docs(bible): picker system`.
+
+### Task 7.3: Full verification gate
+- `npx tsc --noEmit` → 0.
+- Run picker unit suites + `projects-table-v2-phase4/5` + any cell/picker integration → green.
+- `custom-skills:audit-design-system` across all new + migrated files → zero hardcoded values.
+- Manual: open `/dev/playground`, eyeball cohesiveness.
+
+### Task 7.4: Migration note
+**Files:** Append a "Migration status" section to this plan listing every call site converted + any not yet converted (no silent partial coverage). Commit `docs(picker): migration status note`.
+
+---
+
+## Conventions
+- Atomic conventional commits as each task lands. No AI attribution. Stage files by name (never `git add -A`) — the shared tree has parallel WIP.
+- No `git push` without explicit user permission.
+- TDD where behavior is testable (selection, keyboard, commit, states); visual/token correctness verified via `audit-design-system` + the playground.

--- a/docs/superpowers/specs/2026-06-03-standardized-picker-system-design.md
+++ b/docs/superpowers/specs/2026-06-03-standardized-picker-system-design.md
@@ -1,0 +1,250 @@
+# OPS Web — Standardized Picker System
+
+**Status:** Design / pending approval
+**Date:** 2026-06-03
+**Surface:** OPS Web (`ops-web/`) — the logged-in desktop product
+**Author:** picker-system initiative
+**Visual reference:** dev playground mockup served during brainstorming (`.superpowers/brainstorm/.../picker-playground.html`)
+
+---
+
+## 1. Problem
+
+OPS Web has **no standardized picker**. Every picker/popover is bespoke — 20+ of them — and they diverge on every axis that matters:
+
+| Axis | Today's spread |
+|------|----------------|
+| **Mechanism** | Radix `Popover`, Radix `DropdownMenu`, Radix `Select`, `cmdk`, hand-rolled absolute `<div>` + manual outside-click, and `createPortal` with hand-computed coordinates — all coexist. |
+| **z-index** | `z-50` (popover/dropdown), `z-[60]` (select), `z-[1000]` (cell pickers), Radix default (category/unit). |
+| **Surface radius** | `rounded-modal` (12), `glass-dense` (12), `rounded` (5), Radix default. |
+| **Item radius** | `rounded-sm` (2.5), `rounded-[4px]`, `rounded-[5px]`. |
+| **Item padding / height** | `py-[8px]`, `py-[6px]`, `py-1.5`, `h-8`, `h-7`. |
+| **Selected state** | `bg-surface-active`, `bg-fill-neutral-dim`, `inset 2px #B5B5B5` shadow + `rgba(255,255,255,0.04)`, check-only. **Three competing treatments.** |
+| **Hardcoded values** | `select.tsx`: `rgba(255,255,255,0.10)` / `0.20` borders. `command.tsx`: `rgba(255,255,255,0.04)` selected bg + `#B5B5B5` inset. `color-picker-popover.tsx`: hardcoded `blur(28px)` / border. `repeat-picker.tsx`: many raw rgba + px. |
+| **i18n** | Some have none — `category-picker`, `unit-picker`, `segmented-picker`, `repeat-picker`, `color-picker` ship hardcoded English. |
+
+Two are the explicit priority rebuilds:
+
+- **Team picker** — `src/app/(dashboard)/projects/_components/table-v2/cells/cell-team.tsx` (~510 lines). A 720px two-panel (member list + per-task assignment matrix). Owner: *"terrible, way too bulky and confusing — delete and rebuild from scratch."*
+- **Client picker** — `src/app/(dashboard)/projects/_components/table-v2/cells/editable-cell-client.tsx` (~200 lines). Hand-rolled absolute `<div>`, manual `mousedown` outside-click, not portaled (can clip), fragile.
+
+## 2. Goals & non-goals
+
+**Goals**
+- ONE canonical, fully tokenized picker system; every concrete picker is built from it.
+- Rebuild team + client first; migrate the entity cluster (assignee, category, unit); then the rest.
+- Preserve **all** existing capability — simplify the UI, never the function.
+- Zero hardcoded color/spacing/radius/font/z-index values — every value traces to a token.
+- A permanent in-app **dev playground** (full element gallery on a borderless pannable canvas) to confirm cohesiveness continuously.
+
+**Non-goals**
+- The draggable detail/expansion popovers — `client-detail-popover`, `invoice-detail-popover`, `estimate-detail-popover`. Those are **floating windows**, not pickers. Left untouched.
+- iOS / mobile. This is web presentation UI only; no iOS-sync constraints apply.
+- Backend/RPC changes. We reuse the existing data hooks and RPCs as-is. (One semantic must be *verified* against the RPC during planning — see §11.)
+
+## 3. Platform framing (important)
+
+**OPS Web is a cursor-driven desktop product.** Interactions are mouse hover + click + keyboard. **There are no touch targets on web** — the ≥44px touch-minimum from the brand MO ("designed for gloves, sunlight, distraction") describes the **iOS/mobile** context and imposes **no size floor here.** Picker rows are **compact desktop density (~32px)**, matching the existing tables and pickers, optimized for cursor precision and scannability — not finger size. Hover and keyboard-focus states are first-class; there is no "tap" state.
+
+## 4. Design principles
+
+1. **Monochrome restraint.** Surfaces, borders, and text come from the neutral ladder. Earth tones are semantic (status dots, conflict text) and border-only.
+2. **Accent is rare.** `#6F94B0` (steel blue) appears **only** on the focus ring (and the one primary CTA where a picker has one, e.g. the calendar Save). Never on selected rows, links, toggles, tabs, or tags.
+3. **One item state.** Hover → `surface-hover`. Keyboard cursor → `surface-active`. Chosen value → trailing **monochrome** `Check` (in `text`). Disabled → `opacity-40`. This single rule replaces the three competing treatments.
+4. **Glass, not shadow.** The surface is the shipped `.glass-dense` material; depth is the hairline border, never a box-shadow on the dark canvas (the dropdown drop-shadow `--shadow-dropdown` is the one allowed elevation, already in use).
+5. **One easing, honor reduced-motion.** Enter via `anchored-in` (150ms, `EASE_SMOOTH` = `cubic-bezier(0.22,1,0.36,1)`). No spring/bounce. `motion-safe:` gates entrance; `prefers-reduced-motion` falls back to opacity-only.
+6. **Tactical voice.** Panel/section titles use `//`; metadata uses `[brackets]`; UPPERCASE (Cake Mono Light / JetBrains Mono) for authority, sentence case for content. Numbers always JetBrains Mono, tabular + slashed-zero. Empty value is `—`, never "N/A".
+
+## 5. Canonical token decisions
+
+All exist today (verified in `tailwind.config.ts` + `globals.css`) unless marked **new**.
+
+| Concern | Token | Value |
+|---------|-------|-------|
+| Popover surface | `.glass-dense` | `rgba(18,18,20,0.78)` · `blur(28) saturate(1.3)` · `1px rgba(255,255,255,0.09)` · radius **12** |
+| Surface radius | `rounded-modal` | 12 (already baked into `.glass-dense`) |
+| **Row / search / button radius** | `rounded-btn` (= default `rounded`) | **5** — picker rows reuse the button radius; no new token |
+| Tag/chip radius | `rounded-chip` | 4 |
+| Row min-height | — | **~32px** (`min-h-8`), `px-2 py-1.5`; avatar 20–24px |
+| Row hover | `bg-surface-hover` | `rgba(255,255,255,0.05)` |
+| Row keyboard cursor | `bg-surface-active` | `rgba(255,255,255,0.08)` |
+| Chosen check | `text-text` | `#EDEDED`, lucide `Check` 16px |
+| Search field | `bg-surface-input` + `border-border` | `0.04` / `0.10` |
+| Focus ring | `ring-1 ring-ops-accent` | `#6F94B0` |
+| Text ladder | `text` / `text-2` / `text-3` / `text-mute` | `#EDEDED` / `#B5B5B5` / `#8A8A8A` / `#6A6A6A` |
+| Group label / micro | `font-mono text-micro uppercase` | 11px |
+| Conflict text | `text-rose` (semantic) | `#B58289` |
+| **z-index** | `z-dropdown` **(new token)** | maps to `--z-dropdown: 1000` (CSS var already exists) |
+| Enter motion | `motion-safe:animate-anchored-in` | 150ms `EASE_SMOOTH` |
+
+**New token additions (tokenization, not improvisation):**
+- `theme.extend.zIndex` → `{ content:'var(--z-content)', interactive:'var(--z-interactive)', nav:'var(--z-nav)', dropdown:'var(--z-dropdown)', 'floating-ui':'var(--z-floating-ui)', window:'var(--z-window)', modal:'var(--z-modal)', 'map-controls':'var(--z-map-controls)', emergency:'var(--z-emergency)' }`. This makes the documented z-scale usable as Tailwind utilities (`z-dropdown`) instead of `z-[1000]` literals, and lets us migrate the old `z-50`/`z-[60]` as we touch each file.
+
+## 6. Architecture — primitive family
+
+Built on **Radix `Popover`** (reusing the shipped `PopoverContent`, which already applies `.glass-dense` + `anchored-in`) composed with **`cmdk`** for the searchable, keyboard-navigable list. This is the proven "combobox" pattern (Popover + Command) and uses dependencies already installed — no hand-rolled positioning, no manual outside-click, no `createPortal`.
+
+Location: `src/components/ui/picker/`
+
+### `<Picker>` / `<PickerContent>`
+Thin wrapper over `Popover` + `PopoverContent` that standardizes:
+- `side` / `align` / `sideOffset` defaults (`bottom` / `start` / `6`).
+- z-index at `z-dropdown`.
+- width sizing (`size` prop → `sm` 224 / `md` 256 / `lg` 288 / `auto`; or explicit `width`).
+- `onOpenAutoFocus` → focus the `PickerSearch` input (when present).
+- Renders a `cmdk` `Command` root inside so children get filtering + keyboard for free.
+- Escape closes; in table-cell contexts it stops propagation so the table's own key handler doesn't also fire (parity with today's `stopTableKeys`).
+
+### `<PickerSearch>`
+Canonical search input: leading `Search` icon (16px, `text-3`), `cmdk` `Command.Input`, optional trailing clear (`X`) when non-empty. 32px, `surface-input`, `border-border`, `focus-within:ring-1 ring-ops-accent`. Mohave 14px, `placeholder:text-3`. Optional (enum/datetime pickers omit it).
+
+### `<PickerList>` (+ `<PickerEmpty>`, `<PickerGroupLabel>`)
+Scrollable `cmdk` `Command.List` with `scrollbar-hide`, `max-h` cap (default 280, configurable), and internal scroll-lock so wheel/touchpad doesn't bubble to the page. `PickerEmpty` is the canonical `—`/"no results" state (`cmdk` `Command.Empty`). `PickerGroupLabel` is the `// section` micro-label.
+
+### `<PickerItem>`
+The one canonical row (`cmdk` `Command.Item`). Slots: leading (avatar **or** checkbox **or** status dot **or** icon), label (+ optional secondary sub-label), trailing (check / count / sub). Props: `selected`, `disabled`, `value`, `onSelect`. State styling per §4.3. Compact ~32px. `aria-selected` reflects cmdk cursor; chosen value shown via trailing `Check` + `aria-checked` for multi/checkbox semantics.
+
+### `<PickerFooterAction>`
+Divided footer row (`border-t border-border-subtle`) for inline create / clear (e.g. "+ New category", "Remove from all"). Shares row styling; destructive variant uses `text-rose`.
+
+### Keyboard & a11y model
+- `↑/↓` move the cursor (cmdk); `Enter` commits the cursor; `Esc` closes; type-to-filter; `Home/End` jump.
+- Trigger: `aria-haspopup` (`listbox` for single / `dialog` where richer), `aria-expanded`.
+- Content: `role="listbox"` (or `dialog` for multi-section), labelled via `aria-label`.
+- Single-select rows: `role="option"` + `aria-selected`. Multi-select rows: `aria-checked`.
+- Focus returns to trigger on close. Reduced-motion: opacity-only entrance.
+
+## 7. Concrete pickers
+
+Location: `src/components/ui/`
+
+### `<EntityPicker>`
+Search + select with avatars. The workhorse — **replaces client, team, assignee, category, unit** (kills ~400 lines).
+
+```
+<EntityPicker
+  items        ItemT[]            // already-loaded list (we reuse existing hooks)
+  value        string | string[] // single or multi
+  multiple?    boolean
+  onChange     (next) => void     // optimistic; fires per toggle (no Apply)
+  getId / getLabel / getSubLabel? / getAvatar?
+  searchable?  boolean = true
+  placeholder?, emptyLabel? = "—"
+  noneOption?  boolean            // renders a leading "— {none}" row (client)
+  createAction? { label; onCreate } // footer "+ new …"
+  conflictFor? (id) => ConflictNote | null   // inline advisory under a row (team)
+  loading?, disabled?, error?
+/>
+```
+- Single → trailing check on the chosen; clicking commits + closes.
+- Multi → leading checkbox; clicking toggles + commits optimistically, stays open.
+- Data stays in the existing hooks (`useClients`, `useTeamMembers`, `useCatalogLookups`, `useProjectTableTeam`) — `EntityPicker` is presentation only.
+
+### `<EnumPicker>` + `<SegmentedControl>`
+- `<EnumPicker>` — fixed option set, no search, instant commit. Options carry an optional leading dot/icon (status thermal-map colors). Replaces **project status**.
+- `<SegmentedControl>` — inline (non-popover) sibling for view/density segments; tokenized rebuild of `segmented-picker.tsx` with the animated glider on `EASE_SMOOTH`.
+
+### `<DatetimePicker>`
+Preset list (`PickerItem`s) + custom footer. Replaces **snooze** (presets + `datetime-local`), **repeat** (RRULE presets; the full custom editor stays in its side panel, opened via a footer action), and the **badge calendar** (date-range; `CalendarScheduler` reused inside; accent only on selected endpoints).
+
+## 8. Priority rebuilds
+
+### 8.1 Team / crew picker — multi-select (corrected model)
+**The two-panel and the drill-in are both gone.** Team assignment is **per-task**, so the picker is **just a multi-select of crew** — search, tap to toggle, instant optimistic commit, inline schedule-conflict advisory.
+
+- ONE `<EntityPicker multiple>` serves **both** surfaces:
+  - **Projects-table cell** (`cell-team.tsx` rebuild) — "who's on the job." Multi-select of company members; checked = assigned.
+  - **Per-task picker** — replaces `badge-popover.tsx`'s `MiniTeamPickerPopover` (already a plain instant multi-select; finally tokenized).
+- **Conflicts:** reuse `useTeamScheduleConflicts` (`{ date; memberName; projectTitle }[]`, already used by `task-list.tsx`). Surfaced inline under the member in `text-rose` as an **advisory, not a hard block**.
+- **Capability preserved:** member search, multi-select assign/unassign, conflict surfacing, read-only (RLS `42501`) → rows render `disabled` + a `[ view only ]` `PickerEmpty`-style notice, error states → inline message. The "create first task" / per-task matrix complexity is **removed** (it was the source of the bulk); per-task refinement happens in the per-task picker, not here.
+- **Trigger** parity: overlapping avatar stack (≤3) + count, or `UserPlus` + count when empty.
+- **RPC semantics to verify (not guess):** see §11.
+
+### 8.2 Client picker
+`<EntityPicker single>` with `noneOption` ("— No client"). Replaces the hand-rolled `editable-cell-client.tsx`:
+- Portaled via Radix (no clipping), real outside-click/focus management (no manual `mousedown`).
+- Preserves the controlled `editing` / `onBeginEdit` / `onCancelEdit` / `onCommit` contract used by the table's cell-edit machinery, and the `saving`/`saved` visual states on the trigger.
+- Sentence-case content rows (was all-caps mono).
+- Reuses `useClients` (lazy, `enabled: open`).
+
+## 9. Migration map
+
+| Picker | File | Target | Notes |
+|--------|------|--------|-------|
+| Team (project cell) | `…/table-v2/cells/cell-team.tsx` | `EntityPicker multiple` | priority; delete & rebuild |
+| Team (per-task) | `badge-popover.tsx` `MiniTeamPickerPopover` | `EntityPicker multiple` | unify with above |
+| Client | `…/table-v2/cells/editable-cell-client.tsx` | `EntityPicker single` + `noneOption` | priority; delete & rebuild |
+| Pipeline assignee | `…/pipeline/…/cells/editable-cell-assignee.tsx` | `EntityPicker single` | gains avatars + i18n consistency |
+| Category | `components/ops/category-picker.tsx` | `EntityPicker single` + `createAction` | **add i18n** (en+es) |
+| Unit | `components/ops/unit-picker.tsx` | `EntityPicker single` + sub-label + `createAction` | **add i18n** |
+| Project status | `…/table-v2/cells/editable-cell-status.tsx` | `EnumPicker` | thermal dot + check |
+| Segmented | `components/ops/segmented-picker.tsx` | `SegmentedControl` | tokenize raw px/easing |
+| Snooze | `components/ops/inbox/snooze-picker.tsx` | `DatetimePicker` | presets + custom |
+| Repeat | `…/calendar/…/repeat-picker.tsx` | `DatetimePicker` (+ existing side-panel editor) | presets via picker; custom editor stays |
+| Badge calendar | `components/ops/badge-popover.tsx` `MiniCalendarPopover` | `DatetimePicker` (range) | `CalendarScheduler` reused |
+| Color | `components/settings/wizard/color-picker-popover.tsx` | `Picker` (swatch grid) | drop `createPortal` + hardcoded blur |
+| Thread | `components/ops/inbox/thread-picker.tsx` | `Picker` (list) | navigation list |
+| **Out of scope** | `*-detail-popover.tsx` | — | floating windows, untouched |
+
+## 10. Tokenization fixes (apply as each file is touched)
+- `select.tsx`: `border-[rgba(255,255,255,0.10)]` → `border-border`; `focus:border-[rgba(255,255,255,0.20)]` → `focus:border-glass-border-strong` (exact 0.20 match); `z-[60]` → `z-dropdown`.
+- `command.tsx`: `data-[selected=true]:bg-[rgba(255,255,255,0.04)]` → `bg-surface-active`; drop `shadow-[inset_2px_0_0_0_#B5B5B5]` (cursor = surface-active per §4.3); keep chosen-check pattern at the consumer.
+- `popover.tsx` / `dropdown-menu.tsx`: `z-50` → `z-dropdown` (migrate-on-touch).
+- `color-picker-popover.tsx`: drop hardcoded `blur(28px) saturate(1.3)` + `rgba` border → ride `PickerContent`/`.glass-dense`.
+- Standardize item radius (→ `rounded-btn`/5) and padding (→ `px-2 py-1.5`) across migrated pickers.
+
+## 11. Risks / open items (verify in planning, do not guess)
+1. **Projects-table assign target.** When a member is toggled on in the project cell, which tasks do they attach to? `assign_project_team_member(p_task_ids[])` requires task ids; the cell's project-level `teamMemberIds` is the *union* of task assignments. Best read: "assign to all active tasks / remove from all." **Action:** read the `assign_project_team_member` / `remove_project_team_member` RPC SQL (Supabase migrations) before implementing the cell's onChange; confirm whether `p_task_ids = []` has a project-level meaning, and whether `P0001` conflict is a hard reject (which would make "add to all" fail wholesale on one conflicting task — informing whether the cell needs per-task fallback). Pin the exact semantic in the plan.
+2. **Conflict data in the projects table.** `useTeamScheduleConflicts` is wired in `task-list.tsx`; confirm it (or its inputs) is available/cheap to call from the projects-table cell context; otherwise scope conflict-advisory to the per-task surface in phase 1 and add it to the cell in a follow-up (logged, not silent).
+3. **cmdk inside Radix Popover focus.** Standard pattern but verify focus hand-off (`onOpenAutoFocus` → input) and that table key handlers don't double-fire.
+
+## 12. Dev playground (`/dev/playground`)
+A permanent, dev-gated in-app surface — **not** this throwaway mockup. Built from the **real** components + tokens so cohesiveness is verifiable in-app and token drift is caught immediately.
+
+- **Layout:** a **borderless canvas the user pans horizontally and vertically** (not a scroll page). Element groups are absolutely-positioned **zones** on a large surface inside an `overflow-hidden` viewport; pointer-drag on empty canvas translates; wheel pans (shift = horizontal); `+/−` / ctrl-wheel zoom; a "reset view" control. Reduced-motion → no inertia.
+- **Zones (extensible):** **Pickers first** (every primitive + concrete picker + states), then Buttons, Inputs, Tags & badges, Avatars, Status, Dataviz, Surfaces. New groups drop in as new zones.
+- **Tech:** transform-based pan/zoom, **no new dependency** (cost: $0). If a minimap / zoom-to-fit is later wanted, `@xyflow/react` is an option (note bundle cost before adding).
+- **Gating:** route returns `notFound()` in production (`process.env.NODE_ENV === 'production'`) — dev/preview only. Not company-scoped. No i18n (dev tool). No cost.
+- **Location:** `src/app/dev/playground/page.tsx` (+ `_components/`).
+
+## 13. File structure
+```
+src/components/ui/picker/
+  picker.tsx            // Picker, PickerContent (Popover + cmdk Command)
+  picker-search.tsx     // PickerSearch
+  picker-list.tsx       // PickerList, PickerEmpty, PickerGroupLabel
+  picker-item.tsx       // PickerItem, PickerFooterAction
+  index.ts              // barrel
+src/components/ui/entity-picker.tsx
+src/components/ui/enum-picker.tsx
+src/components/ui/segmented-control.tsx   // rebuild of segmented-picker
+src/components/ui/datetime-picker.tsx
+src/app/dev/playground/page.tsx + _components/
+src/i18n/dictionaries/{en,es}/picker.json // shared picker strings (+ category/unit additions)
+```
+
+## 14. i18n
+- New shared namespace `picker` (en + es): generic strings — "Search", "No results", "—", "Clear", "New {entity}", conflict advisory template ("Booked · {project} · {when}").
+- Category/unit pickers gain dictionary-backed strings (were hardcoded English).
+- All migrated pickers route user-facing text through `useDictionary`, en **and** es.
+
+## 15. Testing & verification
+- `npx tsc --noEmit` stays at **0 errors**.
+- Existing suites stay green: `tests/integration/projects-table-v2-phase4.test.tsx`, `…phase5.test.tsx`, plus any cell/picker tests.
+- **New tests:**
+  - Unit — primitive family: keyboard nav (↑/↓/Enter/Esc/type-ahead), single vs multi selection, empty state, disabled, focus management, reduced-motion fallback.
+  - Integration — rebuilt **team** cell (multi-select toggle → optimistic mutation, conflict advisory render, read-only/error states) and **client** cell (none option, controlled editing contract, commit).
+- `custom-skills:audit-design-system` pass over everything built/migrated → zero hardcoded values.
+- Docs updated: canonical picker pattern (anatomy, tokens, states, motion, a11y) into `ops-design-system/project/DESIGN.md` and `ops-software-bible/05_DESIGN_SYSTEM.md`.
+- **Migration note** at the end listing any call sites not yet converted — no silent partial coverage.
+
+## 16. Phasing
+1. **Primitive family** + token additions (`z-*`) + `tsc`/audit green.
+2. **Concrete pickers** — `EntityPicker`, `EnumPicker` + `SegmentedControl`, `DatetimePicker`.
+3. **Priority rebuilds** — team (verify RPC semantics first), client. Tests.
+4. **Entity-cluster migration** — assignee, category (+i18n), unit (+i18n).
+5. **Remaining migrations** — status, segmented, snooze, repeat, badge calendar, color, thread + tokenization fixes (`select`, `command`, `popover`, `dropdown-menu`).
+6. **Dev playground** — borderless canvas, pickers zone first, extensible.
+7. **Docs + bible + migration note.**
+
+Atomic conventional commits as work lands (no AI attribution). No pushes without explicit permission.

--- a/src/app/(dashboard)/projects/_components/table-v2/cells/cell-team.tsx
+++ b/src/app/(dashboard)/projects/_components/table-v2/cells/cell-team.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import Image from "next/image";
-import { useMemo, useRef, useState, type FormEvent, type KeyboardEvent, type MouseEvent } from "react";
-import { Check, ChevronRight, Search, UserPlus, X } from "lucide-react";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useMemo, useState, type KeyboardEvent, type MouseEvent } from "react";
+import { UserPlus } from "lucide-react";
+import { EntityPicker } from "@/components/ui/entity-picker";
+import { UserAvatar } from "@/components/ops/user-avatar";
 import { useDictionary } from "@/i18n/client";
 import { useProjectTableTeam } from "@/lib/hooks/projects-table/use-project-table-team";
+import { ProjectTableMutationError } from "@/lib/api/services/project-table-service";
 import type {
   ProjectTableTaskOption,
   ProjectTableTeamMember,
@@ -13,6 +14,8 @@ import type {
 import type { ProjectTableRow } from "@/lib/types/project-table";
 import { cn } from "@/lib/utils/cn";
 
+// Keys the table grid handles itself — swallow them while the picker is open so
+// cell navigation doesn't fire underneath the popover.
 const ISOLATED_KEYS = new Set([
   "ArrowUp",
   "ArrowDown",
@@ -23,27 +26,11 @@ const ISOLATED_KEYS = new Set([
   " ",
 ]);
 
-function formatText(template: string, replacements?: Record<string, string | number>) {
-  if (!replacements) return template;
+function formatText(template: string, replacements: Record<string, string | number>) {
   return Object.entries(replacements).reduce(
     (value, [key, replacement]) => value.replaceAll(`{${key}}`, String(replacement)),
     template,
   );
-}
-
-function mutationMessage(error: unknown, readOnly: string, fallback: string) {
-  if (error && typeof error === "object" && "code" in error && error.code === "42501") {
-    return readOnly;
-  }
-  return fallback;
-}
-
-function memberInitials(member: ProjectTableTeamMember) {
-  const source = member.name.trim() || member.email?.trim() || member.id;
-  const parts = source.split(/\s+/).filter(Boolean);
-  const first = parts[0]?.[0] ?? "";
-  const last = parts.length > 1 ? parts[parts.length - 1]?.[0] ?? "" : "";
-  return `${first}${last || source[1] || ""}`.toUpperCase();
 }
 
 function isAssignableTask(task: ProjectTableTaskOption) {
@@ -51,65 +38,26 @@ function isAssignableTask(task: ProjectTableTaskOption) {
   return status !== "completed" && status !== "cancelled";
 }
 
-function matchesSearch(member: ProjectTableTeamMember, search: string) {
-  if (!search) return true;
-  const haystack = [member.name, member.email, member.role].filter(Boolean).join(" ").toLowerCase();
-  return haystack.includes(search);
-}
-
-function taskTitle(task: ProjectTableTaskOption, fallback: string) {
-  return task.title.trim() || fallback;
-}
-
-function matchesTaskSearch(task: ProjectTableTaskOption, search: string, fallback: string) {
-  if (!search) return true;
-  return taskTitle(task, fallback).toLowerCase().includes(search);
-}
-
-function stopTableKeys(event: KeyboardEvent<HTMLElement>, onEscape?: () => void) {
-  if (!ISOLATED_KEYS.has(event.key)) return;
-  event.stopPropagation();
-  if (event.key === "Escape") {
-    event.preventDefault();
-    onEscape?.();
-  }
-}
-
-function stopPointer(event: MouseEvent<HTMLElement>) {
-  event.stopPropagation();
-}
-
-function MemberAvatar({
-  member,
-  size = 20,
-}: {
-  member: ProjectTableTeamMember;
-  size?: number;
-}) {
-  const initials = memberInitials(member);
-  const fontSize = Math.max(10, Math.round(size * 0.52));
-
+function is42501(error: unknown) {
   return (
-    <span
-      aria-hidden="true"
-      className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border bg-surface-input font-mono text-[11px] uppercase leading-none text-text-2"
-      style={{ height: size, width: size, fontSize }}
-    >
-      {member.profileImageUrl ? (
-        <Image
-          src={member.profileImageUrl}
-          alt=""
-          width={size}
-          height={size}
-          className="h-full w-full rounded-full object-cover"
-        />
-      ) : (
-        initials
-      )}
-    </span>
-  );
+    error instanceof ProjectTableMutationError && error.code === "42501"
+  ) ||
+    (typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error as { code?: string }).code === "42501");
 }
 
+/**
+ * CellTeam — crew for a project row.
+ *
+ * Team membership is per-task (the project's `team_member_ids` is the union of
+ * its tasks'), so the picker is just a multi-select of crew: checking a member
+ * assigns them to every active task ("on the job"); unchecking removes them from
+ * all. Optimistic, no Apply. When the project has no active task there is nothing
+ * to assign to, so the list is read-only with a notice. A denied write (RLS
+ * 42501) surfaces inline.
+ */
 export function CellTeam({
   row,
   avatarSize = 20,
@@ -118,391 +66,99 @@ export function CellTeam({
   avatarSize?: number;
 }) {
   const { t } = useDictionary("projects");
-  const [open, setOpen] = useState(false);
-  const [memberSearch, setMemberSearch] = useState("");
-  const [taskSearch, setTaskSearch] = useState("");
-  const [selectedMember, setSelectedMember] = useState<ProjectTableTeamMember | null>(null);
-  const [selectedTaskIds, setSelectedTaskIds] = useState<string[]>([]);
-  const [newTaskTitle, setNewTaskTitle] = useState("");
-  const [feedback, setFeedback] = useState<string | null>(null);
-  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const { t: tp } = useDictionary("picker");
+  const [error, setError] = useState<string | null>(null);
 
-  const {
-    teamMembersQuery,
-    tasksQuery,
-    assignedMembers,
-    availableMembers,
-    assignTeamMember,
-    removeTeamMember,
-    createFirstTask,
-  } = useProjectTableTeam({ row });
+  const { teamMembersQuery, tasksQuery, assignedMembers, assignTeamMember, removeTeamMember } =
+    useProjectTableTeam({ row });
 
-  const readOnlyMessage = t("table.cell.team.readOnly");
-  const errorMessage = t("table.cell.team.error");
-  const untitledTaskLabel = t("table.cell.team.untitledTask");
-  const assignableTasks = useMemo(
-    () => (tasksQuery.data ?? []).filter(isAssignableTask),
+  const members = teamMembersQuery.data ?? [];
+  const activeTaskIds = useMemo(
+    () => (tasksQuery.data ?? []).filter(isAssignableTask).map((task) => task.id),
     [tasksQuery.data],
   );
-  const normalizedMemberSearch = memberSearch.trim().toLowerCase();
-  const normalizedTaskSearch = taskSearch.trim().toLowerCase();
-  const filteredAssignedMembers = useMemo(
-    () => assignedMembers.filter((member) => matchesSearch(member, normalizedMemberSearch)),
-    [assignedMembers, normalizedMemberSearch],
-  );
-  const filteredAvailableMembers = useMemo(
-    () => availableMembers.filter((member) => matchesSearch(member, normalizedMemberSearch)),
-    [availableMembers, normalizedMemberSearch],
-  );
-  const visibleTasks = useMemo(
-    () =>
-      assignableTasks.filter((task) =>
-        matchesTaskSearch(task, normalizedTaskSearch, untitledTaskLabel),
-      ),
-    [assignableTasks, normalizedTaskSearch, untitledTaskLabel],
-  );
-  const selectedMemberId = selectedMember?.id ?? null;
+  const hasActiveTasks = activeTaskIds.length > 0;
+
   const assignedCount = row.teamMemberIds.length;
   const triggerLabel = formatText(t("table.cell.team.triggerLabel"), {
     project: row.title,
     count: assignedCount,
   });
   const title = formatText(t("table.cell.team.title"), { project: row.title });
-  const loading = teamMembersQuery.isLoading || tasksQuery.isLoading;
 
-  function handleOpenChange(nextOpen: boolean) {
-    setOpen(nextOpen);
-    if (!nextOpen) {
-      setSelectedMember(null);
-      setSelectedTaskIds([]);
-      setTaskSearch("");
-      setNewTaskTitle("");
-      setFeedback(null);
-    }
-  }
-
-  function toggleTask(taskId: string) {
-    setFeedback(null);
-    setSelectedTaskIds((current) =>
-      current.includes(taskId)
-        ? current.filter((id) => id !== taskId)
-        : [...current, taskId],
-    );
-  }
-
-  async function handleAssign() {
-    if (!selectedMember) return;
-    if (selectedTaskIds.length === 0) {
-      setFeedback(t("table.cell.team.selectTask"));
-      return;
-    }
-
+  async function handleChange(nextIds: string[]) {
+    if (!hasActiveTasks) return;
+    setError(null);
+    const current = new Set(row.teamMemberIds);
+    const next = new Set(nextIds);
+    const added = nextIds.filter((id) => !current.has(id));
+    const removed = row.teamMemberIds.filter((id) => !next.has(id));
     try {
-      await assignTeamMember.mutateAsync({
-        userId: selectedMember.id,
-        taskIds: selectedTaskIds,
-      });
-      setSelectedMember(null);
-      setSelectedTaskIds([]);
-      setTaskSearch("");
-      setFeedback(null);
-    } catch (error) {
-      setFeedback(mutationMessage(error, readOnlyMessage, errorMessage));
+      for (const userId of added) {
+        await assignTeamMember.mutateAsync({ userId, taskIds: activeTaskIds });
+      }
+      for (const userId of removed) {
+        await removeTeamMember.mutateAsync({ userId, taskIds: null });
+      }
+    } catch (err) {
+      setError(is42501(err) ? t("table.cell.team.readOnly") : t("table.cell.team.error"));
     }
   }
 
-  async function handleCreateFirstTask(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!selectedMember) return;
-
-    const titleValue = newTaskTitle.trim();
-    if (!titleValue) {
-      setFeedback(t("table.cell.team.createTaskRequired"));
-      return;
-    }
-
-    try {
-      const created = await createFirstTask.mutateAsync({ title: titleValue });
-      await assignTeamMember.mutateAsync({
-        userId: selectedMember.id,
-        taskIds: [created.taskId],
-      });
-      setSelectedMember(null);
-      setSelectedTaskIds([]);
-      setNewTaskTitle("");
-      setFeedback(null);
-    } catch (error) {
-      setFeedback(mutationMessage(error, readOnlyMessage, errorMessage));
-    }
-  }
-
-  async function handleRemoveFromAll(member: ProjectTableTeamMember) {
-    try {
-      await removeTeamMember.mutateAsync({
-        userId: member.id,
-        taskIds: null,
-      });
-      setFeedback(null);
-    } catch (error) {
-      setFeedback(mutationMessage(error, readOnlyMessage, errorMessage));
-    }
-  }
+  const trigger = (
+    <button
+      type="button"
+      aria-label={triggerLabel}
+      onClick={(event: MouseEvent<HTMLButtonElement>) => event.stopPropagation()}
+      onKeyDown={(event: KeyboardEvent<HTMLButtonElement>) => {
+        if (ISOLATED_KEYS.has(event.key)) event.stopPropagation();
+      }}
+      className="flex h-full w-full min-w-0 items-center gap-1 rounded-[5px] px-1 text-left outline-none transition-colors hover:bg-surface-hover focus-visible:ring-[1.5px] focus-visible:ring-ops-accent focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+    >
+      {assignedMembers.length > 0 ? (
+        <span className="flex min-w-0 items-center">
+          {assignedMembers.slice(0, 3).map((member, index) => (
+            <span key={member.id} className={cn(index > 0 && "-ml-1")}>
+              <UserAvatar name={member.name} imageUrl={member.profileImageUrl} size="sm" />
+            </span>
+          ))}
+        </span>
+      ) : (
+        <span
+          className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border bg-surface-input text-text-3"
+          style={{ height: avatarSize, width: avatarSize }}
+        >
+          <UserPlus
+            style={{
+              height: Math.max(12, Math.round(avatarSize * 0.7)),
+              width: Math.max(12, Math.round(avatarSize * 0.7)),
+            }}
+            strokeWidth={1.5}
+            aria-hidden="true"
+          />
+        </span>
+      )}
+      <span className="font-mono text-micro tabular-nums text-text-2">{assignedCount}</span>
+    </button>
+  );
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          aria-label={triggerLabel}
-          aria-haspopup="dialog"
-          onClick={stopPointer}
-          onKeyDown={(event) => stopTableKeys(event)}
-          className="flex h-full w-full min-w-0 items-center gap-1 rounded-[5px] px-1 text-left outline-none transition-colors hover:bg-surface-hover focus-visible:ring-1 focus-visible:ring-ops-accent"
-        >
-          {assignedMembers.length > 0 ? (
-            <span className="flex min-w-0 items-center">
-              {assignedMembers.slice(0, 3).map((member, index) => (
-                <span key={member.id} className={cn(index > 0 && "-ml-1")}>
-                  <MemberAvatar member={member} size={avatarSize} />
-                </span>
-              ))}
-            </span>
-          ) : (
-            <span
-              className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-border bg-surface-input text-text-3"
-              style={{ height: avatarSize, width: avatarSize }}
-            >
-              <UserPlus
-                style={{
-                  height: Math.max(12, Math.round(avatarSize * 0.7)),
-                  width: Math.max(12, Math.round(avatarSize * 0.7)),
-                }}
-                strokeWidth={1.5}
-                aria-hidden="true"
-              />
-            </span>
-          )}
-          <span className="font-mono text-micro tabular-nums text-text-2">{assignedCount}</span>
-        </button>
-      </PopoverTrigger>
-
-      <PopoverContent
-        align="start"
-        sideOffset={6}
-        role="dialog"
-        aria-label={title}
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-          searchInputRef.current?.focus();
-        }}
-        onKeyDown={(event) => stopTableKeys(event, () => handleOpenChange(false))}
-        className="z-[1000] w-[min(720px,calc(100vw-32px))] rounded-modal border border-border p-0"
-      >
-        <div className="grid max-h-[min(620px,calc(100vh-96px))] min-h-[320px] grid-cols-1 overflow-hidden md:grid-cols-[268px_minmax(280px,1fr)]">
-          <div className="flex min-h-0 flex-col border-b border-border md:border-b-0 md:border-r">
-            <div className="border-b border-border px-3 py-3">
-              <p className="font-mono text-micro uppercase tracking-wider text-text">
-                {title}
-              </p>
-              <label className="mt-3 flex items-center gap-2 rounded-[5px] border border-border bg-surface-input px-2 py-1.5 focus-within:ring-1 focus-within:ring-ops-accent">
-                <Search className="h-3.5 w-3.5 shrink-0 text-text-3" strokeWidth={1.5} aria-hidden="true" />
-                <input
-                  ref={searchInputRef}
-                  value={memberSearch}
-                  onChange={(event) => setMemberSearch(event.target.value)}
-                  placeholder={t("table.cell.team.search")}
-                  className="min-w-0 flex-1 bg-transparent font-mohave text-body-sm text-text outline-none placeholder:text-text-3"
-                />
-              </label>
-            </div>
-
-            <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
-              <section>
-                <h3 className="px-1 font-mono text-micro uppercase tracking-wider text-text-3">
-                  {t("table.cell.team.assigned")}
-                </h3>
-                <div className="mt-1 space-y-1">
-                  {filteredAssignedMembers.map((member) => (
-                    <div
-                      key={member.id}
-                      className="flex min-w-0 items-center gap-2 rounded-[5px] border border-border bg-surface-input px-2 py-1.5"
-                    >
-                      <MemberAvatar member={member} size={avatarSize} />
-                      <span className="min-w-0 flex-1 truncate font-mohave text-body-sm text-text">
-                        {member.name}
-                      </span>
-                      <button
-                        type="button"
-                        aria-label={formatText(t("table.cell.team.removeFromAllMember"), {
-                          member: member.name,
-                        })}
-                        onClick={() => {
-                          void handleRemoveFromAll(member);
-                        }}
-                        className="inline-flex shrink-0 items-center gap-1 rounded-[5px] border border-border px-1.5 py-1 font-mono text-micro uppercase tracking-wider text-text-3 transition-colors hover:bg-surface-hover hover:text-text focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ops-accent"
-                      >
-                        <X className="h-3 w-3" strokeWidth={1.5} aria-hidden="true" />
-                        <span className="hidden sm:inline">{t("table.cell.team.removeFromAll")}</span>
-                      </button>
-                    </div>
-                  ))}
-                  {filteredAssignedMembers.length === 0 ? (
-                    <p className="px-1 py-2 font-mono text-micro uppercase tracking-wider text-text-3">
-                      —
-                    </p>
-                  ) : null}
-                </div>
-              </section>
-
-              <section className="mt-4">
-                <h3 className="px-1 font-mono text-micro uppercase tracking-wider text-text-3">
-                  {t("table.cell.team.available")}
-                </h3>
-                <div className="mt-1 space-y-1">
-                  {filteredAvailableMembers.map((member) => (
-                    <button
-                      key={member.id}
-                      type="button"
-                      onClick={() => {
-                        setSelectedMember(member);
-                        setSelectedTaskIds([]);
-                        setTaskSearch("");
-                        setFeedback(null);
-                      }}
-                      className={cn(
-                        "flex w-full min-w-0 items-center gap-2 rounded-[5px] border px-2 py-1.5 text-left transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ops-accent",
-                        selectedMemberId === member.id
-                          ? "border-border-strong bg-surface-active text-text"
-                          : "border-transparent text-text-2",
-                      )}
-                    >
-                      <MemberAvatar member={member} size={avatarSize} />
-                      <span className="min-w-0 flex-1 truncate font-mohave text-body-sm">
-                        {member.name}
-                      </span>
-                      <ChevronRight className="h-3.5 w-3.5 shrink-0 text-text-3" strokeWidth={1.5} aria-hidden="true" />
-                    </button>
-                  ))}
-                  {filteredAvailableMembers.length === 0 ? (
-                    <p className="px-1 py-2 font-mono text-micro uppercase tracking-wider text-text-3">
-                      {t("table.cell.team.emptyAvailable")}
-                    </p>
-                  ) : null}
-                </div>
-              </section>
-            </div>
-          </div>
-
-          <div className="flex min-h-0 flex-col">
-            <div className="border-b border-border px-3 py-3">
-              <p className="font-mono text-micro uppercase tracking-wider text-text">
-                {selectedMember ? t("table.cell.team.assignToTasks") : t("table.cell.team.available")}
-              </p>
-              {selectedMember ? (
-                <p className="mt-1 truncate font-mohave text-body-sm text-text-2">
-                  {selectedMember.name}
-                </p>
-              ) : null}
-            </div>
-
-            <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
-              {feedback ? (
-                <p className="mb-3 rounded-[5px] border border-border bg-surface-input px-2 py-1.5 font-mono text-micro uppercase tracking-wider text-text-2">
-                  {feedback}
-                </p>
-              ) : null}
-
-              {!selectedMember ? (
-                <div className="flex h-full min-h-[180px] items-center justify-center rounded-[5px] border border-border bg-surface-input px-4 text-center">
-                  <p className="font-mono text-micro uppercase tracking-wider text-text-3">
-                    {t("table.cell.team.available")}
-                  </p>
-                </div>
-              ) : assignableTasks.length === 0 ? (
-                <form onSubmit={handleCreateFirstTask} className="space-y-3">
-                  <p className="font-mono text-micro uppercase tracking-wider text-text-3">
-                    {t("table.cell.team.noTasks")}
-                  </p>
-                  <input
-                    value={newTaskTitle}
-                    onChange={(event) => setNewTaskTitle(event.target.value)}
-                    placeholder={t("table.cell.team.createTaskPlaceholder")}
-                    className="h-9 w-full rounded-[5px] border border-border bg-surface-input px-2 font-mohave text-body-sm text-text outline-none placeholder:text-text-3 focus-visible:ring-1 focus-visible:ring-ops-accent"
-                  />
-                  <button
-                    type="submit"
-                    disabled={createFirstTask.isPending || assignTeamMember.isPending}
-                    className="inline-flex h-8 items-center justify-center gap-1 rounded-[5px] border border-border px-3 font-mohave text-button uppercase text-text-2 transition-colors hover:bg-surface-hover hover:text-text focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ops-accent disabled:pointer-events-none disabled:opacity-40"
-                  >
-                    <UserPlus className="h-3.5 w-3.5" strokeWidth={1.5} aria-hidden="true" />
-                    {t("table.cell.team.createFirstTask")}
-                  </button>
-                </form>
-              ) : (
-                <div className="space-y-3">
-                  <label className="flex items-center gap-2 rounded-[5px] border border-border bg-surface-input px-2 py-1.5 focus-within:ring-1 focus-within:ring-ops-accent">
-                    <Search className="h-3.5 w-3.5 shrink-0 text-text-3" strokeWidth={1.5} aria-hidden="true" />
-                    <input
-                      value={taskSearch}
-                      onChange={(event) => setTaskSearch(event.target.value)}
-                      placeholder={t("table.cell.team.taskSearch")}
-                      className="min-w-0 flex-1 bg-transparent font-mohave text-body-sm text-text outline-none placeholder:text-text-3"
-                    />
-                  </label>
-
-                  <div className="space-y-1">
-                    {visibleTasks.map((task) => {
-                      const checked = selectedTaskIds.includes(task.id);
-                      return (
-                        <button
-                          key={task.id}
-                          type="button"
-                          role="checkbox"
-                          aria-checked={checked}
-                          onClick={() => toggleTask(task.id)}
-                          className={cn(
-                            "flex w-full min-w-0 items-center gap-2 rounded-[5px] border px-2 py-2 text-left transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ops-accent",
-                            checked
-                              ? "border-border-strong bg-surface-active text-text"
-                              : "border-border bg-surface-input text-text-2",
-                          )}
-                        >
-                          <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-[3px] border border-border bg-background">
-                            {checked ? (
-                              <Check className="h-3 w-3 text-text" strokeWidth={1.5} aria-hidden="true" />
-                            ) : null}
-                          </span>
-                          <span className="min-w-0 flex-1 truncate font-mohave text-body-sm">
-                            {taskTitle(task, untitledTaskLabel)}
-                          </span>
-                        </button>
-                      );
-                    })}
-                  </div>
-
-                  <button
-                    type="button"
-                    disabled={assignTeamMember.isPending || selectedTaskIds.length === 0}
-                    onClick={() => {
-                      void handleAssign();
-                    }}
-                    className="inline-flex h-8 items-center justify-center gap-1 rounded-[5px] border border-border px-3 font-mohave text-button uppercase text-text-2 transition-colors hover:bg-surface-hover hover:text-text focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ops-accent disabled:pointer-events-none disabled:opacity-40"
-                  >
-                    <Check className="h-3.5 w-3.5" strokeWidth={1.5} aria-hidden="true" />
-                    {t("table.cell.team.assign")}
-                  </button>
-                </div>
-              )}
-
-              {loading ? (
-                <p className="mt-3 font-mono text-micro uppercase tracking-wider text-text-3">
-                  {t("table.loading.refetching")}
-                </p>
-              ) : null}
-            </div>
-          </div>
-        </div>
-      </PopoverContent>
-    </Popover>
+    <EntityPicker<ProjectTableTeamMember>
+      multiple
+      trigger={trigger}
+      label={title}
+      items={members}
+      value={row.teamMemberIds}
+      onChange={handleChange}
+      getId={(member) => member.id}
+      getLabel={(member) => member.name}
+      getAvatar={(member) => ({ name: member.name, imageUrl: member.profileImageUrl })}
+      searchPlaceholder={t("table.cell.team.search")}
+      clearLabel={tp("clear")}
+      emptyLabel={t("table.cell.team.emptyAvailable")}
+      readOnly={!hasActiveTasks}
+      readOnlyLabel={hasActiveTasks ? undefined : t("table.cell.team.noTasks")}
+      error={error}
+    />
   );
 }

--- a/src/app/(dashboard)/projects/_components/table-v2/cells/cell-team.tsx
+++ b/src/app/(dashboard)/projects/_components/table-v2/cells/cell-team.tsx
@@ -6,6 +6,7 @@ import { EntityPicker } from "@/components/ui/entity-picker";
 import { UserAvatar } from "@/components/ops/user-avatar";
 import { useDictionary } from "@/i18n/client";
 import { useProjectTableTeam } from "@/lib/hooks/projects-table/use-project-table-team";
+import { useTeamScheduleConflicts } from "@/lib/hooks/use-team-conflicts";
 import { ProjectTableMutationError } from "@/lib/api/services/project-table-service";
 import type {
   ProjectTableTaskOption,
@@ -38,14 +39,18 @@ function isAssignableTask(task: ProjectTableTaskOption) {
   return status !== "completed" && status !== "cancelled";
 }
 
+function formatConflictWhen(date: Date) {
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
 function is42501(error: unknown) {
   return (
-    error instanceof ProjectTableMutationError && error.code === "42501"
-  ) ||
+    (error instanceof ProjectTableMutationError && error.code === "42501") ||
     (typeof error === "object" &&
       error !== null &&
       "code" in error &&
-      (error as { code?: string }).code === "42501");
+      (error as { code?: string }).code === "42501")
+  );
 }
 
 /**
@@ -56,7 +61,8 @@ function is42501(error: unknown) {
  * assigns them to every active task ("on the job"); unchecking removes them from
  * all. Optimistic, no Apply. When the project has no active task there is nothing
  * to assign to, so the list is read-only with a notice. A denied write (RLS
- * 42501) surfaces inline.
+ * 42501) surfaces inline. Members already booked on another project in the
+ * window get an inline advisory (not a hard block).
  */
 export function CellTeam({
   row,
@@ -67,6 +73,7 @@ export function CellTeam({
 }) {
   const { t } = useDictionary("projects");
   const { t: tp } = useDictionary("picker");
+  const [open, setOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const { teamMembersQuery, tasksQuery, assignedMembers, assignTeamMember, removeTeamMember } =
@@ -78,6 +85,28 @@ export function CellTeam({
     [tasksQuery.data],
   );
   const hasActiveTasks = activeTaskIds.length > 0;
+
+  // Schedule-conflict advisory — members booked on another project in the
+  // window. Fetched only while the picker is open (excludes this project).
+  const memberNameMap = useMemo(
+    () => new Map(members.map((member) => [member.id, member.name])),
+    [members],
+  );
+  const { data: conflicts = [] } = useTeamScheduleConflicts(
+    members.map((member) => member.id),
+    row.id,
+    memberNameMap,
+    open,
+  );
+  const conflictByMember = useMemo(() => {
+    const map = new Map<string, { projectTitle: string; date: Date }>();
+    for (const conflict of conflicts) {
+      if (!map.has(conflict.memberId)) {
+        map.set(conflict.memberId, { projectTitle: conflict.projectTitle, date: conflict.date });
+      }
+    }
+    return map;
+  }, [conflicts]);
 
   const assignedCount = row.teamMemberIds.length;
   const triggerLabel = formatText(t("table.cell.team.triggerLabel"), {
@@ -103,6 +132,15 @@ export function CellTeam({
     } catch (err) {
       setError(is42501(err) ? t("table.cell.team.readOnly") : t("table.cell.team.error"));
     }
+  }
+
+  function conflictFor(id: string) {
+    const conflict = conflictByMember.get(id);
+    if (!conflict) return null;
+    return formatText(tp("conflict"), {
+      project: conflict.projectTitle,
+      when: formatConflictWhen(conflict.date),
+    });
   }
 
   const trigger = (
@@ -146,6 +184,8 @@ export function CellTeam({
     <EntityPicker<ProjectTableTeamMember>
       multiple
       trigger={trigger}
+      open={open}
+      onOpenChange={setOpen}
       label={title}
       items={members}
       value={row.teamMemberIds}
@@ -153,6 +193,7 @@ export function CellTeam({
       getId={(member) => member.id}
       getLabel={(member) => member.name}
       getAvatar={(member) => ({ name: member.name, imageUrl: member.profileImageUrl })}
+      conflictFor={conflictFor}
       searchPlaceholder={t("table.cell.team.search")}
       clearLabel={tp("clear")}
       emptyLabel={t("table.cell.team.emptyAvailable")}

--- a/src/app/(dashboard)/projects/_components/table-v2/cells/editable-cell-client.tsx
+++ b/src/app/(dashboard)/projects/_components/table-v2/cells/editable-cell-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEvent as ReactMouseEvent } from "react";
-import { Check, Search } from "lucide-react";
+import { useState, type MouseEvent } from "react";
+import { EntityPicker } from "@/components/ui/entity-picker";
 import { useDictionary } from "@/i18n/client";
 import { useClients } from "@/lib/hooks/use-clients";
 import { useAuthStore } from "@/lib/store/auth-store";
@@ -10,6 +10,20 @@ import type { ProjectTableClientEditValue } from "@/lib/types/project-table";
 import { cn } from "@/lib/utils/cn";
 import { CellText } from "./cell-text";
 
+interface ClientLite {
+  id: string;
+  name: string;
+}
+
+/**
+ * EditableCellClient — single-select client picker for a project row.
+ *
+ * Built on EntityPicker (portaled, real focus + outside-click) — replaces the
+ * hand-rolled absolute div + manual mousedown listener. Preserves the table's
+ * controlled-edit contract (`editing` / `onBeginEdit` / `onCancelEdit` /
+ * `onCommit`) and the saving/saved trigger states. Selecting commits + closes;
+ * the "—" row clears the client.
+ */
 export function EditableCellClient({
   clientId,
   clientName,
@@ -28,169 +42,66 @@ export function EditableCellClient({
   onCommit: (value: ProjectTableClientEditValue) => Promise<void> | void;
 }) {
   const { t } = useDictionary("projects");
-  const popoverRef = useRef<HTMLDivElement | null>(null);
-  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const { t: tp } = useDictionary("picker");
   const [internalOpen, setInternalOpen] = useState(false);
-  const [search, setSearch] = useState("");
   const open = editing ?? internalOpen;
   const companyId = useAuthStore((state) => state.company?.id ?? "");
   const clientsQuery = useClients(undefined, {
     enabled: open && Boolean(companyId),
     staleTime: 5 * 60 * 1000,
   });
+  const clients: ClientLite[] = clientsQuery.data?.clients ?? [];
 
-  const clients = useMemo(() => {
-    const query = search.trim().toLowerCase();
-    const source = clientsQuery.data?.clients ?? [];
-    if (!query) return source;
-    return source.filter((client) => client.name.toLowerCase().includes(query));
-  }, [clientsQuery.data?.clients, search]);
-
-  useEffect(() => {
-    if (!open) return;
-    window.setTimeout(() => searchInputRef.current?.focus(), 0);
-
-    function handlePointerDown(event: globalThis.MouseEvent) {
-      if (popoverRef.current?.contains(event.target as Node)) return;
-      closePopover();
-    }
-
-    document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
-  });
-
-  function openPopover() {
-    onBeginEdit?.();
-    setSearch("");
-    if (editing == null) setInternalOpen(true);
-  }
-
-  function closePopover() {
-    onCancelEdit?.();
-    if (editing == null) setInternalOpen(false);
-  }
-
-  function handleKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      event.stopPropagation();
-      closePopover();
+  function setOpen(next: boolean) {
+    if (next) {
+      onBeginEdit?.();
+      if (editing == null) setInternalOpen(true);
+    } else {
+      onCancelEdit?.();
+      if (editing == null) setInternalOpen(false);
     }
   }
 
-  async function handleSelect(
-    event: ReactMouseEvent<HTMLButtonElement>,
-    value: ProjectTableClientEditValue,
-  ) {
-    event.preventDefault();
-    event.stopPropagation();
-    await onCommit(value);
-    closePopover();
+  function handleChange(id: string | null) {
+    if (id == null) {
+      void onCommit({ clientId: null, clientName: null });
+      return;
+    }
+    const match = clients.find((client) => client.id === id);
+    void onCommit({ clientId: id, clientName: match?.name ?? clientName });
   }
+
+  const trigger = (
+    <button
+      type="button"
+      aria-label={t("table.cell.client.triggerLabel")}
+      onClick={(event: MouseEvent<HTMLButtonElement>) => event.stopPropagation()}
+      className={cn(
+        "flex h-full w-full min-w-0 items-center rounded-[5px] px-1 text-left outline-none transition-colors hover:bg-surface-hover focus-visible:ring-[1.5px] focus-visible:ring-ops-accent focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+        saveState === "saving" && "opacity-70",
+        saveState === "saved" && "bg-surface-active",
+      )}
+    >
+      <CellText value={clientName} className="text-text-2" />
+    </button>
+  );
 
   return (
-    <div
-      ref={popoverRef}
-      className="relative flex h-full w-full min-w-0 items-center"
-      onKeyDown={handleKeyDown}
-    >
-      <button
-        type="button"
-        aria-label={t("table.cell.client.triggerLabel")}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        onClick={(event) => {
-          event.stopPropagation();
-          if (open) {
-            closePopover();
-          } else {
-            openPopover();
-          }
-        }}
-        className={cn(
-          "flex h-full w-full min-w-0 items-center rounded-[5px] px-1 text-left outline-none transition-colors hover:bg-surface-hover focus-visible:ring-1 focus-visible:ring-ops-accent",
-          saveState === "saving" && "opacity-70",
-          saveState === "saved" && "bg-surface-active",
-        )}
-      >
-        <CellText value={clientName} className="text-text-2" />
-      </button>
-
-      {open ? (
-        <div
-          role="dialog"
-          aria-label={t("table.cell.client.title")}
-          className="glass-dense absolute left-0 top-full z-[1000] mt-1 w-[280px] rounded-modal border border-border p-2"
-        >
-          <label className="flex h-7 items-center gap-1.5 rounded-[5px] border border-border bg-surface-input px-2 focus-within:ring-1 focus-within:ring-ops-accent">
-            <Search className="h-3 w-3 shrink-0 text-text-3" strokeWidth={1.5} />
-            <input
-              ref={searchInputRef}
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder={t("table.cell.client.search")}
-              className="min-w-0 flex-1 bg-transparent font-mono text-micro uppercase text-text outline-none placeholder:text-text-3"
-            />
-          </label>
-
-          <div
-            role="listbox"
-            aria-label={t("table.cell.client.title")}
-            className="mt-2 max-h-[220px] overflow-auto"
-          >
-            <button
-              type="button"
-              role="option"
-              aria-selected={clientId == null}
-              onClick={(event) => {
-                void handleSelect(event, { clientId: null, clientName: null });
-              }}
-              className={cn(
-                "flex h-8 w-full min-w-0 items-center gap-2 rounded-[5px] px-2 text-left font-mono text-micro uppercase transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ops-accent",
-                clientId == null ? "bg-surface-active text-text" : "text-text-2",
-              )}
-            >
-              <span className="w-3 shrink-0">
-                {clientId == null ? <Check className="h-3 w-3" strokeWidth={1.5} /> : null}
-              </span>
-              <span className="truncate">—</span>
-            </button>
-
-            {clients.map((client) => {
-              const selected = client.id === clientId;
-              return (
-                <button
-                  key={client.id}
-                  type="button"
-                  role="option"
-                  aria-selected={selected}
-                  onClick={(event) => {
-                    void handleSelect(event, {
-                      clientId: client.id,
-                      clientName: client.name,
-                    });
-                  }}
-                  className={cn(
-                    "flex h-8 w-full min-w-0 items-center gap-2 rounded-[5px] px-2 text-left font-mono text-micro uppercase transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ops-accent",
-                    selected ? "bg-surface-active text-text" : "text-text-2",
-                  )}
-                >
-                  <span className="w-3 shrink-0">
-                    {selected ? <Check className="h-3 w-3" strokeWidth={1.5} /> : null}
-                  </span>
-                  <span className="truncate">{client.name}</span>
-                </button>
-              );
-            })}
-
-            {clients.length === 0 ? (
-              <p className="px-2 py-2 font-mono text-micro uppercase tracking-wider text-text-3">
-                {t("table.cell.client.empty")}
-              </p>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
-    </div>
+    <EntityPicker<ClientLite>
+      trigger={trigger}
+      open={open}
+      onOpenChange={setOpen}
+      label={t("table.cell.client.title")}
+      items={clients}
+      value={clientId}
+      onChange={handleChange}
+      getId={(client) => client.id}
+      getLabel={(client) => client.name}
+      searchPlaceholder={t("table.cell.client.search")}
+      clearLabel={tp("clear")}
+      emptyLabel={t("table.cell.client.empty")}
+      noneOption
+      noneLabel="—"
+    />
   );
 }

--- a/src/components/ui/entity-picker.tsx
+++ b/src/components/ui/entity-picker.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import * as React from "react";
+import { Plus } from "lucide-react";
+import {
+  Picker,
+  PickerTrigger,
+  PickerContent,
+  PickerSearch,
+  PickerList,
+  PickerEmpty,
+  PickerItem,
+  PickerFooterAction,
+} from "@/components/ui/picker";
+import { UserAvatar } from "@/components/ops/user-avatar";
+
+export interface EntityAvatar {
+  name: string;
+  imageUrl?: string | null;
+}
+
+interface EntityPickerBaseProps<T> {
+  /** Trigger node — rendered via PickerTrigger asChild. */
+  trigger: React.ReactNode;
+  items: T[];
+  getId: (item: T) => string;
+  getLabel: (item: T) => string;
+  /** Right-aligned secondary text (e.g. a unit abbreviation). */
+  getSubLabel?: (item: T) => React.ReactNode;
+  /** Leading avatar descriptor. */
+  getAvatar?: (item: T) => EntityAvatar | null | undefined;
+  /** Advisory line under a row (e.g. a schedule conflict). Multi-select only in practice. */
+  conflictFor?: (id: string) => React.ReactNode | null | undefined;
+  /** Accessible name for the popover. */
+  label: string;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  clearLabel?: string;
+  emptyLabel?: React.ReactNode;
+  /** Footer create action ("+ New …"). Hidden in read-only. */
+  createAction?: { label: React.ReactNode; onCreate: () => void };
+  /** Read-only (e.g. RLS 42501) — rows non-interactive + a notice. */
+  readOnly?: boolean;
+  readOnlyLabel?: React.ReactNode;
+  /** Inline error (e.g. mutation failure). */
+  error?: React.ReactNode;
+  /** Controlled open (optional — uncontrolled by default). */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  size?: "sm" | "md" | "lg" | "auto";
+  align?: "start" | "center" | "end";
+  side?: "top" | "right" | "bottom" | "left";
+}
+
+interface SingleProps<T> extends EntityPickerBaseProps<T> {
+  multiple?: false;
+  value: string | null;
+  onChange: (id: string | null) => void;
+  /** Leading "— none" row (single-select only). */
+  noneOption?: boolean;
+  noneLabel?: React.ReactNode;
+}
+
+interface MultiProps<T> extends EntityPickerBaseProps<T> {
+  multiple: true;
+  value: string[];
+  onChange: (ids: string[]) => void;
+}
+
+export type EntityPickerProps<T> = SingleProps<T> | MultiProps<T>;
+
+/**
+ * EntityPicker — search + single/multi select with optional avatars,
+ * sub-labels, a "none" row, an inline create action, and per-row conflict
+ * advisories. The one component behind client, team, assignee, category, unit.
+ * Presentation only — data lives in the caller's hooks. Optimistic: single
+ * commits + closes; multi toggles and stays open. No Apply button.
+ */
+export function EntityPicker<T>(props: EntityPickerProps<T>) {
+  const {
+    trigger,
+    items,
+    getId,
+    getLabel,
+    getSubLabel,
+    getAvatar,
+    conflictFor,
+    label,
+    searchable = true,
+    searchPlaceholder,
+    clearLabel,
+    emptyLabel,
+    createAction,
+    readOnly,
+    readOnlyLabel,
+    error,
+    open,
+    onOpenChange,
+    size = "md",
+    align = "start",
+    side = "bottom",
+  } = props;
+
+  const [search, setSearch] = React.useState("");
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const isOpen = open ?? internalOpen;
+
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      setInternalOpen(next);
+      onOpenChange?.(next);
+      if (!next) setSearch("");
+    },
+    [onOpenChange],
+  );
+
+  const selectedIds = props.multiple ? props.value : [];
+  const singleValue = props.multiple ? null : props.value;
+  const isSelected = (id: string) =>
+    props.multiple ? selectedIds.includes(id) : singleValue === id;
+
+  function handleSelect(id: string) {
+    if (readOnly) return;
+    if (props.multiple) {
+      const next = props.value.includes(id)
+        ? props.value.filter((x) => x !== id)
+        : [...props.value, id];
+      props.onChange(next);
+    } else {
+      props.onChange(id);
+      setOpen(false);
+    }
+  }
+
+  return (
+    <Picker open={isOpen} onOpenChange={setOpen}>
+      <PickerTrigger asChild>{trigger}</PickerTrigger>
+      <PickerContent
+        label={label}
+        size={size}
+        align={align}
+        side={side}
+        shouldFilter={searchable}
+      >
+        {searchable ? (
+          <PickerSearch
+            value={search}
+            onValueChange={setSearch}
+            placeholder={searchPlaceholder}
+            clearLabel={clearLabel}
+          />
+        ) : null}
+
+        {readOnly && readOnlyLabel ? (
+          <p className="px-3 pb-1 pt-2 font-mono text-micro uppercase tracking-wider text-text-3">
+            {readOnlyLabel}
+          </p>
+        ) : null}
+
+        <PickerList>
+          <PickerEmpty>{emptyLabel ?? "—"}</PickerEmpty>
+
+          {!props.multiple && props.noneOption ? (
+            <PickerItem
+              value={
+                typeof props.noneLabel === "string" ? props.noneLabel : "__none__"
+              }
+              selected={singleValue == null}
+              disabled={readOnly}
+              onSelect={() => {
+                if (readOnly) return;
+                props.onChange(null);
+                setOpen(false);
+              }}
+            >
+              <span className="text-text-3">{props.noneLabel ?? "—"}</span>
+            </PickerItem>
+          ) : null}
+
+          {items.map((item) => {
+            const id = getId(item);
+            const labelText = getLabel(item);
+            const avatar = getAvatar?.(item);
+            const conflict = conflictFor?.(id);
+            const sub = getSubLabel?.(item);
+            return (
+              <PickerItem
+                key={id}
+                value={labelText}
+                multiple={props.multiple}
+                selected={isSelected(id)}
+                disabled={readOnly}
+                onSelect={() => handleSelect(id)}
+                leading={
+                  avatar ? (
+                    <UserAvatar name={avatar.name} imageUrl={avatar.imageUrl} size="sm" />
+                  ) : undefined
+                }
+                subLabel={conflict ?? undefined}
+                trailing={
+                  sub != null ? (
+                    <span className="shrink-0 font-mono text-micro text-text-3">{sub}</span>
+                  ) : undefined
+                }
+              >
+                {labelText}
+              </PickerItem>
+            );
+          })}
+        </PickerList>
+
+        {error ? (
+          <p className="border-t border-border-subtle px-3 py-2 font-mono text-micro text-rose">
+            {error}
+          </p>
+        ) : null}
+
+        {createAction && !readOnly ? (
+          <PickerFooterAction
+            icon={<Plus className="h-4 w-4" strokeWidth={1.5} aria-hidden="true" />}
+            onClick={createAction.onCreate}
+          >
+            {createAction.label}
+          </PickerFooterAction>
+        ) : null}
+      </PickerContent>
+    </Picker>
+  );
+}

--- a/src/components/ui/picker/index.ts
+++ b/src/components/ui/picker/index.ts
@@ -1,0 +1,4 @@
+export { Picker, PickerTrigger, PickerAnchor, PickerContent } from "./picker";
+export { PickerSearch } from "./picker-search";
+export { PickerList, PickerEmpty, PickerGroup } from "./picker-list";
+export { PickerItem, PickerFooterAction } from "./picker-item";

--- a/src/components/ui/picker/picker-item.tsx
+++ b/src/components/ui/picker/picker-item.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import * as React from "react";
+import { Check } from "lucide-react";
+import { Command as CommandPrimitive } from "cmdk";
+import { cn } from "@/lib/utils/cn";
+
+interface PickerItemProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>,
+    "onSelect"
+  > {
+  /** cmdk match value — typed search filters against this. Keep unique. */
+  value: string;
+  /** Currently-chosen value? Renders the trailing check (single) / checked box (multi). */
+  selected?: boolean;
+  /** Multi-select → leading checkbox instead of a trailing check. */
+  multiple?: boolean;
+  onSelect?: (value: string) => void;
+  /** Leading slot — avatar, status dot, or icon. */
+  leading?: React.ReactNode;
+  /** Second line beneath the label (e.g. a conflict advisory). */
+  subLabel?: React.ReactNode;
+  /** Right-aligned slot — unit abbreviation, count, chevron. */
+  trailing?: React.ReactNode;
+}
+
+/**
+ * PickerItem — the one canonical row. State rule (everywhere):
+ *  hover → surface-hover · keyboard cursor (cmdk data-selected) → surface-active
+ *  · chosen → surface-active + monochrome check · disabled → opacity-40.
+ * Accent never appears here — it is reserved for the focus ring.
+ */
+const PickerItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  PickerItemProps
+>(
+  (
+    {
+      value,
+      selected,
+      multiple,
+      disabled,
+      onSelect,
+      leading,
+      subLabel,
+      trailing,
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => (
+    <CommandPrimitive.Item
+      ref={ref}
+      value={value}
+      disabled={disabled}
+      onSelect={() => onSelect?.(value)}
+      aria-checked={multiple ? Boolean(selected) : undefined}
+      data-chosen={selected ? "true" : undefined}
+      className={cn(
+        "flex min-h-8 cursor-pointer select-none items-center gap-2 rounded-[5px] px-2 py-1.5",
+        "font-mohave text-body-sm text-text-2 outline-none transition-colors duration-150",
+        "hover:bg-surface-hover hover:text-text",
+        "data-[selected=true]:bg-surface-active data-[selected=true]:text-text",
+        "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-40",
+        selected && "bg-surface-active text-text",
+        className,
+      )}
+      {...props}
+    >
+      {multiple ? (
+        <span
+          aria-hidden="true"
+          className={cn(
+            "flex h-4 w-4 shrink-0 items-center justify-center rounded-chip border",
+            selected ? "border-border-strong bg-surface-active" : "border-border",
+          )}
+        >
+          {selected ? <Check className="h-3 w-3 text-text" strokeWidth={2} /> : null}
+        </span>
+      ) : null}
+      {leading}
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate">{children}</span>
+        {subLabel ? (
+          <span className="truncate font-mono text-micro normal-case text-text-3">{subLabel}</span>
+        ) : null}
+      </span>
+      {trailing}
+      {!multiple && selected ? (
+        <Check className="h-4 w-4 shrink-0 text-text" strokeWidth={1.5} aria-hidden="true" />
+      ) : null}
+    </CommandPrimitive.Item>
+  ),
+);
+PickerItem.displayName = "PickerItem";
+
+interface PickerFooterActionProps
+  extends React.ComponentPropsWithoutRef<"button"> {
+  icon?: React.ReactNode;
+  destructive?: boolean;
+}
+
+/** Divided footer action — inline create / clear / remove. */
+const PickerFooterAction = React.forwardRef<
+  HTMLButtonElement,
+  PickerFooterActionProps
+>(({ icon, destructive, className, children, ...props }, ref) => (
+  <div className="border-t border-border-subtle p-1">
+    <button
+      ref={ref}
+      type="button"
+      className={cn(
+        "flex min-h-8 w-full cursor-pointer items-center gap-2 rounded-[5px] px-2 py-1.5",
+        "font-mohave text-body-sm outline-none transition-colors duration-150",
+        "hover:bg-surface-hover focus-visible:bg-surface-hover",
+        destructive ? "text-rose" : "text-text-2 hover:text-text",
+        className,
+      )}
+      {...props}
+    >
+      {icon ? <span className="shrink-0 text-text-3">{icon}</span> : null}
+      {children}
+    </button>
+  </div>
+));
+PickerFooterAction.displayName = "PickerFooterAction";
+
+export { PickerItem, PickerFooterAction };

--- a/src/components/ui/picker/picker-list.tsx
+++ b/src/components/ui/picker/picker-list.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { cn } from "@/lib/utils/cn";
+
+/** Scrollable list wrapper. Scroll is contained; default cap 280px. */
+const PickerList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn(
+      "scrollbar-hide max-h-[280px] overflow-y-auto overflow-x-hidden p-1",
+      className,
+    )}
+    {...props}
+  />
+));
+PickerList.displayName = "PickerList";
+
+/** Canonical empty / no-results state. */
+const PickerEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className={cn(
+      "px-2 py-3 text-center font-mono text-micro uppercase tracking-wider text-text-3",
+      className,
+    )}
+    {...props}
+  />
+));
+PickerEmpty.displayName = "PickerEmpty";
+
+/** Optional grouping (cmdk Group). `heading` renders the `// section` label. */
+const PickerGroup = CommandPrimitive.Group;
+
+export { PickerList, PickerEmpty, PickerGroup };

--- a/src/components/ui/picker/picker-search.tsx
+++ b/src/components/ui/picker/picker-search.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search, X } from "lucide-react";
+import { cn } from "@/lib/utils/cn";
+
+interface PickerSearchProps
+  extends Omit<
+    React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>,
+    "value" | "onChange"
+  > {
+  value: string;
+  onValueChange: (value: string) => void;
+  /** aria-label for the clear button (pass an i18n string). */
+  clearLabel?: string;
+}
+
+/**
+ * PickerSearch — canonical search row: icon + cmdk input + clear.
+ * Controlled (owns nothing; parent holds the query). Focus = accent ring.
+ */
+const PickerSearch = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  PickerSearchProps
+>(
+  (
+    { className, value, onValueChange, clearLabel = "Clear search", placeholder, ...props },
+    ref,
+  ) => (
+    <div className="m-1 flex h-8 items-center gap-2 rounded-[5px] border border-border bg-surface-input px-2 focus-within:ring-[1.5px] focus-within:ring-ops-accent focus-within:ring-offset-2 focus-within:ring-offset-black">
+      <Search className="h-4 w-4 shrink-0 text-text-3" strokeWidth={1.5} aria-hidden="true" />
+      <CommandPrimitive.Input
+        ref={ref}
+        value={value}
+        onValueChange={onValueChange}
+        placeholder={placeholder}
+        className={cn(
+          "min-w-0 flex-1 bg-transparent font-mohave text-body-sm text-text outline-none placeholder:text-text-3",
+          className,
+        )}
+        {...props}
+      />
+      {value ? (
+        <button
+          type="button"
+          onClick={() => onValueChange("")}
+          aria-label={clearLabel}
+          className="shrink-0 text-text-3 transition-colors hover:text-text"
+        >
+          <X className="h-3.5 w-3.5" strokeWidth={1.5} aria-hidden="true" />
+        </button>
+      ) : null}
+    </div>
+  ),
+);
+PickerSearch.displayName = "PickerSearch";
+
+export { PickerSearch };

--- a/src/components/ui/picker/picker.tsx
+++ b/src/components/ui/picker/picker.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils/cn";
+
+/**
+ * Picker — the canonical OPS popover-select shell.
+ *
+ * Composition: Radix Popover (reuses the shipped `.glass-dense` PopoverContent
+ * + `anchored-in` entrance, which is already reduced-motion aware) wrapping a
+ * cmdk Command for search + keyboard navigation. Every concrete picker
+ * (EntityPicker, EnumPicker, DatetimePicker) is built from this shell plus the
+ * sibling primitives — never hand-rolled divs or portals.
+ *
+ * Values trace to tokens only (see `.interface-design/system.md`). Rows are
+ * compact ~32px — OPS Web is cursor-driven; there is no touch-size minimum.
+ */
+
+const Picker = Popover;
+const PickerTrigger = PopoverTrigger;
+const PickerAnchor = PopoverAnchor;
+
+const SIZE_WIDTH: Record<"sm" | "md" | "lg", string> = {
+  sm: "w-56", // 224px
+  md: "w-64", // 256px
+  lg: "w-72", // 288px
+};
+
+/** cmdk group headings → `// section` micro-label. */
+const GROUP_HEADING = cn(
+  "[&_[cmdk-group-heading]]:px-2",
+  "[&_[cmdk-group-heading]]:pb-1",
+  "[&_[cmdk-group-heading]]:pt-2",
+  "[&_[cmdk-group-heading]]:font-mono",
+  "[&_[cmdk-group-heading]]:text-micro",
+  "[&_[cmdk-group-heading]]:uppercase",
+  "[&_[cmdk-group-heading]]:tracking-wider",
+  "[&_[cmdk-group-heading]]:text-text-3",
+);
+
+interface PickerContentProps
+  extends React.ComponentPropsWithoutRef<typeof PopoverContent> {
+  /** Preset width. `auto` sizes to content. Default `md`. */
+  size?: "sm" | "md" | "lg" | "auto";
+  /** Explicit pixel width (overrides `size`). */
+  width?: number;
+  /** Accessible name for the popover. */
+  label?: string;
+  /** Let cmdk filter items by typed search. Default `true`. */
+  shouldFilter?: boolean;
+  /** Wrap keyboard cursor at the ends. Default `true`. */
+  loop?: boolean;
+}
+
+const PickerContent = React.forwardRef<
+  React.ElementRef<typeof PopoverContent>,
+  PickerContentProps
+>(
+  (
+    {
+      size = "md",
+      width,
+      label,
+      shouldFilter = true,
+      loop = true,
+      align = "start",
+      sideOffset = 6,
+      className,
+      style,
+      children,
+      ...props
+    },
+    ref,
+  ) => (
+    <PopoverContent
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      role="dialog"
+      aria-label={label}
+      className={cn(
+        "overflow-hidden p-0",
+        size !== "auto" && SIZE_WIDTH[size],
+        className,
+      )}
+      style={width ? { ...style, width } : style}
+      {...props}
+    >
+      <CommandPrimitive
+        label={label}
+        shouldFilter={shouldFilter}
+        loop={loop}
+        className={cn("flex w-full flex-col", GROUP_HEADING)}
+      >
+        {children}
+      </CommandPrimitive>
+    </PopoverContent>
+  ),
+);
+PickerContent.displayName = "PickerContent";
+
+export { Picker, PickerTrigger, PickerAnchor, PickerContent };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -18,7 +18,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 outline-none",
+        "z-dropdown outline-none",
         "glass-dense",
         "motion-safe:animate-anchored-in",
         "data-[state=closed]:animate-fade-out",

--- a/src/i18n/dictionaries/en/picker.json
+++ b/src/i18n/dictionaries/en/picker.json
@@ -1,0 +1,16 @@
+{
+  "search": "Search",
+  "noResults": "No matches",
+  "clear": "Clear search",
+  "loading": "Loading",
+  "viewOnly": "View only",
+  "conflict": "Double-booked · {project} · {when}",
+
+  "category.search": "Search categories",
+  "category.create": "New category",
+  "category.empty": "No categories",
+
+  "unit.search": "Search units",
+  "unit.create": "New unit",
+  "unit.empty": "No units"
+}

--- a/src/i18n/dictionaries/es/picker.json
+++ b/src/i18n/dictionaries/es/picker.json
@@ -1,0 +1,16 @@
+{
+  "search": "Buscar",
+  "noResults": "Sin coincidencias",
+  "clear": "Borrar búsqueda",
+  "loading": "Cargando",
+  "viewOnly": "Solo lectura",
+  "conflict": "Doble reserva · {project} · {when}",
+
+  "category.search": "Buscar categorías",
+  "category.create": "Nueva categoría",
+  "category.empty": "Sin categorías",
+
+  "unit.search": "Buscar unidades",
+  "unit.create": "Nueva unidad",
+  "unit.empty": "Sin unidades"
+}

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -37,7 +37,8 @@ export type Namespace =
   | 'quick-actions'
   | 'server-emails'
   | 'unsubscribe'
-  | 'project-workspace';
+  | 'project-workspace'
+  | 'picker';
 
 
 export type Dictionary = Record<string, string | string[] | Record<string, unknown>>;

--- a/tests/integration/projects-table-v2-phase4.test.tsx
+++ b/tests/integration/projects-table-v2-phase4.test.tsx
@@ -19,6 +19,7 @@ const {
   createFirstTaskMock,
   useProjectTableTeamMock,
   teamState,
+  teamConflictsState,
   authState,
   fetchProjectPhotosMock,
   uploadProjectPhotoMock,
@@ -41,6 +42,16 @@ const {
     assignedMembers: [] as Array<Record<string, unknown>>,
     availableMembers: [] as Array<Record<string, unknown>>,
     tasks: [] as Array<Record<string, unknown>>,
+  },
+  teamConflictsState: {
+    data: [] as Array<{
+      date: Date;
+      memberName: string;
+      memberId: string;
+      projectTitle: string;
+      projectId: string;
+      taskColor: string;
+    }>,
   },
   authState: {
     company: { id: "co-1" },
@@ -113,6 +124,7 @@ const dictionary: Record<string, string> = {
   "table.cell.team.readOnly": "// READ-ONLY - no team permission",
   "table.cell.team.error": "// TEAM UPDATE FAILED",
   "table.cell.team.emptyAvailable": "No active crew available.",
+  conflict: "Double-booked · {project} · {when}",
   "table.cell.photos.title": "// PHOTOS - {project}",
   "table.cell.photos.triggerLabel": "Photos - {project} - {count}",
   "table.cell.photos.drop": "Drop photos here",
@@ -392,6 +404,10 @@ vi.mock("@/i18n/client", () => ({
   }),
 }));
 
+vi.mock("@/lib/hooks/use-team-conflicts", () => ({
+  useTeamScheduleConflicts: () => ({ data: teamConflictsState.data }),
+}));
+
 vi.mock("@/lib/store/auth-store", () => ({
   useAuthStore: (selector?: (state: typeof authState) => unknown) =>
     selector ? selector(authState) : authState,
@@ -529,6 +545,7 @@ describe("Projects table v2 Phase 4 team cell", () => {
   beforeEach(() => {
     rows = createRows();
     resetTeamState();
+    teamConflictsState.data = [];
     openProjectWindow.mockReset();
     assignTeamMemberMock.mockReset();
     removeTeamMemberMock.mockReset();
@@ -683,6 +700,25 @@ describe("Projects table v2 Phase 4 team cell", () => {
     await waitFor(() =>
       expect(screen.queryByRole("dialog", { name: "// TEAM - Deck rebuild" })).not.toBeInTheDocument(),
     );
+  });
+
+  it("shows an inline conflict advisory for a double-booked member", async () => {
+    const user = userEvent.setup();
+    teamConflictsState.data = [
+      {
+        date: new Date("2026-06-09T00:00:00Z"),
+        memberName: "Owen Vale",
+        memberId: "u-2",
+        projectTitle: "Cedar & Main",
+        projectId: "p-9",
+        taskColor: "#000000",
+      },
+    ];
+
+    renderProjectsTable();
+
+    await user.click(screen.getByRole("button", { name: "Team - Deck rebuild - 1 assigned" }));
+    expect(await screen.findByText(/double-booked · cedar & main/i)).toBeInTheDocument();
   });
 });
 

--- a/tests/integration/projects-table-v2-phase4.test.tsx
+++ b/tests/integration/projects-table-v2-phase4.test.tsx
@@ -601,7 +601,7 @@ describe("Projects table v2 Phase 4 team cell", () => {
     }));
   });
 
-  it("renders the All Active team cell as an avatar/count control", () => {
+  it("renders the All Active team cell as an avatar/count control", async () => {
     renderProjectsTable();
 
     expect(screen.getByRole("button", { name: "All Active" })).toBeInTheDocument();
@@ -609,27 +609,16 @@ describe("Projects table v2 Phase 4 team cell", () => {
       name: "Team - Deck rebuild - 1 assigned",
     });
     expect(trigger).toHaveAttribute("aria-haspopup", "dialog");
-    expect(within(trigger).getByText("MS")).toBeInTheDocument();
+    expect(await within(trigger).findByText("MS")).toBeInTheDocument();
     expect(within(trigger).getByText("1")).toBeInTheDocument();
   });
 
-  it("opens a task cascade for an available member and assigns checked active tasks only", async () => {
+  it("assigns a member to every active task when toggled on", async () => {
     const user = userEvent.setup();
     renderProjectsTable();
 
     await user.click(screen.getByRole("button", { name: "Team - Deck rebuild - 1 assigned" }));
-    await user.click(screen.getByRole("button", { name: "Owen Vale" }));
-
-    const dialog = screen.getByRole("dialog", { name: "// TEAM - Deck rebuild" });
-    expect(within(dialog).getByText("Assign to tasks")).toBeInTheDocument();
-    expect(within(dialog).getByRole("checkbox", { name: "Frame inspection" })).toBeInTheDocument();
-    expect(within(dialog).getByRole("checkbox", { name: "Final walkthrough" })).toBeInTheDocument();
-    expect(within(dialog).queryByText("Closeout packet")).not.toBeInTheDocument();
-    expect(within(dialog).queryByText("Cancelled task")).not.toBeInTheDocument();
-
-    await user.click(within(dialog).getByRole("checkbox", { name: "Frame inspection" }));
-    await user.click(within(dialog).getByRole("checkbox", { name: "Final walkthrough" }));
-    await user.click(within(dialog).getByRole("button", { name: "Assign" }));
+    await user.click(await screen.findByText("Owen Vale"));
 
     expect(assignTeamMemberMock).toHaveBeenCalledWith({
       userId: "u-2",
@@ -637,14 +626,12 @@ describe("Projects table v2 Phase 4 team cell", () => {
     });
   });
 
-  it("removes an assigned member from all tasks", async () => {
+  it("removes a member from all tasks when toggled off", async () => {
     const user = userEvent.setup();
     renderProjectsTable();
 
     await user.click(screen.getByRole("button", { name: "Team - Deck rebuild - 1 assigned" }));
-    const dialog = screen.getByRole("dialog", { name: "// TEAM - Deck rebuild" });
-
-    await user.click(within(dialog).getByRole("button", { name: "Remove Mara Silva from all" }));
+    await user.click(await screen.findByText("Mara Silva"));
 
     expect(removeTeamMemberMock).toHaveBeenCalledWith({
       userId: "u-1",
@@ -652,7 +639,7 @@ describe("Projects table v2 Phase 4 team cell", () => {
     });
   });
 
-  it("creates the first task before assigning a member when no assignment targets exist", async () => {
+  it("blocks assignment with a notice when the project has no active task", async () => {
     const user = userEvent.setup();
     teamState.tasks = [];
     rows = rows.map((row) => ({ ...row, taskCount: 0, taskCompletedCount: 0 }));
@@ -660,24 +647,13 @@ describe("Projects table v2 Phase 4 team cell", () => {
     renderProjectsTable();
 
     await user.click(screen.getByRole("button", { name: "Team - Deck rebuild - 1 assigned" }));
-    await user.click(screen.getByRole("button", { name: "Owen Vale" }));
+    expect(await screen.findByText("No tasks to assign")).toBeInTheDocument();
 
-    const dialog = screen.getByRole("dialog", { name: "// TEAM - Deck rebuild" });
-    expect(within(dialog).getByText("No tasks to assign")).toBeInTheDocument();
-
-    await user.type(within(dialog).getByPlaceholderText("Task name"), "Site kickoff");
-    await user.click(within(dialog).getByRole("button", { name: "Create first task" }));
-
-    await waitFor(() =>
-      expect(createFirstTaskMock).toHaveBeenCalledWith({ title: "Site kickoff" }),
-    );
-    expect(assignTeamMemberMock).toHaveBeenCalledWith({
-      userId: "u-2",
-      taskIds: ["task-new"],
-    });
+    await user.click(screen.getByText("Owen Vale"));
+    expect(assignTeamMemberMock).not.toHaveBeenCalled();
   });
 
-  it("renders a dictionary-backed read-only message when team assignment is denied", async () => {
+  it("surfaces a dictionary-backed read-only message when assignment is denied", async () => {
     const user = userEvent.setup();
     assignTeamMemberMock.mockRejectedValue(
       new ProjectTableMutationError("permission denied", "42501"),
@@ -686,12 +662,9 @@ describe("Projects table v2 Phase 4 team cell", () => {
     renderProjectsTable();
 
     await user.click(screen.getByRole("button", { name: "Team - Deck rebuild - 1 assigned" }));
-    await user.click(screen.getByRole("button", { name: "Owen Vale" }));
-    const dialog = screen.getByRole("dialog", { name: "// TEAM - Deck rebuild" });
-    await user.click(within(dialog).getByRole("checkbox", { name: "Frame inspection" }));
-    await user.click(within(dialog).getByRole("button", { name: "Assign" }));
+    await user.click(await screen.findByText("Owen Vale"));
 
-    expect(await within(dialog).findByText("// READ-ONLY - no team permission")).toBeInTheDocument();
+    expect(await screen.findByText("// READ-ONLY - no team permission")).toBeInTheDocument();
   });
 
   it("keeps table focus navigation isolated while the team popover is active", async () => {
@@ -699,9 +672,9 @@ describe("Projects table v2 Phase 4 team cell", () => {
     renderProjectsTable();
 
     await user.click(screen.getByRole("button", { name: "Team - Deck rebuild - 1 assigned" }));
-    const search = screen.getByPlaceholderText("Search team members...");
+    const search = await screen.findByPlaceholderText("Search team members...");
     await user.click(search);
-    await user.keyboard("{ArrowDown}{Enter} ");
+    await user.keyboard("{ArrowDown} ");
 
     expect(search).toHaveFocus();
     expect(screen.getByRole("dialog", { name: "// TEAM - Deck rebuild" })).toBeInTheDocument();

--- a/tests/unit/components/ui/entity-picker.test.tsx
+++ b/tests/unit/components/ui/entity-picker.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from "vitest";
+import * as React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EntityPicker } from "@/components/ui/entity-picker";
+
+type Member = { id: string; name: string };
+const MEMBERS: Member[] = [
+  { id: "u1", name: "Dana Reyes" },
+  { id: "u2", name: "Tariq Osei" },
+  { id: "u3", name: "Marcus Webb" },
+];
+
+function SingleEP({
+  onChange,
+  noneOption,
+  readOnly,
+  onCreate,
+}: {
+  onChange?: (id: string | null) => void;
+  noneOption?: boolean;
+  readOnly?: boolean;
+  onCreate?: () => void;
+}) {
+  const [value, setValue] = React.useState<string | null>(null);
+  return (
+    <EntityPicker<Member>
+      trigger={<button type="button">Open</button>}
+      items={MEMBERS}
+      value={value}
+      onChange={(id) => {
+        setValue(id);
+        onChange?.(id);
+      }}
+      getId={(m) => m.id}
+      getLabel={(m) => m.name}
+      getAvatar={(m) => ({ name: m.name })}
+      label="People"
+      noneOption={noneOption}
+      noneLabel="Unassigned"
+      readOnly={readOnly}
+      readOnlyLabel="View only"
+      createAction={onCreate ? { label: "New person", onCreate } : undefined}
+    />
+  );
+}
+
+function MultiEP({ onChange }: { onChange?: (ids: string[]) => void }) {
+  const [ids, setIds] = React.useState<string[]>([]);
+  return (
+    <EntityPicker<Member>
+      multiple
+      trigger={<button type="button">Open</button>}
+      items={MEMBERS}
+      value={ids}
+      onChange={(next) => {
+        setIds(next);
+        onChange?.(next);
+      }}
+      getId={(m) => m.id}
+      getLabel={(m) => m.name}
+      getAvatar={(m) => ({ name: m.name })}
+      conflictFor={(id) => (id === "u2" ? "Double-booked · Cedar & Main · Mon" : null)}
+      label="Crew"
+    />
+  );
+}
+
+describe("<EntityPicker>", () => {
+  it("single: commits the id and closes", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<SingleEP onChange={onChange} />);
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    await user.click(await screen.findByText("Tariq Osei"));
+    expect(onChange).toHaveBeenCalledWith("u2");
+    await waitFor(() =>
+      expect(screen.queryByRole("option", { name: /tariq/i })).not.toBeInTheDocument(),
+    );
+  });
+
+  it("single: renders avatar initials in the rows", async () => {
+    const user = userEvent.setup();
+    render(<SingleEP />);
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    expect(await screen.findByText("DR")).toBeInTheDocument();
+    expect(screen.getByText("TO")).toBeInTheDocument();
+  });
+
+  it("single: none-option commits null", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<SingleEP onChange={onChange} noneOption />);
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    await user.click(await screen.findByText("Unassigned"));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("single: read-only blocks selection and shows the notice", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<SingleEP onChange={onChange} readOnly />);
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    expect(await screen.findByText("View only")).toBeInTheDocument();
+    await user.click(screen.getByText("Tariq Osei"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("single: create action fires", async () => {
+    const onCreate = vi.fn();
+    const user = userEvent.setup();
+    render(<SingleEP onCreate={onCreate} />);
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    await user.click(await screen.findByText("New person"));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("multi: toggles ids, stays open, surfaces conflicts", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<MultiEP onChange={onChange} />);
+    await user.click(screen.getByRole("button", { name: /open/i }));
+    await user.click(await screen.findByText("Dana Reyes"));
+    expect(onChange).toHaveBeenLastCalledWith(["u1"]);
+    // still open → Tariq still visible
+    await user.click(screen.getByText("Tariq Osei"));
+    expect(onChange).toHaveBeenLastCalledWith(["u1", "u2"]);
+    // conflict advisory shows on Tariq's row
+    expect(screen.getByText(/double-booked · cedar & main · mon/i)).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /dana/i })).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/tests/unit/components/ui/picker/picker.test.tsx
+++ b/tests/unit/components/ui/picker/picker.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from "vitest";
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  Picker,
+  PickerTrigger,
+  PickerContent,
+  PickerSearch,
+  PickerList,
+  PickerEmpty,
+  PickerItem,
+  PickerFooterAction,
+} from "@/components/ui/picker";
+
+const ITEMS = [
+  { id: "cat-1", label: "Hardware" },
+  { id: "cat-2", label: "Labor" },
+  { id: "cat-3", label: "Materials" },
+];
+
+function SingleHarness({
+  onPick,
+  onCreate,
+}: {
+  onPick?: (id: string) => void;
+  onCreate?: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState("");
+  const [value, setValue] = React.useState<string | null>(null);
+  return (
+    <Picker open={open} onOpenChange={setOpen}>
+      <PickerTrigger asChild>
+        <button type="button">Open picker</button>
+      </PickerTrigger>
+      <PickerContent label="Categories">
+        <PickerSearch
+          value={search}
+          onValueChange={setSearch}
+          placeholder="Search"
+          clearLabel="Clear search"
+        />
+        <PickerList>
+          <PickerEmpty>No matches</PickerEmpty>
+          {ITEMS.map((it) => (
+            <PickerItem
+              key={it.id}
+              value={it.label}
+              selected={value === it.id}
+              onSelect={() => {
+                setValue(it.id);
+                onPick?.(it.id);
+              }}
+            >
+              {it.label}
+            </PickerItem>
+          ))}
+          <PickerItem value="Concrete" disabled onSelect={() => onPick?.("disabled")}>
+            Concrete
+          </PickerItem>
+        </PickerList>
+        <PickerFooterAction onClick={() => onCreate?.()}>New category</PickerFooterAction>
+      </PickerContent>
+    </Picker>
+  );
+}
+
+function MultiHarness() {
+  const [open, setOpen] = React.useState(false);
+  const [ids, setIds] = React.useState<string[]>([]);
+  const toggle = (id: string) =>
+    setIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+  return (
+    <Picker open={open} onOpenChange={setOpen}>
+      <PickerTrigger asChild>
+        <button type="button">Open picker</button>
+      </PickerTrigger>
+      <PickerContent label="Crew">
+        <PickerList>
+          {ITEMS.map((it) => (
+            <PickerItem
+              key={it.id}
+              value={it.label}
+              multiple
+              selected={ids.includes(it.id)}
+              onSelect={() => toggle(it.id)}
+            >
+              {it.label}
+            </PickerItem>
+          ))}
+        </PickerList>
+      </PickerContent>
+    </Picker>
+  );
+}
+
+describe("Picker primitives", () => {
+  it("opens on trigger click and lists every item", async () => {
+    const user = userEvent.setup();
+    render(<SingleHarness />);
+    await user.click(screen.getByRole("button", { name: /open picker/i }));
+    expect(await screen.findByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("Labor")).toBeInTheDocument();
+    expect(screen.getByText("Materials")).toBeInTheDocument();
+  });
+
+  it("filters items as you type", async () => {
+    const user = userEvent.setup();
+    render(<SingleHarness />);
+    await user.click(screen.getByRole("button", { name: /open picker/i }));
+    await user.type(screen.getByPlaceholderText("Search"), "lab");
+    expect(await screen.findByText("Labor")).toBeInTheDocument();
+    expect(screen.queryByText("Hardware")).not.toBeInTheDocument();
+    expect(screen.queryByText("Materials")).not.toBeInTheDocument();
+  });
+
+  it("commits on click and marks the chosen row", async () => {
+    const onPick = vi.fn();
+    const user = userEvent.setup();
+    render(<SingleHarness onPick={onPick} />);
+    await user.click(screen.getByRole("button", { name: /open picker/i }));
+    await user.click(await screen.findByText("Labor"));
+    expect(onPick).toHaveBeenCalledWith("cat-2");
+    expect(screen.getByRole("option", { name: /labor/i })).toHaveAttribute("data-chosen", "true");
+  });
+
+  it("commits the keyboard-cursored item on Enter", async () => {
+    const onPick = vi.fn();
+    const user = userEvent.setup();
+    render(<SingleHarness onPick={onPick} />);
+    await user.click(screen.getByRole("button", { name: /open picker/i }));
+    await screen.findByText("Hardware");
+    await user.keyboard("{Enter}");
+    expect(onPick).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the empty state when nothing matches", async () => {
+    const user = userEvent.setup();
+    render(<SingleHarness />);
+    await user.click(screen.getByRole("button", { name: /open picker/i }));
+    await user.type(screen.getByPlaceholderText("Search"), "zzzzz");
+    expect(await screen.findByText("No matches")).toBeInTheDocument();
+  });
+
+  it("clears the search via the clear button", async () => {
+    const user = userEvent.setup();
+    render(<SingleHarness />);
+    await user.click(screen.getByRole("button", { name: /open picker/i }));
+    const input = screen.getByPlaceholderText("Search");
+    await user.type(input, "lab");
+    expect(screen.queryByText("Hardware")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /clear search/i }));
+    expect(input).toHaveValue("");
+    expect(await screen.findByText("Hardware")).toBeInTheDocument();
+  });
+
+  it("does not commit a disabled item", async () => {
+    const onPick = vi.fn();
+    const user = userEvent.setup();
+    render(<SingleHarness onPick={onPick} />);
+    await user.click(screen.getByRole("button", { name: /open picker/i }));
+    await user.click(await screen.findByText("Concrete"));
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
+  it("fires the footer action", async () => {
+    const onCreate = vi.fn();
+    const user = userEvent.setup();
+    render(<SingleHarness onCreate={onCreate} />);
+    await user.click(screen.getByRole("button", { name: /open picker/i }));
+    await user.click(await screen.findByText(/new category/i));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles multiple rows with aria-checked", async () => {
+    const user = userEvent.setup();
+    render(<MultiHarness />);
+    await user.click(screen.getByRole("button", { name: /open picker/i }));
+    const hardware = await screen.findByRole("option", { name: /hardware/i });
+    expect(hardware).toHaveAttribute("aria-checked", "false");
+    await user.click(hardware);
+    expect(screen.getByRole("option", { name: /hardware/i })).toHaveAttribute("aria-checked", "true");
+    const labor = screen.getByRole("option", { name: /labor/i });
+    await user.click(labor);
+    expect(screen.getByRole("option", { name: /labor/i })).toHaveAttribute("aria-checked", "true");
+    // Hardware stays checked — multi-select does not clear siblings.
+    expect(screen.getByRole("option", { name: /hardware/i })).toHaveAttribute("aria-checked", "true");
+  });
+});


### PR DESCRIPTION
## BRANCH CONSOLIDATION — EntityPicker system

Consolidates the standalone `feat/picker-system` branch into `main`. Part of the pipeline/lead consolidation cluster.

### What this lands
Standardized **EntityPicker** system replacing hand-rolled popover/cascade selection surfaces:
- Picker primitive family (`Picker` / `PickerSearch` / `PickerList` / `PickerItem` / `PickerFooterAction`) on Radix Popover + cmdk, glass-dense, `z-dropdown` layer.
- `EntityPicker` generic single/multi-select wrapper (avatars, sub-labels, create action, read-only mode, conflict advisories).
- Projects table **team cell** rebuilt as multi-select with inline schedule-conflict advisory; **client cell** rebuilt as single-select.
- New `picker` i18n namespace (en + es).

### Conflict resolution
- `src/i18n/types.ts` — `Namespace` union: kept **both** main's `'catalog-setup'` and the branch's `'picker'`.

### Verification (against the change's own signals)
- `tsc --noEmit`: **0 new errors** (baseline: 2 pre-existing errors in `notification-service.test.ts`, identical to main).
- `next lint`: clean — no new errors/warnings in picker-touched files.
- Tests: **35/35** — `entity-picker`, `picker`, `projects-table-v2-phase4`.
- Re-confirmed clean merge onto current `main` (`0bdce012`).

### Merge coordination
Parallel BRANCH CONSOLIDATION work is in flight. **Merge only when no other open PR titled `BRANCH CONSOLIDATION` is ahead of it**; rebase onto latest `main` + re-run type-check/lint/tests immediately before merging. Independent of the lead-detail PR (no shared files).

> Note: `main` CI is currently red on pre-existing lint errors unrelated to this change; gate on this PR's own signals above.
