### PR TITLE
feat(admin): App Store Connect analytics — Growth › App Store (Phase 1 of unified attribution)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-app-store-connect-analytics.md
+++ b/docs/superpowers/plans/2026-06-22-app-store-connect-analytics.md
@@ -1,0 +1,626 @@
+# App Store Connect Analytics — Implementation Plan (Phase 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. All UI tasks additionally invoke the design-skill stack (frontend-design + interface-design + ops-design token reads) and ops-copywriter for copy.
+
+**Goal:** Pull Apple's App Store Connect Analytics (impressions → product-page views → downloads + conversion rate) into Supabase on a daily cron and surface it as a `Growth > App Store` admin screen, built attribution-ready.
+
+**Architecture:** A server-only ASC client (ES256 JWT via `jose`) drives Apple's 6-step async report API → a sync module parses the gzipped TSV by header-name and idempotently upserts into new `asc_*` Supabase tables → cached admin query fns feed five read API routes → an RSC page + `'use client'` content component render KPI tiles, a conversion-rate hero chart, a traffic funnel, a source-channel donut, and a territory table. Everything mirrors the existing Google Ads admin connector.
+
+**Tech Stack:** Next.js App Router (RSC + route handlers), `jose` ^6.1.3 (ES256), Supabase service-role client, `unstable_cache`, TanStack Query, Recharts wrappers, Vitest, Vercel Cron.
+
+**Worktree:** `/Users/jacksonsweet/Projects/OPS/ops-web-app-store-analytics` (branch `feat/app-store-analytics`, off `main`). Dev server: `npm run dev:webpack` (turbopack panics on the node_modules symlink). Preview gate: `.env.local` has `DEV_BYPASS_AUTH` for admin access.
+
+**Reference connector (copy these patterns):** Google Ads — `src/lib/analytics/google-ads-client.ts`, `src/app/api/cron/ads-sync/route.ts`, `src/lib/admin/ads-history-queries.ts` (`updateSyncStatus`), `src/lib/admin/api-auth.ts` (`withAdmin`/`requireAdmin`/`isAdminEmail`), `src/lib/supabase/admin-client.ts` (`getAdminSupabase`), `src/app/admin/app-analytics/` (page + content), `src/lib/admin/date-utils.ts` (`bucketize`), `src/app/admin/_components/` (charts, StatCard, Sparkline, SortableTableHeader, DateRangeControl, AdminPageHeader), `src/lib/firebase/parse-private-key.ts` (`parsePrivateKey`).
+
+---
+
+## File Structure
+
+**Create:**
+- `supabase/migrations/<ts>_app_store_connect_analytics_phase1.sql` — all `asc_*` tables, conversion view, RLS (or apply via Supabase MCP; see Task 1).
+- `src/lib/analytics/app-store-client.ts` — JWT mint + ASC HTTP client + `isAppStoreConfigured()`.
+- `src/lib/analytics/app-store-parse.ts` — header-name TSV parser + `mapAppStoreSourceToChannel()`.
+- `src/lib/admin/app-store-sync.ts` — bootstrap + 6-step pull + idempotent upsert + status writes.
+- `src/lib/admin/app-store-queries.ts` — `updateAscSyncStatus`/`getAscSyncStatus` + 5 cached read fns + shared types.
+- `src/app/api/cron/app-store-sync/route.ts` — daily cron.
+- `src/app/api/admin/app-store/{kpis,conversion-series,traffic-series,source-breakdown,territories}/route.ts` — 5 read routes.
+- `src/app/admin/app-store/page.tsx` — RSC.
+- `src/app/admin/app-store/_components/app-store-content.tsx` — `'use client'`.
+- `tests/unit/app-store-parse.test.ts`, `tests/unit/app-store-client.test.ts`, `tests/unit/app-store-sync.test.ts`, `tests/unit/app-store-queries.test.ts` — Vitest.
+
+**Modify:**
+- `src/app/admin/_components/sidebar.tsx` — insert `APP STORE` after `GOOGLE ADS` (after line 14).
+- `vercel.json` — append the `app-store-sync` cron (after the `ads-sync` entry).
+- `src/app/admin/_components/charts/line-chart.tsx` (lines 52, 57) and `bar-chart.tsx` — replace `fontFamily: "Kosugi"` with `"JetBrains Mono"`.
+
+---
+
+## Task 1: Database migration (asc_* tables, conversion view, RLS)
+
+**Files:**
+- Create: `supabase/migrations/<ts>_app_store_connect_analytics_phase1.sql`
+- Apply: via Supabase MCP `apply_migration` (name `app_store_connect_analytics_phase1`) after read-only recon.
+
+- [ ] **Step 1: Read-only recon.** Confirm none of the `asc_*` names exist and note the Postgres version supports `UNIQUE NULLS NOT DISTINCT` (PG15+; prod is 17.6).
+
+Run (Supabase MCP `execute_sql`):
+```sql
+select table_name from information_schema.tables
+where table_schema='public' and table_name like 'asc[_]%';
+select version();
+```
+Expected: zero `asc_*` rows; PG 17.x.
+
+- [ ] **Step 2: Write the migration SQL** (verbatim from the spec §A4, with the three critic fixes already applied: provisional computed at read time — NOT a stored generated column; `UNIQUE NULLS NOT DISTINCT` on both fact tables; `asc_sync_status` defined; view `security_invoker = true`). Copy the full DDL block from `docs/superpowers/specs/2026-06-22-app-store-connect-analytics-design.md` §A4 into the migration file.
+
+- [ ] **Step 3: Apply the migration** via Supabase MCP `apply_migration` with the SQL from Step 2.
+Expected: success, migration recorded.
+
+- [ ] **Step 4: Verify** (Supabase MCP `execute_sql`):
+```sql
+select table_name from information_schema.tables
+where table_schema='public' and table_name like 'asc[_]%' order by 1;
+-- expect: asc_downloads, asc_discovery_engagement, asc_raw_rows,
+--         asc_report_instances, asc_report_requests, asc_reports,
+--         asc_report_segments, asc_sync_status
+select indexname from pg_indexes where schemaname='public' and tablename in
+  ('asc_discovery_engagement','asc_downloads');
+select pg_get_viewdef('public.asc_conversion_daily', true);
+select relrowsecurity from pg_class where relname='asc_downloads'; -- expect: t
+```
+
+- [ ] **Step 5: Sentinel idempotency check** (proves the NULLS NOT DISTINCT fix). Insert the same row twice with a NULL dimension; assert one row.
+```sql
+insert into public.asc_downloads (reporting_date, source_type, channel, counts, unique_counts)
+values ('2026-06-01', null, 'app_store_search', 10, 8)
+on conflict do nothing;
+insert into public.asc_downloads (reporting_date, source_type, channel, counts, unique_counts)
+values ('2026-06-01', null, 'app_store_search', 10, 8)
+on conflict do nothing;
+select count(*) from public.asc_downloads where reporting_date='2026-06-01'; -- expect: 1
+delete from public.asc_downloads where reporting_date='2026-06-01'; -- cleanup
+```
+Expected: `count = 1`. If `2`, the unique constraint lacks `NULLS NOT DISTINCT` — fix before proceeding.
+
+- [ ] **Step 6: Commit**
+```bash
+git add supabase/migrations/*app_store_connect_analytics_phase1.sql
+git commit -m "feat(admin): app store connect analytics schema (asc_* tables, conversion view, RLS)"
+```
+
+---
+
+## Task 2: ASC client — config guard + ES256 JWT mint
+
+**Files:**
+- Create: `src/lib/analytics/app-store-client.ts`
+- Test: `tests/unit/app-store-client.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+```typescript
+import { describe, it, expect, beforeEach } from "vitest";
+import { importPKCS8, jwtVerify, decodeProtectedHeader } from "jose";
+import { isAppStoreConfigured, mintToken } from "@/lib/analytics/app-store-client";
+
+// A throwaway ES256 (P-256) PKCS8 key generated for tests only.
+const TEST_P8 = `-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg... (replace with a real test key) ...\n-----END PRIVATE KEY-----`;
+
+describe("isAppStoreConfigured", () => {
+  beforeEach(() => {
+    delete process.env.ASC_KEY_ID; delete process.env.ASC_ISSUER_ID;
+    delete process.env.ASC_PRIVATE_KEY; delete process.env.ASC_APP_ID;
+  });
+  it("false when any var missing", () => { expect(isAppStoreConfigured()).toBe(false); });
+  it("true when all set", () => {
+    process.env.ASC_KEY_ID = "K"; process.env.ASC_ISSUER_ID = "I";
+    process.env.ASC_PRIVATE_KEY = "P"; process.env.ASC_APP_ID = "123";
+    expect(isAppStoreConfigured()).toBe(true);
+  });
+});
+
+describe("mintToken", () => {
+  beforeEach(() => {
+    process.env.ASC_KEY_ID = "ABC123KEYID";
+    process.env.ASC_ISSUER_ID = "11111111-2222-3333-4444-555555555555";
+    process.env.ASC_PRIVATE_KEY = TEST_P8;
+  });
+  it("signs an ES256 JWT with the right header + claims and exp <= 20min", async () => {
+    const token = await mintToken();
+    const header = decodeProtectedHeader(token);
+    expect(header.alg).toBe("ES256");
+    expect(header.kid).toBe("ABC123KEYID");
+    const pub = await importPKCS8(TEST_P8, "ES256"); // verify with the same key (test only)
+    const { payload } = await jwtVerify(token, await importPKCS8(TEST_P8, "ES256"), {
+      audience: "appstoreconnect-v1",
+    }).catch(async () => {
+      // ES256 verify needs the public key; for the unit test assert claims via decode instead
+      const [, body] = token.split(".");
+      return { payload: JSON.parse(Buffer.from(body, "base64url").toString()) } as never;
+    });
+    expect(payload.iss).toBe("11111111-2222-3333-4444-555555555555");
+    expect(payload.aud).toBe("appstoreconnect-v1");
+    expect((payload.exp as number) - (payload.iat as number)).toBeLessThanOrEqual(1200);
+  });
+});
+```
+> Note for the implementing subagent: generate a real throwaway P-256 PKCS8 key with `openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 | openssl pkcs8 -topk8 -nocrypt` and paste it as `TEST_P8`. Assert header via `decodeProtectedHeader` and claims via base64url-decoding the payload (simplest, no public-key handling needed).
+
+- [ ] **Step 2: Run test to verify it fails** — `npm test -- app-store-client` → FAIL (module not found).
+
+- [ ] **Step 3: Implement `src/lib/analytics/app-store-client.ts`**
+```typescript
+import { SignJWT, importPKCS8 } from "jose";
+import { parsePrivateKey } from "@/lib/firebase/parse-private-key";
+
+const ASC_BASE = "https://api.appstoreconnect.apple.com";
+const AUD = "appstoreconnect-v1";
+
+export function isAppStoreConfigured(): boolean {
+  return !!(
+    process.env.ASC_KEY_ID &&
+    process.env.ASC_ISSUER_ID &&
+    process.env.ASC_PRIVATE_KEY &&
+    process.env.ASC_APP_ID
+  );
+}
+
+export function getAscAppId(): string {
+  const id = process.env.ASC_APP_ID;
+  if (!id) throw new Error("Missing ASC_APP_ID");
+  return id;
+}
+
+export async function mintToken(): Promise<string> {
+  const kid = process.env.ASC_KEY_ID;
+  const iss = process.env.ASC_ISSUER_ID;
+  const pem = parsePrivateKey(process.env.ASC_PRIVATE_KEY);
+  if (!kid || !iss || !pem) throw new Error("App Store Connect not configured");
+  const key = await importPKCS8(pem, "ES256");
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({})
+    .setProtectedHeader({ alg: "ES256", kid, typ: "JWT" })
+    .setIssuer(iss)
+    .setIssuedAt(now)
+    .setExpirationTime(now + 1140) // 19 min (<= 20 min hard cap)
+    .setAudience(AUD)
+    .sign(key);
+}
+
+export interface AscFetchOpts { token?: string; }
+
+export async function ascGet<T = unknown>(path: string, opts: AscFetchOpts = {}): Promise<T> {
+  const token = opts.token ?? (await mintToken());
+  const url = path.startsWith("http") ? path : `${ASC_BASE}${path}`;
+  const res = await fetchWithBackoff(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`ASC GET ${path} -> ${res.status}: ${await res.text()}`);
+  return (await res.json()) as T;
+}
+
+export async function ascPost<T = unknown>(path: string, body: unknown, opts: AscFetchOpts = {}): Promise<T> {
+  const token = opts.token ?? (await mintToken());
+  const res = await fetchWithBackoff(`${ASC_BASE}${path}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`ASC POST ${path} -> ${res.status}: ${await res.text()}`);
+  return (await res.json()) as T;
+}
+
+/** Download a signed segment URL and gunzip → string. */
+export async function downloadSegment(url: string): Promise<string> {
+  const res = await fetchWithBackoff(url, {});
+  if (!res.ok) throw new Error(`segment download -> ${res.status}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  const { gunzipSync } = await import("node:zlib");
+  return gunzipSync(buf).toString("utf8");
+}
+
+async function fetchWithBackoff(url: string, init: RequestInit, attempt = 0): Promise<Response> {
+  const res = await fetch(url, init);
+  if (res.status === 429 && attempt < 4) {
+    const wait = Math.min(2000 * 2 ** attempt, 30_000) + Math.floor(Math.random() * 500);
+    await new Promise((r) => setTimeout(r, wait));
+    return fetchWithBackoff(url, init, attempt + 1);
+  }
+  return res;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes** — `npm test -- app-store-client` → PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/lib/analytics/app-store-client.ts tests/unit/app-store-client.test.ts
+git commit -m "feat(admin): app store connect client (ES256 JWT mint + ASC fetch/backoff)"
+```
+
+---
+
+## Task 3: TSV parser + channel mapping
+
+**Files:**
+- Create: `src/lib/analytics/app-store-parse.ts`
+- Test: `tests/unit/app-store-parse.test.ts`
+
+- [ ] **Step 1: Write the failing test** (the highest-value test — column drift + channel map)
+```typescript
+import { describe, it, expect } from "vitest";
+import { parseTsv, mapAppStoreSourceToChannel } from "@/lib/analytics/app-store-parse";
+
+describe("mapAppStoreSourceToChannel", () => {
+  it.each([
+    ["App Store Search", "app_store_search"],
+    ["App Store Browse", "app_store_browse"],
+    ["App Referrer", "app_referrer"],
+    ["Web Referrer", "web_referrer"],
+    ["App Clip", "app_clip"],
+    ["Institutional Purchase", "institutional"],
+    ["Unavailable", "unavailable"],
+    ["", "unavailable"],
+    ["Something New", "other"],
+  ])("maps %s -> %s", (src, expected) => {
+    expect(mapAppStoreSourceToChannel(src, null)).toBe(expected);
+  });
+});
+
+describe("parseTsv (header-name based, drift-tolerant)", () => {
+  const canonicalAliases = {
+    reporting_date: ["date"], source_type: ["source type"],
+    counts: ["counts"], unique_counts: ["unique counts", "unique devices"],
+  };
+  it("maps documented header order", () => {
+    const tsv = "Date\tSource Type\tCounts\tUnique Counts\n2026-06-01\tApp Store Search\t1,234\t1000";
+    const rows = parseTsv(tsv, canonicalAliases);
+    expect(rows[0]).toMatchObject({ reporting_date: "2026-06-01", source_type: "App Store Search", counts: 1234, unique_counts: 1000 });
+  });
+  it("survives reordered columns", () => {
+    const tsv = "Unique Counts\tCounts\tSource Type\tDate\n5\t9\tApp Store Browse\t2026-06-02";
+    const rows = parseTsv(tsv, canonicalAliases);
+    expect(rows[0]).toMatchObject({ counts: 9, unique_counts: 5, source_type: "App Store Browse" });
+  });
+  it("keeps unknown columns in raw and never drops them", () => {
+    const tsv = "Date\tSource Type\tCounts\tNew Apple Column\n2026-06-03\tWeb Referrer\t3\tXYZ";
+    const rows = parseTsv(tsv, canonicalAliases);
+    expect(rows[0].raw["new apple column"]).toBe("XYZ");
+  });
+  it("handles 'Unique Devices' alias for unique_counts", () => {
+    const tsv = "Date\tSource Type\tCounts\tUnique Devices\n2026-06-04\tApp Store Search\t7\t4";
+    const rows = parseTsv(tsv, canonicalAliases);
+    expect(rows[0].unique_counts).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL** — `npm test -- app-store-parse`.
+
+- [ ] **Step 3: Implement `src/lib/analytics/app-store-parse.ts`**
+```typescript
+export type AscChannel =
+  | "app_store_search" | "app_store_browse" | "app_referrer" | "web_referrer"
+  | "app_clip" | "institutional" | "unavailable" | "other";
+
+export function mapAppStoreSourceToChannel(sourceType: string | null, _info: string | null): AscChannel {
+  const s = (sourceType ?? "").trim().toLowerCase();
+  if (s === "") return "unavailable";
+  if (s === "app store search") return "app_store_search";
+  if (s === "app store browse") return "app_store_browse";
+  if (s === "app referrer") return "app_referrer";
+  if (s === "web referrer") return "web_referrer";
+  if (s === "app clip") return "app_clip";
+  if (s === "institutional purchase") return "institutional";
+  if (s === "unavailable") return "unavailable";
+  return "other";
+}
+
+const norm = (h: string) => h.trim().toLowerCase().replace(/\s+/g, " ");
+
+export interface ParsedRow {
+  [canonical: string]: string | number | Record<string, string>;
+  raw: Record<string, string>;
+}
+
+/** aliases: canonicalName -> list of normalized header aliases (besides the canonical name itself). */
+export function parseTsv(text: string, aliases: Record<string, string[]>): ParsedRow[] {
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length < 2) return [];
+  const headers = lines[0].split("\t").map(norm);
+  // Build canonical -> column index
+  const numericCanon = new Set(["counts", "unique_counts"]);
+  const resolve: Record<string, number> = {};
+  for (const [canon, alist] of Object.entries(aliases)) {
+    const candidates = [norm(canon.replace(/_/g, " ")), ...alist.map(norm)];
+    const idx = headers.findIndex((h) => candidates.includes(h));
+    if (idx >= 0) resolve[canon] = idx;
+  }
+  return lines.slice(1).map((line) => {
+    const cells = line.split("\t");
+    const raw: Record<string, string> = {};
+    headers.forEach((h, i) => { raw[h] = cells[i] ?? ""; });
+    const out: ParsedRow = { raw };
+    for (const [canon, idx] of Object.entries(resolve)) {
+      const v = (cells[idx] ?? "").trim();
+      out[canon] = numericCanon.has(canon) ? parseNum(v) : v;
+    }
+    return out;
+  });
+}
+
+function parseNum(v: string): number {
+  const n = Number(v.replace(/[, ]/g, ""));
+  return Number.isFinite(n) ? n : 0;
+}
+```
+
+- [ ] **Step 4: Run → PASS** — `npm test -- app-store-parse`.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/lib/analytics/app-store-parse.ts tests/unit/app-store-parse.test.ts
+git commit -m "feat(admin): app store TSV header-name parser + channel mapping"
+```
+
+---
+
+## Task 4: Sync status queries + read query fns + types
+
+**Files:**
+- Create: `src/lib/admin/app-store-queries.ts`
+- Test: `tests/unit/app-store-queries.test.ts`
+
+- [ ] **Step 1: Write failing test for the cache-key regression guard + range parsing helper**
+```typescript
+import { describe, it, expect } from "vitest";
+import { ascCacheKey } from "@/lib/admin/app-store-queries";
+
+describe("ascCacheKey", () => {
+  it("includes from/to/granularity so dated variants never collide", () => {
+    const a = ascCacheKey("kpis", "2026-06-01", "2026-06-30", "daily");
+    const b = ascCacheKey("kpis", "2026-05-01", "2026-05-31", "daily");
+    expect(a).not.toEqual(b);
+    expect(a).toEqual(["asc", "kpis", "2026-06-01", "2026-06-30", "daily"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement `src/lib/admin/app-store-queries.ts`** — status helpers + the cache-key helper + 5 cached read fns. Status helpers mirror `updateSyncStatus` in `ads-history-queries.ts`. **Every cached read fn includes `from/to/granularity` in the key array** (do NOT replicate the `admin-queries.ts` static-key bug).
+```typescript
+import { unstable_cache } from "next/cache";
+import { getAdminSupabase } from "@/lib/supabase/admin-client";
+
+const db = () => getAdminSupabase();
+
+export type AscGranularity = "daily" | "weekly" | "monthly";
+export interface AscSyncStatus {
+  job_name: string; status: "idle" | "running" | "complete" | "failed";
+  last_synced_date: string | null; last_run_at: string | null; error: string | null;
+}
+
+export async function getAscSyncStatus(job = "app-store-sync"): Promise<AscSyncStatus | null> {
+  const { data } = await db().from("asc_sync_status").select("*").eq("job_name", job).maybeSingle();
+  return data as AscSyncStatus | null;
+}
+export async function updateAscSyncStatus(job: string, patch: Partial<Omit<AscSyncStatus, "job_name">>): Promise<void> {
+  await db().from("asc_sync_status").upsert(
+    { job_name: job, ...patch, last_run_at: new Date().toISOString(), updated_at: new Date().toISOString() },
+    { onConflict: "job_name" },
+  );
+}
+
+export function ascCacheKey(...parts: (string | number)[]): string[] {
+  return ["asc", ...parts.map(String)];
+}
+
+export interface AscKpis {
+  conversionRate: number | null; impressions: number; pageViews: number; downloads: number;
+  prev: { conversionRate: number | null; impressions: number; pageViews: number; downloads: number };
+  finalizedThrough: string; // current_date - 2
+  hasData: boolean;
+}
+
+// KPIs: current range + immediately-preceding equal-length range, from the view + facts.
+async function _kpis(from: string, to: string): Promise<AscKpis> {
+  // Implementation: query asc_conversion_daily for downloads + unique_impressions over [from,to]
+  // and the preceding range; query asc_discovery_engagement for impressions (unique_counts where
+  // engagement ~ impression) and page views (counts where engagement ~ product page view).
+  // conversionRate = downloads / unique_impressions (null when denom 0). Compute finalizedThrough.
+  // Return hasData=false when no rows in range.
+  // (Full SQL in spec §A7.3; use db().rpc or .select with filters + JS reduce.)
+  throw new Error("implement per spec §A7.3");
+}
+export const getAscKpis = (from: string, to: string) =>
+  unstable_cache(() => _kpis(from, to), ascCacheKey("kpis", from, to), { revalidate: 300 })();
+
+// conversion-series, traffic-series, source-breakdown, territories follow the SAME shape:
+//   export const getAscConversionSeries = (from,to,g) =>
+//     unstable_cache(() => _conversionSeries(from,to,g), ascCacheKey("conv", from, to, g), {revalidate:300})();
+// Each _fn() reads the relevant table/view, buckets via bucketize() from date-utils, returns
+// ChartDataPoint[] / DonutSegment[] / TerritoryRow[]. provisional computed at read time:
+//   reporting_date > current_date - 2.
+```
+> Implementing subagent: flesh out `_kpis` and the four series fns against the real columns (spec §A7.3–A7.7). Reuse `bucketize`/`bucketizeAggregate` from `src/lib/admin/date-utils.ts`. Keep each `_fn` ≤ ~40 lines; if longer, the query is doing too much — split.
+
+- [ ] **Step 4: Run → PASS** (the `ascCacheKey` test; the read fns get integration coverage in Task 6 fixtures).
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/lib/admin/app-store-queries.ts tests/unit/app-store-queries.test.ts
+git commit -m "feat(admin): app store sync-status + cached read queries (args in cache key)"
+```
+
+---
+
+## Task 5: Sync pipeline (bootstrap + 6-step pull + idempotent upsert)
+
+**Files:**
+- Create: `src/lib/admin/app-store-sync.ts`
+- Test: `tests/unit/app-store-sync.test.ts`
+
+- [ ] **Step 1: Write the failing test** — mock the ASC client + Supabase; assert (a) bootstrap creates ONGOING + SNAPSHOT once, (b) a processed segment checksum is skipped on re-run, (c) parsed rows upsert with mapped `channel`, (d) trailing-3-day re-pull updates in place. Use `vi.mock("@/lib/analytics/app-store-client", ...)` returning recorded fixtures (requests → reports → instances → segments → gz string).
+
+- [ ] **Step 2: Run → FAIL.**
+
+- [ ] **Step 3: Implement `src/lib/admin/app-store-sync.ts`**
+  - `bootstrapIfNeeded()` — if `asc_report_requests` empty, `ascPost("/v1/analyticsReportRequests", {data:{type:"analyticsReportRequests", attributes:{accessType}, relationships:{app:{data:{type:"apps", id: getAscAppId()}}}}})` for `ONGOING` then `ONE_TIME_SNAPSHOT`; persist ids. Guard: skip SNAPSHOT if one exists < 31 days old.
+  - `syncOnce()` — for each active request: list reports (filter category `APP_STORE_ENGAGEMENT`, `APP_STORE_COMMERCE`) → instances (`granularity=DAILY`, paginate via `links.next`) → segments → for each unprocessed checksum: `downloadSegment` → `parseTsv(text, ALIASES)` → map source→channel → land `asc_raw_rows` → upsert facts (`onConflict` on the unique constraint, `ignoreDuplicates:false` so it UPDATEs) → mark segment `processed`. Re-pull trailing 3 reporting dates each run.
+  - Define `ENGAGEMENT_ALIASES` / `DOWNLOAD_ALIASES` from spec §A5.
+  - Write `updateAscSyncStatus` running/complete/failed + `last_synced_date`.
+> Keep the file focused on orchestration; parsing lives in Task 3, HTTP in Task 2.
+
+- [ ] **Step 4: Run → PASS.**
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/lib/admin/app-store-sync.ts tests/unit/app-store-sync.test.ts
+git commit -m "feat(admin): app store sync pipeline (bootstrap + 6-step pull + idempotent upsert)"
+```
+
+---
+
+## Task 6: Cron route
+
+**Files:**
+- Create: `src/app/api/cron/app-store-sync/route.ts`
+
+- [ ] **Step 1: Write test** (`tests/unit/app-store-sync.test.ts` addition or a route test) — wrong/empty `CRON_SECRET` → 401; correct → calls `bootstrapIfNeeded` + `syncOnce`.
+
+- [ ] **Step 2: Implement** (mirror `ads-sync/route.ts` exactly)
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { bootstrapIfNeeded, syncOnce } from "@/lib/admin/app-store-sync";
+import { updateAscSyncStatus } from "@/lib/admin/app-store-queries";
+
+export const maxDuration = 60;
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  try {
+    await updateAscSyncStatus("app-store-sync", { status: "running", error: null });
+    await bootstrapIfNeeded();
+    const result = await syncOnce();
+    await updateAscSyncStatus("app-store-sync", { status: "complete", last_synced_date: result.lastDate, error: null });
+    return NextResponse.json({ status: "synced", ...result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await updateAscSyncStatus("app-store-sync", { status: "failed", error: message });
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 3: Run tests → PASS.**
+
+- [ ] **Step 4: Add the cron to `vercel.json`** — after the `ads-sync` object, insert `{ "path": "/api/cron/app-store-sync", "schedule": "0 9 * * *" }`.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/app/api/cron/app-store-sync/route.ts vercel.json
+git commit -m "feat(admin): app store daily sync cron (09:00 UTC, CRON_SECRET guarded)"
+```
+
+---
+
+## Task 7: Read API routes (5)
+
+**Files:**
+- Create: `src/app/api/admin/app-store/{kpis,conversion-series,traffic-series,source-breakdown,territories}/route.ts`
+
+- [ ] **Step 1: Implement each route** (uniform; example `kpis`)
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { getAscKpis } from "@/lib/admin/app-store-queries";
+
+function parseRange(req: NextRequest) {
+  const u = new URL(req.url);
+  const to = u.searchParams.get("to") ?? new Date().toISOString();
+  const from = u.searchParams.get("from") ?? new Date(Date.now() - 30 * 86_400_000).toISOString();
+  const granularity = (u.searchParams.get("granularity") ?? "daily") as "daily" | "weekly" | "monthly";
+  return { from, to, granularity };
+}
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+  const { from, to } = parseRange(req);
+  const data = await getAscKpis(from, to);
+  return NextResponse.json({ data });
+});
+```
+The other four call their respective query fn with `(from, to, granularity)`.
+
+- [ ] **Step 2: Test** — non-admin (no `DEV_BYPASS_AUTH`, no admin cookie) → 403; admin → 200 with `{ data }`. (Reuse the admin-route test harness if present; otherwise assert `requireAdmin` throws 403 via a mocked `isAdminEmail` → false.)
+
+- [ ] **Step 3: Commit**
+```bash
+git add src/app/api/admin/app-store
+git commit -m "feat(admin): app store read API routes (kpis/series/source/territories)"
+```
+
+---
+
+## Task 8: The `Growth > App Store` page (RSC + content)
+
+**Files:**
+- Create: `src/app/admin/app-store/page.tsx`, `src/app/admin/app-store/_components/app-store-content.tsx`
+
+> **Invoke the design-skill stack for this task** (frontend-design + interface-design + ops-design token reads + ops-copywriter). Reuse `AdminPageHeader`, `StatCard`, `AdminLineChart`, `AdminDonutChart`, `FunnelChart`, `Sparkline`, `SortableTableHeader`/`useSortState`, `DateRangeControl`/`useDateRange`. Numbers JetBrains Mono tabular; empty `—`; accent NEVER on a data series.
+
+- [ ] **Step 1: RSC `page.tsx`** — mirror `app-analytics/page.tsx`: `isAppStoreConfigured()` false → render SETUP REQUIRED card (mirror the Google Ads setup card). Else `try/catch` fetch default (last 30d daily) via `Promise.all` of the query fns; on empty + no processed instance → AWAITING FIRST APPLE REPORT panel (query `getAscSyncStatus` + an instance-count check); pass `initialData` to `<AppStoreContent>`. `AdminPageHeader title="APP STORE" caption="APP STORE CONNECT · ACQUISITION FUNNEL"`, plus `COMPLETE THROUGH {finalizedThrough}`.
+
+- [ ] **Step 2: `app-store-content.tsx` (`'use client'`)** — `DateRangeControl` + `useDateRange("30d")`; TanStack `useQuery` per section keyed `["asc-kpis", from, to]` etc., seeded with `initialData` when params match the RSC default; render: KPI row (4 `StatCard`s with period-over-period `trend` + `sparklineData`), conversion-rate `AdminLineChart` (hero; provisional points muted), traffic `AdminLineChart`/stacked (impressions vs page views vs downloads) + optional `FunnelChart`, source `AdminDonutChart` by channel (legend footnote "App Store Search includes Apple Search Ads"), territory table (`SortableTableHeader` + `useSortState("downloads")`, inline `Sparkline` per row). Provisional banner when range right edge < 2 days.
+
+- [ ] **Step 3: Manual verify in preview** (see Proof section) — page renders all three states (setup-required, awaiting, populated-with-fixture).
+
+- [ ] **Step 4: Commit**
+```bash
+git add src/app/admin/app-store
+git commit -m "feat(admin): Growth > App Store page (conversion funnel, source, territories)"
+```
+
+---
+
+## Task 9: Sidebar nav + Kosugi font fix
+
+**Files:**
+- Modify: `src/app/admin/_components/sidebar.tsx`, `src/app/admin/_components/charts/line-chart.tsx`, `charts/bar-chart.tsx`
+
+- [ ] **Step 1:** Insert after the GOOGLE ADS entry (after line 14):
+```typescript
+  { type: "item", href: "/admin/app-store", label: "APP STORE" },
+```
+- [ ] **Step 2:** In `line-chart.tsx` (lines 52, 57) and `bar-chart.tsx`, replace `fontFamily: "Kosugi"` → `fontFamily: "JetBrains Mono"`.
+- [ ] **Step 3: Verify** the sidebar shows APP STORE under GROWTH after GOOGLE ADS in the preview.
+- [ ] **Step 4: Commit**
+```bash
+git add src/app/admin/_components/sidebar.tsx src/app/admin/_components/charts/line-chart.tsx src/app/admin/_components/charts/bar-chart.tsx
+git commit -m "feat(admin): register App Store nav + retire Kosugi font in admin charts"
+```
+
+---
+
+## Task 10: Full test sweep + typecheck
+
+- [ ] **Step 1:** `npm test -- app-store` → all pass.
+- [ ] **Step 2:** `npx tsc --noEmit` (or the project's typecheck script) → no new errors in `app-store*` files. (CI lint is known-red on unrelated pre-existing issues — verify only that our files are clean.)
+- [ ] **Step 3: Commit** any fixes.
+
+---
+
+## Post-build (gated on Jackson's credential — not blocking the build)
+
+- [ ] **Live validation #13/#14** (spec §A9): after Jackson adds `ASC_KEY_ID/ASC_ISSUER_ID/ASC_PRIVATE_KEY/ASC_APP_ID` to Vercel and Apple unlocks analytics (~24–48h), trigger the cron once, download one real segment, **byte-confirm header strings + pin the Unique-Impressions denominator and the download summation rule**, then adjust `ENGAGEMENT_ALIASES`/`DOWNLOAD_ALIASES` and the conversion view if needed. Spot-check one date vs the App Store Connect dashboard.
+
+---
+
+## Self-Review (run by author)
+
+- **Spec coverage:** Tasks 1–10 cover spec §A1–A9 (prereqs/secrets handled via env + `isAppStoreConfigured`; A2 JWT=Task2; A3 pipeline=Task5; A3.5 cron=Task6; A4 schema=Task1; A5 parser=Task3; A6 channel map=Task3; A7 page=Task8; A8 routes=Task7+sync-status Task4; A9 tests across 2/3/5/6/7 + post-build live validation). North-star/roadmap (Parts B–E) are future phases, intentionally out of this plan.
+- **Placeholders:** The only deferred detail is the body of `_kpis`/series read fns (Task 4 Step 3) and the Task 5 sync internals — both have explicit per-spec instructions + exact tables/columns, not "TODO". Acceptable as bite-sized implementer work with concrete references.
+- **Type consistency:** `AscChannel`, `AscGranularity`, `AscKpis`, `ParsedRow`, `mintToken`/`ascGet`/`ascPost`/`downloadSegment`, `getAscKpis`, `updateAscSyncStatus`/`getAscSyncStatus`, `ascCacheKey`, `bootstrapIfNeeded`/`syncOnce` are named identically wherever referenced across tasks.
+- **Idempotency fix** verified by Task 1 Step 5 sentinel; **provisional** is read-time everywhere; **`asc_sync_status`** defined in Task 1 and used in Tasks 4/6.

--- a/docs/superpowers/specs/2026-06-22-app-store-connect-analytics-design.md
+++ b/docs/superpowers/specs/2026-06-22-app-store-connect-analytics-design.md
@@ -1,0 +1,512 @@
+# App Store Connect Analytics → Admin Panel (Phase 1 of Unified Attribution)
+
+**Date:** 2026-06-22
+**Surface:** `OPS-Web` admin → `Growth > App Store` (`/admin/app-store`)
+**Status:** Design approved in brainstorming; ready for implementation-plan stage.
+**Build posture:** OPS perfection standard — no stubs, no TODOs, no deferral. Every section is production-ready.
+
+> **Review status.** This spec was grounded by a multi-agent investigation of the live OPS codebase + Supabase schema and current (2025–2026) Apple/attribution docs, then put through an adversarial critic pass. Three build-breaking issues the critic found are **already fixed in this document** (illegal stored generated column → read-time computed; NULL-distinct unique keys breaking idempotency → `NULLS NOT DISTINCT`; an undefined `asc_sync_status` table → full DDL added), plus five smaller corrections (RLS view comment, conversion summation rule, dependency provenance, "awaiting first report" state machine, and removal of a "likely-zero pre-orders" guess).
+
+---
+
+## The bigger picture (why this is "Phase 1," not a one-off)
+
+The closing requirement — *"all our conversion, tracking, and ads data consolidated into a centralized analytics screen with drill-downs for attribution by channel"* — reframes this work. The App Store Connect connector is **the first brick of a warehouse-centric cross-channel attribution stack**, not a standalone screen. It is therefore built **attribution-ready from day one**: its facts carry a normalized `channel` dimension in the same canonical vocabulary the future unified screen uses, so App Store rows later flow into the unified fact **without re-ingestion**.
+
+- **Part A** — Phase 1: the App Store Connect integration (this is what gets built now).
+- **Part B** — North-star: the centralized cross-channel attribution screen and the warehouse layers beneath it.
+- **Part C** — Phased roadmap to get from A to B.
+- **Part D** — Canonical channel taxonomy (shared contract for every connector).
+- **Part E** — Open questions for Jackson.
+
+---
+
+# PART A — Phase 1: App Store Connect Analytics Integration
+
+## A0. What this delivers, in one sentence
+
+A daily, idempotent pull of Apple's App Store Connect Analytics into Supabase, surfaced as a founder-grade admin screen showing how people find the app on the App Store (impressions → product-page views → downloads), the App Store conversion rate, where that traffic comes from (source type → normalized channel), and which territories drive it — with period-over-period deltas and a selectable date range + granularity.
+
+## A1. Prerequisites (gathered once by Jackson, stored as Vercel secrets)
+
+None of these are inventable; each is required by Apple's API.
+
+### A1.1 App Store Connect API key — **Admin role**
+App Store Connect → Users and Access → Integrations → App Store Connect API → generate a **Team key** with the **Admin** role.
+- **Admin is required to *create*** an Analytics Report Request (`POST /v1/analyticsReportRequests`). Downloading generated reports later only needs *Sales and Reports* or *Finance*, but because we both create the ONGOING request and download, the key must be **Admin**.
+- On generation Apple gives three things; the `.p8` **downloads exactly once**:
+  - **Key ID** (`kid`, ~10 chars)
+  - **Issuer ID** (`iss`, a UUID, shown once at the top of the Keys page)
+  - **`.p8` private key** (ES256) — download immediately, store securely.
+
+### A1.2 The app's numeric App Store ID (adamId)
+The report request is scoped to one app via the `apps` relationship using the **numeric App Store app id** (the "Apple ID"/adamId on the App Information page), **not the bundle id**.
+
+### A1.3 Analytics unlock latency (operational)
+- After we issue the **ONGOING** request, Apple produces the **first report ~24–48 h later**, daily thereafter. The screen legitimately shows an "awaiting first Apple report" state until the first instance is processed (see A7.8).
+- A **ONE_TIME_SNAPSHOT** returns all available history, but a *new* snapshot can only be requested roughly **every 31 days** — so we fire it exactly once at bootstrap.
+
+### A1.4 Environment secrets (Vercel; mirror in `.env.local` for dev)
+
+| Variable | Purpose |
+|---|---|
+| `ASC_KEY_ID` | App Store Connect key `kid` (JWT header) |
+| `ASC_ISSUER_ID` | App Store Connect issuer id (JWT `iss`) |
+| `ASC_PRIVATE_KEY` | Contents of the `.p8` (PEM; newlines as `\n`, parsed at runtime — same handling as `FIREBASE_ADMIN_PRIVATE_KEY`) |
+| `ASC_APP_ID` | Numeric App Store app id (adamId) for the `apps` relationship |
+| `CRON_SECRET` | **Already set** — reused. Cron route authorizes on `Authorization: Bearer ${CRON_SECRET}`, identical to `/api/cron/ads-sync`. |
+| `SUPABASE_SERVICE_ROLE_KEY` | **Already set** — all reads/writes use the service-role admin client. |
+
+An `isAppStoreConfigured()` guard (mirroring `isGoogleAdsConfigured()`) returns false when any of `ASC_KEY_ID / ASC_ISSUER_ID / ASC_PRIVATE_KEY / ASC_APP_ID` is unset; the page then renders a **SETUP REQUIRED** state instead of erroring (same pattern as the Google Ads page).
+
+### A1.5 Cost transparency
+The App Store Connect Analytics Reports API is **free to call** with the existing Apple Developer Program membership — no per-request or subscription fee. The only marginal cost is Vercel function execution for **one cron run per day** (a handful of HTTP calls + a gzip parse, comparable to `ads-sync`). No new third-party service, no new database tier. **Net new recurring cost: ~$0.**
+
+## A2. Authentication — minting the JWT
+
+- **Algorithm:** ES256, signed with the `.p8`.
+- **Header:** `{ "alg": "ES256", "kid": ASC_KEY_ID, "typ": "JWT" }`
+- **Payload:** `{ "iss": ASC_ISSUER_ID, "iat": now, "exp": now + 1140, "aud": "appstoreconnect-v1" }`
+  - `exp` must be ≤ **20 min** (1200 s). We use **1140 s (19 min)** for clock-skew margin and mint **one token per cron run**.
+- **Base URL:** `https://api.appstoreconnect.apple.com`
+- Implemented in `OPS-Web/src/lib/analytics/app-store-client.ts` (peer of `google-ads-client.ts`). **`jose ^6.1.3` is a direct dependency in OPS-Web** (used for Firebase token verification) and supports ES256 signing. The client exposes `mintToken()`, `ascGet(path)`, and `downloadSegment(url)`.
+
+## A3. Daily data flow (the pull pipeline)
+
+Apple's Analytics Reports API is a **6-step pull**, not a single report endpoint. The connector implements all six steps and is **idempotent**.
+
+### A3.1 Bootstrap (once, on first deploy)
+On the first sync (detected because `asc_report_requests` is empty), issue **two** report requests against `ASC_APP_ID`:
+1. **`accessType: "ONGOING"`** — recurring daily generation from the request date forward. **No historical backfill.** First report ~24–48 h later.
+2. **`accessType: "ONE_TIME_SNAPSHOT"`** — all available history at request time. Fired **once**; the connector will not re-fire a snapshot if one exists in `asc_report_requests` younger than 31 days.
+
+Both request ids, their `accessType`, and creation time persist in `asc_report_requests`.
+
+### A3.2 Each daily run (the cron)
+For each persisted request (ONGOING, and the SNAPSHOT until its instances are fully drained):
+1. **`GET /v1/analyticsReportRequests/{id}/reports`** filtered by **category**:
+   - `APP_STORE_ENGAGEMENT` → **App Store Discovery and Engagement** report (impressions + product page views).
+   - `APP_STORE_COMMERCE` → **App Store Downloads** report (first-time vs redownloads, by source/page/device/territory).
+   - Persist each report id + category in `asc_reports`.
+2. **`GET /v1/analyticsReports/{id}/instances`** filtered by `granularity=DAILY` (+ `processingDate` for catch-up). Page with `limit=200`, follow `links.next`. Each instance = one reporting date. Persist in `asc_report_instances` with `state='discovered'`.
+3. **`GET /v1/analyticsReportInstances/{id}/segments`** — each segment carries a signed `url`, a `checksum`, and `sizeInBytes`. Persist in `asc_report_segments`.
+4. **Download** the segment `url` (signed, short-lived — download promptly). Payload is a **compressed, tab-delimited `.txt.gz`**.
+5. **`gunzip`** → parse the tab-delimited text.
+6. **Parse by header NAME, not column index** (A5), **normalize the source dimension to a canonical channel** (A6), **upsert idempotently** into the fact tables (A4), and mark the segment `processed` keyed on its `checksum`.
+
+### A3.3 Idempotency & the 2-day restatement
+- **Idempotency key per fact row:** `(report_kind, granularity, reporting_date, <full dimension tuple>)` enforced as a unique constraint **with `NULLS NOT DISTINCT`** (critical — Apple emits blank/absent dimensions; default UNIQUE treats NULLs as distinct, which would defeat `ON CONFLICT` and duplicate rows on every re-pull). All writes are `ON CONFLICT ... DO UPDATE`.
+- **Segment-level skip:** if a segment's `checksum` already exists as `processed`, skip download+parse entirely.
+- **Restatement:** Apple finalizes a reporting date's data **2 days after** that date (privacy thresholding drops rows with <5 users/devices and adds statistical noise; late rows restate earlier days). The cron **re-pulls the trailing 3 reporting dates every run** and re-upserts. The unique key + `DO UPDATE` (with NULLS NOT DISTINCT) makes re-processing safe and self-correcting.
+
+### A3.4 The "2-day-complete" display rule
+- `provisional` is **computed at read time** as `reporting_date > current_date - 2` — never stored (a stored generated column on `current_date` is illegal in Postgres). It is exposed by the conversion view and every query.
+- The screen's headline KPIs and "complete through" caption use the most recent finalized date (`current_date - 2`) as the right edge of the trustworthy window. Provisional days still render in charts but dashed/muted with a "preliminary — Apple finalizes at +2 days" tooltip, so a founder never reads a half-finalized number as truth.
+
+### A3.5 Scheduling (cron)
+- New `vercel.json` cron entry appended to the existing `crons` array:
+  ```json
+  { "path": "/api/cron/app-store-sync", "schedule": "0 9 * * *" }
+  ```
+  **09:00 UTC daily** — one hour after `ads-sync` (`0 8 * * *`) to avoid stacking external pulls. Data is final at +2 days, so time-of-day is not load-bearing.
+- Route authorizes on `Authorization: Bearer ${CRON_SECRET}` (verbatim `ads-sync` guard).
+- **Rate limiting:** Apple's budget is ~3500–3600 req/hr rolling. One app × 2 categories × a handful of instances/segments is a few dozen calls per run — far under budget. The client mints a ≤19-min token, reads rate-limit headers, and on **429** applies exponential backoff with jitter and resumes (bookkeeping lets it resume mid-run next invocation).
+
+## A4. Supabase data model (DDL)
+
+> **DO NOT apply to prod without Jackson's explicit go-ahead.** Net-new infra; stage as a migration, recon read-only, then sign-off (OPS prod-migration policy). The migration is **additive only** (new tables) — safe under the iOS-sync constraint.
+
+Design principles: faithful to the two source reports (one fact per report), header-name parsing with a raw JSONB landing column for forward-compat, an attribution-ready normalized `channel` on every fact, conversion computed (never stored), bookkeeping tables for resumable idempotent runs, and RLS locked to service-role writes / admin-gated server reads (the app runs as the **anon** role and `auth.uid()` is unusable under the Firebase bridge — so no client-facing table grants exist).
+
+```sql
+-- ============================================================================
+-- App Store Connect Analytics — Phase 1 ingestion + facts
+-- Additive migration. Service-role write, admin-gated server reads only.
+-- ============================================================================
+
+-- ---------- Bookkeeping: report requests (ONGOING + ONE_TIME_SNAPSHOT) -------
+create table if not exists public.asc_report_requests (
+  id              uuid primary key default gen_random_uuid(),
+  asc_request_id  text not null unique,                 -- Apple's analyticsReportRequest id
+  app_id          text not null,                        -- ASC_APP_ID (adamId)
+  access_type     text not null check (access_type in ('ONGOING','ONE_TIME_SNAPSHOT')),
+  created_at      timestamptz not null default now(),
+  stopped_at      timestamptz
+);
+
+-- ---------- Bookkeeping: reports per request (by category) -------------------
+create table if not exists public.asc_reports (
+  id             uuid primary key default gen_random_uuid(),
+  request_id     uuid not null references public.asc_report_requests(id) on delete cascade,
+  asc_report_id  text not null unique,
+  category       text not null,                         -- APP_STORE_ENGAGEMENT | APP_STORE_COMMERCE
+  report_name    text,
+  created_at     timestamptz not null default now()
+);
+
+-- ---------- Bookkeeping: instances (one per reporting date/granularity) ------
+create table if not exists public.asc_report_instances (
+  id               uuid primary key default gen_random_uuid(),
+  report_id        uuid not null references public.asc_reports(id) on delete cascade,
+  asc_instance_id  text not null unique,
+  granularity      text not null check (granularity in ('DAILY','WEEKLY','MONTHLY')),
+  processing_date  date not null,
+  state            text not null default 'discovered'
+                     check (state in ('discovered','downloaded','processed','error')),
+  error_detail     text,
+  discovered_at    timestamptz not null default now(),
+  processed_at     timestamptz
+);
+
+-- ---------- Bookkeeping: segments (downloadable gz parts, checksum-keyed) ----
+create table if not exists public.asc_report_segments (
+  id              uuid primary key default gen_random_uuid(),
+  instance_id     uuid not null references public.asc_report_instances(id) on delete cascade,
+  checksum        text not null,                        -- Apple's segment checksum (idempotency)
+  size_bytes      bigint,
+  url             text,                                 -- signed, short-lived
+  state           text not null default 'discovered'
+                     check (state in ('discovered','processed','error')),
+  rows_ingested   integer,
+  processed_at    timestamptz,
+  created_at      timestamptz not null default now(),
+  unique (instance_id, checksum)
+);
+
+-- ---------- Raw landing (forward-compat: never lose an unknown column) -------
+create table if not exists public.asc_raw_rows (
+  id              bigint generated always as identity primary key,
+  segment_id      uuid not null references public.asc_report_segments(id) on delete cascade,
+  report_kind     text not null check (report_kind in ('discovery_engagement','downloads')),
+  reporting_date  date not null,
+  raw             jsonb not null,                       -- full header->value map, verbatim
+  ingested_at     timestamptz not null default now()
+);
+create index if not exists asc_raw_rows_kind_date_idx
+  on public.asc_raw_rows (report_kind, reporting_date);
+
+-- ---------- FACT 1: App Store Discovery and Engagement ----------------------
+create table if not exists public.asc_discovery_engagement (
+  id                  bigint generated always as identity primary key,
+  granularity         text not null default 'DAILY',
+  reporting_date      date not null,
+  engagement_type     text,        -- "Engagement Type" (Impression, Product Page View, Tap)
+  page_type           text,        -- "Page Type"
+  source_type         text,        -- "Source Type" (App Store Search, Browse, App Referrer, Web Referrer, App Clip, ...)
+  source_info         text,        -- "Source Info"
+  device              text,        -- "Device"
+  platform_version    text,        -- "Platform Version"
+  territory           text,        -- "Territory" (ISO country)
+  channel             text not null default 'unknown',  -- canonical taxonomy (A6)
+  counts              bigint not null default 0,         -- "Counts"
+  unique_counts       bigint not null default 0,         -- "Unique Counts"
+  segment_id          uuid references public.asc_report_segments(id) on delete set null,
+  updated_at          timestamptz not null default now(),
+  -- NULLS NOT DISTINCT: Apple emits blank dimensions; without this, ON CONFLICT
+  -- never fires on NULL dims and the trailing-3-day re-pull duplicates rows.
+  constraint asc_de_uk unique nulls not distinct
+    (granularity, reporting_date, engagement_type, page_type,
+     source_type, source_info, device, platform_version, territory)
+);
+create index if not exists asc_de_date_idx       on public.asc_discovery_engagement (reporting_date);
+create index if not exists asc_de_channel_idx    on public.asc_discovery_engagement (channel, reporting_date);
+create index if not exists asc_de_territory_idx  on public.asc_discovery_engagement (territory, reporting_date);
+
+-- ---------- FACT 2: App Store Downloads -------------------------------------
+create table if not exists public.asc_downloads (
+  id                  bigint generated always as identity primary key,
+  granularity         text not null default 'DAILY',
+  reporting_date      date not null,
+  download_type       text,        -- "Download Type" (First Time Download / Redownload / Total)
+  page_type           text,        -- "Page Type"
+  source_type         text,        -- "Source Type"
+  source_info         text,        -- "Source Info"
+  campaign            text,        -- "Campaign" (when present)
+  device              text,        -- "Device"
+  platform_version    text,        -- "Platform Version"
+  territory           text,        -- "Territory"
+  channel             text not null default 'unknown',
+  counts              bigint not null default 0,         -- "Counts" (download count)
+  unique_counts       bigint not null default 0,         -- "Unique Counts" (unique devices)
+  segment_id          uuid references public.asc_report_segments(id) on delete set null,
+  updated_at          timestamptz not null default now(),
+  constraint asc_dl_uk unique nulls not distinct
+    (granularity, reporting_date, download_type, page_type,
+     source_type, source_info, campaign, device, platform_version, territory)
+);
+create index if not exists asc_dl_date_idx       on public.asc_downloads (reporting_date);
+create index if not exists asc_dl_channel_idx    on public.asc_downloads (channel, reporting_date);
+create index if not exists asc_dl_territory_idx  on public.asc_downloads (territory, reporting_date);
+
+-- ---------- Bookkeeping: sync status (mirrors ads_sync_status) ---------------
+create table if not exists public.asc_sync_status (
+  job_name          text primary key,                   -- e.g. 'app-store-sync'
+  status            text not null default 'idle'
+                      check (status in ('idle','running','complete','failed')),
+  last_synced_date  date,                                -- most recent reporting_date ingested
+  last_run_at       timestamptz,
+  error             text,
+  updated_at        timestamptz not null default now()
+);
+
+-- ---------- DERIVED VIEW: conversion (never stored; provisional read-time) ---
+-- Apple's definition: (Total Downloads + Pre-orders) / Unique Device Impressions.
+-- Pre-orders are a separate report (out of Phase 1) — this is Apple's formula
+-- MINUS the pre-order term; the UI labels it as such.
+-- security_invoker=true so base-table RLS is enforced against the querying role
+-- (defense-in-depth: the view is also never granted to anon/authenticated).
+create or replace view public.asc_conversion_daily
+with (security_invoker = true) as
+with imp as (
+  select reporting_date, territory, channel,
+         sum(unique_counts) as unique_impressions
+  from public.asc_discovery_engagement
+  where lower(engagement_type) like '%impression%'
+  group by reporting_date, territory, channel
+),
+dl as (
+  -- Summation rule is PINNED during live validation (test #13): confirm whether
+  -- Apple emits a discrete 'Total' download row per dimension tuple, OR only
+  -- First Time + Redownload. Until pinned, sum the 'Total' rows when present.
+  select reporting_date, territory, channel,
+         sum(counts) as total_downloads
+  from public.asc_downloads
+  where download_type is null
+     or lower(download_type) in ('total downloads','total')
+  group by reporting_date, territory, channel
+)
+select
+  coalesce(imp.reporting_date, dl.reporting_date) as reporting_date,
+  coalesce(imp.territory, dl.territory)           as territory,
+  coalesce(imp.channel, dl.channel)               as channel,
+  coalesce(imp.unique_impressions, 0)             as unique_impressions,
+  coalesce(dl.total_downloads, 0)                 as total_downloads,
+  case when coalesce(imp.unique_impressions,0) > 0
+       then coalesce(dl.total_downloads,0)::numeric / imp.unique_impressions
+       else null end                              as conversion_rate,
+  coalesce(imp.reporting_date, dl.reporting_date) > (current_date - 2) as provisional
+from imp
+full outer join dl
+  on  imp.reporting_date = dl.reporting_date
+  and imp.territory      = dl.territory
+  and imp.channel        = dl.channel;
+
+-- ---------- RLS: service-role write, deny anon/authenticated ----------------
+-- The app executes as the anon role and auth.uid() is unusable under the
+-- Firebase bridge, so NO table-level access is granted to clients. All UI
+-- access is server-side via the service-role admin client behind isAdminEmail().
+-- Service role bypasses RLS; enabling it with zero policies = default-deny,
+-- explicit and auditable.
+alter table public.asc_report_requests    enable row level security;
+alter table public.asc_reports            enable row level security;
+alter table public.asc_report_instances   enable row level security;
+alter table public.asc_report_segments    enable row level security;
+alter table public.asc_raw_rows           enable row level security;
+alter table public.asc_discovery_engagement enable row level security;
+alter table public.asc_downloads          enable row level security;
+alter table public.asc_sync_status        enable row level security;
+-- No CREATE POLICY ... TO anon/authenticated is issued anywhere → RLS denies all
+-- client reads by default. asc_conversion_daily is read only by the service role;
+-- security_invoker=true means base-table RLS would also apply if it were ever
+-- exposed to a client role.
+```
+
+**Faithfulness notes / stated assumptions (not guesses):**
+- Apple does not publish a stable, versioned header list and reorders/renames columns over time. The parser maps by **normalized header name** via an alias table and lands every row's full header→value map in `asc_raw_rows.raw`. The fact columns are the documented dimensions; unknown/extra columns survive in `raw` (no data loss) and are mapped in later without re-ingestion.
+- **Unique Impressions** (the conversion denominator): the view assumes the safe superset — `sum(unique_counts) where engagement_type LIKE '%impression%'`. **Validate against a real downloaded file (test #13) before pinning**; adjust if Apple exposes a discrete column.
+- **Download summation rule** is explicitly pinned during live validation (test #13): confirm whether a discrete `Total` row exists per dimension tuple or whether totals are `First Time + Redownload`, then make the view's `download_type` handling a single explicit rule (not a tolerant OR that could double-count or miss). The `NULLS NOT DISTINCT` key prevents numerator double-counting regardless.
+- **Pre-orders** are excluded (separate report, out of Phase 1). The conversion view is Apple's formula minus the pre-order term; the UI labels it. (See Part E open question — Jackson confirms whether pre-orders were ever used rather than assuming zero.)
+
+## A5. Header-name-based parsing (column-drift defense)
+
+In `OPS-Web/src/lib/admin/app-store-sync.ts`:
+1. Read **row 1** of each decompressed file as the header.
+2. Build `normalize(h) -> rawIndex` (`normalize`: lowercase, strip, collapse internal whitespace).
+3. Resolve each canonical column via an **alias table**, e.g. `reporting_date ← date`; `engagement_type ← engagement type | event | event type`; `download_type ← download type`; `source_type ← source type`; `source_info ← source info | source`; `page_type ← page type`; `device ← device`; `platform_version ← platform version`; `territory ← territory | country / region`; `campaign ← campaign`; `counts ← counts`; `unique_counts ← unique counts | unique devices`.
+4. Any header with no alias is preserved in `raw` and ignored for facts (never dropped).
+5. Numeric fields parse with thousands-separator tolerance, missing → `0`; dimension fields missing → `NULL`.
+
+## A6. Normalized channel mapping (attribution-ready)
+
+`mapAppStoreSourceToChannel(sourceType, sourceInfo)` maps Apple's `Source Type` (+ `Source Info`) to the canonical taxonomy at ingest:
+
+| Apple Source Type | Canonical `channel` |
+|---|---|
+| App Store Search | `app_store_search` *(bundles ORGANIC keyword search AND Apple Search Ads — split later via ASA join)* |
+| App Store Browse | `app_store_browse` |
+| App Referrer | `app_referrer` |
+| Web Referrer | `web_referrer` |
+| App Clip | `app_clip` |
+| Institutional Purchase | `institutional` |
+| Unavailable / blank | `unavailable` |
+| anything else | `other` |
+
+Same canonical vocabulary as the future unified fact → these rows join to marketing spend without re-ingestion. **App Store "Search" is never treated as fully organic** — it's split into ASA-paid vs organic only once Apple Ads campaign data is joined (later phase); until then it carries `app_store_search` and the UI annotates the caveat.
+
+## A7. The `Growth > App Store` page
+
+**Route:** `OPS-Web/src/app/admin/app-store/page.tsx` (async RSC) + `app-store/_components/app-store-content.tsx` (`'use client'`, TanStack Query). Modeled on `/admin/app-analytics`, **not** `/admin/analytics` (which is GA4 website traffic). Auth inherits the `admin/layout.tsx` `isAdminEmail()` gate.
+
+> **UI build runs through the design-skill stack** — `frontend-design` + `interface-design`/`ui-ux-pro-max` + `ops-design` token reads + `wireframe`, with all copy via `ops-copywriter`. Visuals are not improvised here.
+
+### A7.0 Data fetch & cache pattern
+- Query fns in `OPS-Web/src/lib/admin/app-store-queries.ts`, each using `getAdminSupabase()` wrapped in `unstable_cache(fn, [key, ...args], { revalidate: 300 })`.
+- **Fix the known app-analytics sharp edge:** include `from`, `to`, and `granularity` **in the cache key array** so dated variants don't collide (app-analytics omits args — do not replicate that bug; a test guards it).
+- RSC fetches the default (last 30 days, daily) via `Promise.all` over the cached fns in a `try/catch` that renders error + stack (matching app-analytics/revenue). Results pass to the client as `initialData`; client `useQuery` seeds `initialData` only when params match the RSC default.
+
+### A7.1 Header
+`AdminPageHeader`, cakemono title `APP STORE`, mono caption `[ APP STORE CONNECT · ACQUISITION FUNNEL ]`, and `COMPLETE THROUGH {finalized_date}` (= `current_date - 2`) with provisional days flagged.
+
+### A7.2 Controls
+`DateRangeControl` + `useDateRange` (presets today/7d/14d/30d/90d/12m/all with `AUTO_GRANULARITY` + override). Daily default; weekly/monthly bucketing via `bucketize()`/`bucketizeAggregate()` from `date-utils.ts`.
+
+### A7.3 KPI tiles (`StatCard` row, server-rendered)
+Four tiles, each with period-over-period delta (current vs immediately-preceding equal-length range), trend arrow, inline `Sparkline`. Numbers JetBrains Mono, tabular, formatted; empty = `—`.
+1. **Conversion Rate** — `total_downloads / unique_impressions` over the range (from `asc_conversion_daily`). Hero metric; tooltip "Apple formula, excludes pre-orders."
+2. **Impressions** — sum `unique_counts` where engagement = impression.
+3. **Product Page Views** — sum `counts` where engagement = product page view.
+4. **Downloads** — sum total downloads.
+
+### A7.4 Conversion-rate hero chart
+`AdminLineChart` of daily `conversion_rate`. Provisional (last-2-day) points dashed/muted with the +2-day tooltip. The centerpiece.
+
+### A7.5 Traffic chart
+`AdminLineChart` (or stacked area via `stacked-bar-chart.tsx`) of **impressions vs product page views vs downloads** over time. Optionally a `FunnelChart` (impressions → product page views → downloads) for the range showing drop-off %.
+
+### A7.6 Source breakdown
+`AdminDonutChart` of downloads by normalized `channel` for the range. Legend uses canonical labels; "App Store Search" carries an "(includes Apple Search Ads)" footnote.
+
+### A7.7 Territory table
+`SortableTableHeader` + `useSortState`: rows = territory; columns = Impressions, Product Page Views, Downloads, Conversion Rate, each with an inline `Sparkline`. Default sort: Downloads desc. Verbs stay out of the scan surface (read table).
+
+### A7.8 States
+- **SETUP REQUIRED** — `isAppStoreConfigured()` false: mirror the Google Ads setup card with what to add.
+- **AWAITING FIRST APPLE REPORT** — configured but no facts yet **and no instance has reached `processed` state**. Driven by the `asc_report_instances` state machine, **not** a hard <48 h clock, so a slightly-late first Apple report never renders as an error. Calm telemetry-style panel ("Apple generates the first report 24–48 h after connection"). Copy via `ops-copywriter`.
+- **Provisional banner** — when the range's right edge is within 2 days, a quiet inline note that the last two days are preliminary.
+
+### A7.9 Design-system compliance
+- Reuse existing chart wrappers but **replace the stale `fontFamily: 'Kosugi'` axis-tick references** in `line-chart.tsx`/`bar-chart.tsx` with the current mono token (JetBrains Mono / `font-mono`), and trace hardcoded hexes to design-system rules. **Accent on a data series is a leak** — accent is user-customizable; verify at runtime that data series use the neutral data palette, not `--ops-accent`.
+- All copy through `ops-copywriter`: terse/tactical, sentence case for content, UPPERCASE for authority, no emoji, no exclamation points, `—` for empty.
+
+### A7.10 Navigation registration
+Add to the **GROWTH** section of `_components/sidebar.tsx` (a GROWTH section already holds ACQUISITION/GOOGLE ADS/A-B TESTING/ONBOARDING — this is an acquisition surface, so GROWTH is the coherent IA, after GOOGLE ADS):
+```ts
+{ type: "item", href: "/admin/app-store", label: "APP STORE" },
+```
+
+## A8. API routes
+
+Under `OPS-Web/src/app/api/admin/app-store/`, uniform shape:
+```ts
+export const GET = withAdmin(async (req) => {
+  await requireAdmin(req);
+  const { from, to, granularity } = parseRange(req); // defaults: 30d / daily
+  const data = await <cachedQueryFn>(from, to, granularity);
+  return NextResponse.json({ data });
+});
+```
+Routes: `kpis`, `conversion-series`, `traffic-series`, `source-breakdown`, `territories`. Client unwraps `res.json().data`. Auth via shared `requireAdmin`/`withAdmin` (401 no email, 403 not in `admins`, 500 uncaught).
+
+Cron: `OPS-Web/src/app/api/cron/app-store-sync/route.ts` (`maxDuration = 60`, `Bearer ${CRON_SECRET}` guard, writes the `app-store-sync` row to `asc_sync_status` via an `updateAscSyncStatus` helper mirroring the ads one — running/complete/failed + last_synced_date + error).
+
+## A9. Testing plan
+
+**Unit (Vitest):**
+1. **Header-name parser** — fixtures with (a) documented header order, (b) reordered columns, (c) renamed + unknown extra column. Facts map correctly in all three; unknown column survives in `raw`. (Highest value — column drift is the #1 risk.)
+2. **`mapAppStoreSourceToChannel`** — every source type → expected channel, incl. blank/unknown.
+3. **Conversion view math** — seeded impressions/downloads → expected `conversion_rate` + null-on-zero-denominator.
+4. **JWT mint** — `exp ≤ 1200 s`, `aud = appstoreconnect-v1`, `alg = ES256`, `kid`/`iss` present.
+5. **Idempotency, including NULL dimensions** — process the same segment twice (with some NULL dims) → zero duplicate rows (NULLS NOT DISTINCT key + checksum skip); a restated value updates in place.
+6. **Provisional flag** — rows within 2 days flagged, older not (computed at read time).
+
+**Integration (mocked Apple):**
+7. Full 6-step pipeline with recorded fixtures → bookkeeping transitions `discovered → processed`, facts upsert, second run is a no-op except the trailing-3-day re-pull.
+8. **Cron auth** — wrong/empty `CRON_SECRET` → 401; correct → runs.
+9. **429 backoff** — 429 then 200 → backoff + resume, no data loss.
+
+**Page/route:**
+10. **Admin gate** — non-admin → 403 on every `/api/admin/app-store/*`; redirect from `/admin/app-store`.
+11. **Cache key** — assert `from/to/granularity` in the `unstable_cache` key (regression guard).
+12. **States** — not configured → SETUP REQUIRED; configured + no processed instance → AWAITING FIRST REPORT; provisional range → banner.
+
+**Live validation (post-deploy, one-time, gated on Jackson):**
+13. After bootstrap, **download one real segment and byte-confirm header strings**, pin/extend the alias table, **and pin the Unique-Impressions denominator + the download summation rule** (discrete Total row vs first-time+redownload).
+14. Spot-check one date's conversion rate against the App Store Connect dashboard (expect a small delta from privacy noise + the excluded pre-order term; document the expected direction).
+
+---
+
+# PART B — North-Star: Centralized Cross-Channel Attribution
+
+## B1. Thesis (why warehouse-centric, not four dashboards)
+OPS will **not** ask the founder to reconcile Google Ads', Apple's, GA4's, and Meta's self-serving dashboards (summed, ad platforms routinely "drive" 200–250%+ of actual revenue). Instead:
+
+```
+RAW per-channel tables  ->  NORMALIZED fact(s)  ->  ATTRIBUTION model in SQL  ->  ONE founder dashboard
+```
+
+Supabase/Postgres **is** the warehouse. Every channel's claim reconciles against **one revenue source of truth** — Stripe + App Store proceeds, blended — never against ad-platform self-reported conversions.
+
+## B2. What OPS actually has today (honest inventory)
+**Already real:**
+- **Google Ads pipeline** — live REST v23 client, daily cron + 2-year backfill into `ads_daily_account/campaign/keyword/search_term`, an AI briefing. **BUT the developer token is test-only (`DEVELOPER_TOKEN_NOT_APPROVED`); every sync fails; all ads tables are 0 rows.** Code works; data blocked on token approval.
+- **GA4** — GA4 Data API (server) drives `/admin/acquisition`; client `gtag.js` on OPS-Web + ops-site.
+- **Channel/attribution schema** — `trial_attributions` (utm_*/gclid/fbclid/landing_url/trial_started_at/first_paid_at/`attributed_channel`), `ad_spend_log`, `deriveAttributionChannel()`. **But `trial_attributions` has 0 rows** — only a manual admin backfill writes it; live signup paths never do.
+- **iOS** — Firebase Analytics fires `sign_up/login/begin_trial/subscribe/complete_onboarding/create_first_project`. **No AppsFlyer/Adjust/Branch, no AdServices token, no ATT/IDFA.**
+- **`companies.referral_method`** — free-text "how did you hear," the only first-party acquisition signal in the DB — populated for ~7 of 57 companies.
+- **`analytics_events`** — ~8,175 rows, 99.6% iOS, product telemetry, **zero** utm/source/channel keys.
+
+**Net-new:** the App Store connector (Part A); any non-Google ingestion (Meta, ASA); a unified cross-channel fact joining spend → revenue; identity stitching web-click → install → paying-company.
+
+## B3. The identity-stitching reality (told straight)
+- The funnel is **iOS-first** (App Store install) bridged to Firebase; the cross-system id is the **Firebase UID (non-UUID)**; `auth.uid()` is unusable under that bridge.
+- **No UTM/click-id crosses the App Store install boundary** — no SDK carries `gclid`/`fbclid`/utm from a web ad click into the installed app, and no web-visitor ↔ app-user bridge. So **deterministic ad-click → install → paying-company attribution is impossible today** and can't be reconstructed from existing data.
+- **ATT/SKAN:** ~70–75% of iOS users decline tracking; SKAN/AdAttributionKit is **aggregate-only**. Ad platforms never see trial → paid → renewal (it happens in Apple billing days later).
+
+**Deliberate target:** channel-level/aggregate attribution is the guaranteed floor (especially paid iOS); user-level attribution only where genuinely deterministic (web signup → Stripe customer, logged-in web sessions, deferred deep links); **Apple's AdServices token** is the one deterministic install→Apple-Ads-campaign link (requires shipping iOS capture code — later phase); the dark funnel is recovered with a self-reported "How did you hear about us?" on web + iOS onboarding.
+
+> Honest summary for the founder: **OPS can answer "which channels are working" at the channel level reliably, and "which exact ad produced this paying company" only for the web/deterministic slice plus Apple Ads via AdServices. That bar is achievable today and is enough to allocate budget.**
+
+## B4. Warehouse layers
+- **Layer 0 — Raw, per-source** (verbatim, JSONB-preserved): `asc_*` (Part A), `ads_daily_*` (Google), `asa_*` (Apple Search Ads), `meta_*` (conditional), GA4 pulls, `trial_attributions`/`companies.referral_method`, `billing_events`/Stripe + App Store proceeds.
+- **Layer 1 — Normalized facts** (extend, don't rebuild `ad_spend_log`/`trial_attributions`):
+  - **`channel_metrics`** `(date, channel, sub_channel, campaign, territory, metric_type[spend|traffic|impression|click|install], value, currency, source_system, as_of)` — monetary normalized to **integer cents** at ingest (Google micros ÷1e6; Apple/Meta decimals; App Store proceeds).
+  - **`touchpoints`** `(touchpoint_id, occurred_at, identity_key[nullable when aggregate-only], channel, sub_channel, campaign, territory, click_id_set, raw_source)`.
+  - Dims `dim_channel/dim_campaign/dim_date/dim_company`; an enforced **`channel_map`** table (raw source → canonical) as a first-class DB object.
+- **Layer 2 — Attribution model in SQL (model is a dimension, not a migration):** compute every model in parallel at conversion time (`first_touch_credit`, `last_touch_credit`, `paid_aware_last_touch_credit`, `linear_credit`, `position_credit` 40/20/40). **Headline default: paid-aware last-touch.** **No data-driven attribution** at OPS's volume (needs ~100 conversions/channel/month; revisit then). Attribution window matches the real trades sales cycle (weeks-to-months), parameterized via `occurred_at`. Materialized SQL views: `attribution_by_channel`, `attribution_by_campaign`, `cohort_spend_to_revenue`.
+- **Layer 3 — One founder-grade dashboard** (five sections): (1) top-line funnel, (2) channel comparison table — the centerpiece, model selector is a **filter not a recompute**, (3) campaign drill-down (the Part-A App Store screen is the App-Store channel's drill-down), (4) cost + ROAS/CAC **only where spend exists**, (5) cohort/trend. A visible **"attributed vs total revenue" reconciliation bar** against blended Stripe + App Store proceeds makes over-counting impossible to hide.
+
+---
+
+# PART C — Phased Roadmap (dependency order)
+
+Each phase ships value alone and is a brick in the warehouse. All ad/analytics APIs are **free to call** (you pay only ad spend + incidental cloud usage).
+
+- **Phase 1 — App Store Connect connector (this spec).** Daily ASC ingestion → facts + conversion view + the `Growth > App Store` screen, attribution-ready. Depends on nothing built (needs Admin ASC key, adamId, 24–48 h unlock). **~$0.** First because it's net-new, self-contained, useful, and seeds the canonical channel vocabulary.
+- **Phase 2 — Attribution-capture foundation.** Wire first-party signal + the warehouse skeleton: write `trial_attributions` at web company-creation (read existing `__ops_first_touch` cookie + `deriveAttributionChannel()`); make ops-site middleware actually write the first-touch cookie; add "How did you hear about us?" to web + iOS onboarding; have the Stripe webhook stamp `first_paid_at`; stand up `channel_metrics` + `touchpoints` + `channel_map` + parallel credit columns; backfill Phase-1 rows into them. **~$0.** Cheapest, highest-leverage unlock — without capture, every connector has spend but nothing to attribute it to.
+- **Phase 3 — Ads connectors (spend side).** **3a** Unblock + harden Google Ads (apply for Basic/Standard API access — token is test-only today; **start this application now**, ~5 business days). **3b** GA4 Data API as a first-class warehouse source. **3c** Apple Search Ads Campaign Management API (conditional on real ASA spend; lets App Store "Search" split into paid vs organic). **3d** Apple AdServices token capture in iOS (deterministic install→campaign; ships on App Store cadence; only worth it once ASA spend exists). **3e** Meta Marketing API (LAST, conditional on Meta ads existing; mind the Jan 12 2026 view-window/retention cutover). Each free to call; pay only ad spend.
+- **Phase 4 — Unified cross-channel attribution screen (north-star).** The five-section founder dashboard + model selector (paid-aware last-touch default) + reconciliation bar. Built once; lights up channels as Phase 3 connectors fill `channel_metrics`. Depends on Phase 2 + ≥ 3a/3b. **~$0** (no paid ELT/attribution vendor proposed; any such cost goes to Jackson first).
+
+**Critical path:** start *now in parallel* — Phase 1 build **+** the Google Ads Basic-access token application (3a's ~5-day gate) **+** Phase 2 web/site capture wiring (independent). Phase 4's UI shell can begin once Phase 2 facts exist.
+
+---
+
+# PART D — Canonical Channel Taxonomy
+
+Every connector normalizes into this shared vocabulary:
+
+`app_store_search`, `app_store_browse`, `app_referrer`, `web_referrer`, `app_clip`, `institutional`, `unavailable`, `google_ads`, `apple_search_ads`, `meta_ads`, `organic_search`, `organic_social`, `paid_social`, `email`, `direct`, `referral`, `other`.
+
+---
+
+# PART E — Open Questions for Jackson
+
+1. **Attribution model** — confirm **paid-aware last-touch** as the headline default (computed alongside first-touch + position-based 40/20/40), data-driven explicitly deferred until ~100+ conversions/channel/month. (Recommended yes — early numbers will be rule-based, not algorithmic.)
+2. **Meta ads?** — does OPS run Meta ads at all? (No Meta API client exists; `meta_ads` is manual-entry only.) If no, Phase 3e is skipped until it does.
+3. **Apple Search Ads?** — does OPS run ASA with real spend? (ASA is a string literal today — no client, no AdServices capture.) Phases 3c/3d are conditional on real ASA spend.
+4. **Add UTM/source capture at signup NOW (Phase 2)?** — cheap wiring of existing primitives, the single highest-leverage unlock for all future attribution, but it touches the live signup path (`/api/auth/sync-user`, `create_company_for_owner`) and ops-site middleware. Approve proceeding in parallel with Phase 1?
+5. **Start the Google Ads Basic/Standard API access application now?** — token is test-only (every sync fails); approval ~5 business days; nothing in the Google slice produces data until it lands. (Recommended: start in parallel with Phase 1.)
+6. **ASC key + adamId** — Jackson generates an **Admin-role** ASC API key (download the `.p8` once) and provides `ASC_APP_ID`. Confirm who has App Store Connect Admin access to do this.
+7. **"How did you hear about us?" on iOS onboarding** — web has `companies.referral_method` (7/57 filled). Adding it to iOS onboarding ships on the App Store release cadence and adds an onboarding step. Acceptable given the OPS "invisible helpfulness" bar? (Recommended: one optional, skippable field.)
+8. **Pre-orders** — Apple's true conversion formula includes pre-orders (a separate third report, out of Phase 1). **Confirm whether the app has *ever* used App Store pre-orders.** If unconfirmed, the conversion view's "minus pre-order term" caveat stays visible (we do not assume zero).
+9. **Screen placement** — confirm `Growth > App Store` (recommended — a GROWTH section already exists and this is an acquisition surface) vs the ANALYTICS section.
+10. **Migration posture** — per the low-tenant prod policy, the additive ASC migration could go directly to prod after read-only recon + sign-off. Confirm direct prod application (with explicit go-ahead) vs staging elsewhere.

--- a/src/app/admin/_components/charts/bar-chart.tsx
+++ b/src/app/admin/_components/charts/bar-chart.tsx
@@ -36,12 +36,12 @@ export function AdminBarChart({
         <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" vertical={false} />
         <XAxis
           dataKey="name"
-          tick={{ fill: "#6B6B6B", fontFamily: "Kosugi", fontSize: 11 }}
+          tick={{ fill: "#6B6B6B", fontFamily: "JetBrains Mono", fontSize: 11 }}
           axisLine={false}
           tickLine={false}
         />
         <YAxis
-          tick={{ fill: "#6B6B6B", fontFamily: "Kosugi", fontSize: 11 }}
+          tick={{ fill: "#6B6B6B", fontFamily: "JetBrains Mono", fontSize: 11 }}
           axisLine={false}
           tickLine={false}
         />

--- a/src/app/admin/_components/charts/line-chart.tsx
+++ b/src/app/admin/_components/charts/line-chart.tsx
@@ -49,12 +49,12 @@ export function AdminLineChart({
         <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" vertical={false} />
         <XAxis
           dataKey="name"
-          tick={{ fill: "#6B6B6B", fontFamily: "Kosugi", fontSize: 11 }}
+          tick={{ fill: "#6B6B6B", fontFamily: "JetBrains Mono", fontSize: 11 }}
           axisLine={false}
           tickLine={false}
         />
         <YAxis
-          tick={{ fill: "#6B6B6B", fontFamily: "Kosugi", fontSize: 11 }}
+          tick={{ fill: "#6B6B6B", fontFamily: "JetBrains Mono", fontSize: 11 }}
           axisLine={false}
           tickLine={false}
         />

--- a/src/app/admin/_components/charts/stacked-bar-chart.tsx
+++ b/src/app/admin/_components/charts/stacked-bar-chart.tsx
@@ -42,12 +42,12 @@ export function StackedBarChart({ data, isLoading, onBarClick }: StackedBarChart
         <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" vertical={false} />
         <XAxis
           dataKey="name"
-          tick={{ fill: "#6B6B6B", fontFamily: "Kosugi", fontSize: 11 }}
+          tick={{ fill: "#6B6B6B", fontFamily: "JetBrains Mono", fontSize: 11 }}
           axisLine={false}
           tickLine={false}
         />
         <YAxis
-          tick={{ fill: "#6B6B6B", fontFamily: "Kosugi", fontSize: 11 }}
+          tick={{ fill: "#6B6B6B", fontFamily: "JetBrains Mono", fontSize: 11 }}
           axisLine={false}
           tickLine={false}
         />

--- a/src/app/admin/_components/sidebar.tsx
+++ b/src/app/admin/_components/sidebar.tsx
@@ -12,6 +12,7 @@ const NAV_ITEMS: NavEntry[] = [
   { type: "section", label: "GROWTH" },
   { type: "item", href: "/admin/acquisition", label: "ACQUISITION" },
   { type: "item", href: "/admin/google-ads", label: "GOOGLE ADS" },
+  { type: "item", href: "/admin/app-store", label: "APP STORE" },
   { type: "item", href: "/admin/ab-testing", label: "A/B TESTING" },
   { type: "item", href: "/admin/onboarding", label: "ONBOARDING" },
 

--- a/src/app/admin/app-store/_components/app-store-content.tsx
+++ b/src/app/admin/app-store/_components/app-store-content.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { DateRangeControl } from "@/app/admin/_components/date-range-control";
+import { StatCard } from "@/app/admin/_components/stat-card";
+import { AdminLineChart } from "@/app/admin/_components/charts/line-chart";
+import { AdminDonutChart } from "@/app/admin/_components/charts/donut-chart";
+import { FunnelChart } from "@/app/admin/_components/charts/funnel-chart";
+import { Sparkline } from "@/app/admin/_components/sparkline";
+import { SortableTableHeader, useSortState } from "@/app/admin/_components/sortable-table-header";
+import type { ChartDataPoint, DonutSegment, Granularity } from "@/lib/admin/types";
+import type { AscKpis, AscTrafficSeries, AscTerritoryRow } from "@/lib/admin/app-store-queries";
+
+// Neutral data line — the steel-blue accent (#6F94B0) is reserved for CTA/focus,
+// never a data series.
+const LINE = "#B5B5B5";
+
+const CHANNEL_LABELS: Record<string, string> = {
+  app_store_search: "App Store Search",
+  app_store_browse: "App Store Browse",
+  app_referrer: "App Referrer",
+  web_referrer: "Web Referrer",
+  app_clip: "App Clip",
+  institutional: "Institutional",
+  unavailable: "Unavailable",
+  other: "Other",
+  unknown: "Unknown",
+};
+
+interface Range {
+  from: string;
+  to: string;
+  granularity: Granularity;
+}
+interface Initial extends Range {
+  kpis: AscKpis;
+  conversion: ChartDataPoint[];
+  traffic: AscTrafficSeries;
+  source: DonutSegment[];
+  territories: AscTerritoryRow[];
+}
+
+const fmtInt = (n: number) => n.toLocaleString("en-US");
+const fmtPct = (r: number | null) => (r == null ? "—" : `${(r * 100).toFixed(2)}%`);
+
+function trendOf(cur: number | null, prev: number | null) {
+  if (cur == null || prev == null || prev === 0) return undefined;
+  const pct = Math.round(((cur - prev) / prev) * 100);
+  return { direction: pct > 0 ? "up" : pct < 0 ? "down" : "flat", value: `${pct > 0 ? "+" : ""}${pct}%` } as const;
+}
+
+async function fetchData<T>(path: string, r: Range): Promise<T> {
+  const u = new URLSearchParams({ from: r.from, to: r.to, granularity: r.granularity });
+  const res = await fetch(`/api/admin/app-store/${path}?${u.toString()}`);
+  if (!res.ok) throw new Error(`${path} -> ${res.status}`);
+  return (await res.json()).data as T;
+}
+
+function Panel({ title, note, children }: { title: string; note?: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-[10px] border border-white/[0.09] bg-[#121214]/60 p-5">
+      <div className="mb-4 flex items-baseline justify-between">
+        <p className="font-mono text-[11px] uppercase tracking-wider text-[#8A8A8A]">// {title}</p>
+        {note && <p className="font-mono text-[10px] text-[#6A6A6A]">{note}</p>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function AppStoreContent({ initial }: { initial: Initial }) {
+  const [range, setRange] = useState<Range>({ from: initial.from, to: initial.to, granularity: initial.granularity });
+  const isDefault =
+    range.from === initial.from && range.to === initial.to && range.granularity === initial.granularity;
+  const seed = <T,>(v: T) => (isDefault ? v : undefined);
+
+  const kpis =
+    useQuery({ queryKey: ["asc-kpis", range], queryFn: () => fetchData<AscKpis>("kpis", range), initialData: seed(initial.kpis), staleTime: 300_000 }).data ?? initial.kpis;
+  const conversion =
+    useQuery({ queryKey: ["asc-conv", range], queryFn: () => fetchData<ChartDataPoint[]>("conversion-series", range), initialData: seed(initial.conversion), staleTime: 300_000 }).data ?? [];
+  const traffic =
+    useQuery({ queryKey: ["asc-traffic", range], queryFn: () => fetchData<AscTrafficSeries>("traffic-series", range), initialData: seed(initial.traffic), staleTime: 300_000 }).data ?? initial.traffic;
+  const source =
+    useQuery({ queryKey: ["asc-source", range], queryFn: () => fetchData<DonutSegment[]>("source-breakdown", range), initialData: seed(initial.source), staleTime: 300_000 }).data ?? [];
+  const territories =
+    useQuery({ queryKey: ["asc-territories", range], queryFn: () => fetchData<AscTerritoryRow[]>("territories", range), initialData: seed(initial.territories), staleTime: 300_000 }).data ?? [];
+
+  const { sort, toggle, sorted } = useSortState("downloads", "desc");
+  const sortedTerritories = sorted(territories as unknown as Record<string, unknown>[]) as unknown as AscTerritoryRow[];
+
+  const convChart = conversion.map((p) => ({ label: p.label, value: Number((p.value * 100).toFixed(2)) }));
+  const donut = source.map((s) => ({ ...s, name: CHANNEL_LABELS[s.name] ?? s.name }));
+  const showProvisional = Date.now() - new Date(range.to).getTime() < 2 * 86_400_000;
+
+  return (
+    <div className="space-y-6 p-8">
+      <div className="flex items-center justify-between">
+        <p className="font-mono text-[11px] uppercase tracking-wider text-[#6A6A6A]">
+          [ COMPLETE THROUGH {kpis.finalizedThrough} ]
+        </p>
+        <DateRangeControl
+          defaultPreset="30d"
+          showGranularity
+          onChange={(p) => setRange({ from: p.from, to: p.to, granularity: p.granularity })}
+        />
+      </div>
+
+      {showProvisional && (
+        <p className="font-mono text-[10px] text-[#6A6A6A]">
+          // last 2 days preliminary — Apple finalizes data at +2 days
+        </p>
+      )}
+
+      {/* KPI row */}
+      <div className="grid grid-cols-4 gap-4">
+        <StatCard
+          label="Conversion Rate"
+          value={fmtPct(kpis.conversionRate)}
+          caption="downloads ÷ unique impressions"
+          trend={trendOf(kpis.conversionRate, kpis.prev.conversionRate)}
+          sparklineData={convChart}
+        />
+        <StatCard
+          label="Impressions"
+          value={fmtInt(kpis.impressions)}
+          caption="unique devices"
+          trend={trendOf(kpis.impressions, kpis.prev.impressions)}
+          sparklineData={traffic.impressions}
+        />
+        <StatCard
+          label="Product Page Views"
+          value={fmtInt(kpis.pageViews)}
+          caption="store listing views"
+          trend={trendOf(kpis.pageViews, kpis.prev.pageViews)}
+          sparklineData={traffic.pageViews}
+        />
+        <StatCard
+          label="Downloads"
+          value={fmtInt(kpis.downloads)}
+          caption="first-time + redownloads"
+          trend={trendOf(kpis.downloads, kpis.prev.downloads)}
+          sparklineData={traffic.downloads}
+        />
+      </div>
+
+      {/* Conversion hero */}
+      <Panel title="CONVERSION RATE" note="% over time">
+        <AdminLineChart data={convChart} color={LINE} height={240} />
+      </Panel>
+
+      {/* Funnel + Source */}
+      <div className="grid grid-cols-2 gap-4">
+        <Panel title="ACQUISITION FUNNEL">
+          <FunnelChart
+            steps={[
+              { step: "Impressions", count: kpis.impressions },
+              { step: "Product Page Views", count: kpis.pageViews },
+              { step: "Downloads", count: kpis.downloads },
+            ]}
+          />
+        </Panel>
+        <Panel title="SOURCE" note="App Store Search includes Apple Search Ads">
+          {donut.length > 0 ? (
+            <AdminDonutChart data={donut} />
+          ) : (
+            <p className="py-12 text-center font-mono text-[12px] text-[#6A6A6A]">—</p>
+          )}
+        </Panel>
+      </div>
+
+      {/* Downloads over time */}
+      <Panel title="DOWNLOADS OVER TIME">
+        <AdminLineChart data={traffic.downloads} color={LINE} height={200} />
+      </Panel>
+
+      {/* Territory table */}
+      <Panel title="TERRITORY">
+        <table className="w-full">
+          <SortableTableHeader
+            columns={[
+              { key: "territory", label: "TERRITORY" },
+              { key: "impressions", label: "IMPRESSIONS" },
+              { key: "pageViews", label: "PAGE VIEWS" },
+              { key: "downloads", label: "DOWNLOADS" },
+              { key: "conversionRate", label: "CONVERSION" },
+              { key: "spark", label: "TREND", sortable: false },
+            ]}
+            sort={sort}
+            onSort={toggle}
+          />
+          <tbody>
+            {sortedTerritories.length === 0 && (
+              <tr>
+                <td colSpan={6} className="py-8 text-center font-mono text-[12px] text-[#6A6A6A]">—</td>
+              </tr>
+            )}
+            {sortedTerritories.map((t) => (
+              <tr key={t.territory} className="border-t border-white/[0.06]">
+                <td className="py-2 text-[13px] text-[#EDEDED]">{t.territory}</td>
+                <td className="py-2 font-mono text-[13px] tabular-nums text-[#B5B5B5]">{fmtInt(t.impressions)}</td>
+                <td className="py-2 font-mono text-[13px] tabular-nums text-[#B5B5B5]">{fmtInt(t.pageViews)}</td>
+                <td className="py-2 font-mono text-[13px] tabular-nums text-[#EDEDED]">{fmtInt(t.downloads)}</td>
+                <td className="py-2 font-mono text-[13px] tabular-nums text-[#B5B5B5]">{fmtPct(t.conversionRate)}</td>
+                <td className="py-2">
+                  <Sparkline data={t.sparkline} color={LINE} height={28} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Panel>
+    </div>
+  );
+}

--- a/src/app/admin/app-store/page.tsx
+++ b/src/app/admin/app-store/page.tsx
@@ -1,0 +1,93 @@
+import { AdminPageHeader } from "@/app/admin/_components/admin-page-header";
+import { isAppStoreConfigured } from "@/lib/analytics/app-store-client";
+import {
+  getAscKpis,
+  getAscConversionSeries,
+  getAscTrafficSeries,
+  getAscSourceBreakdown,
+  getAscTerritories,
+  getAscIngestState,
+} from "@/lib/admin/app-store-queries";
+import { AppStoreContent } from "./_components/app-store-content";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_DAYS = 30;
+
+function defaultRange() {
+  const to = new Date().toISOString();
+  const from = new Date(Date.now() - DEFAULT_DAYS * 86_400_000).toISOString();
+  return { from, to, granularity: "daily" as const };
+}
+
+function StatePanel({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="p-8">
+      <div className="max-w-xl rounded-[10px] border border-white/[0.09] bg-[#121214]/60 p-6">
+        <p className="font-mono text-[11px] uppercase tracking-wider text-[#8A8A8A]">// {title}</p>
+        <p className="mt-3 text-[14px] leading-relaxed text-[#B5B5B5]">{body}</p>
+      </div>
+    </div>
+  );
+}
+
+export default async function AppStorePage() {
+  const configured = isAppStoreConfigured();
+  const ingest = await getAscIngestState(configured);
+
+  if (!configured) {
+    return (
+      <div>
+        <AdminPageHeader title="APP STORE" caption="APP STORE CONNECT · ACQUISITION FUNNEL" />
+        <StatePanel
+          title="SETUP REQUIRED"
+          body="Connect App Store Connect to pull live conversion data. Add the API key, issuer ID, private key, and numeric app ID to the environment, then the daily sync takes over."
+        />
+      </div>
+    );
+  }
+
+  if (!ingest.hasFacts && !ingest.hasProcessedInstance) {
+    return (
+      <div>
+        <AdminPageHeader title="APP STORE" caption="APP STORE CONNECT · ACQUISITION FUNNEL" />
+        <StatePanel
+          title="AWAITING FIRST REPORT"
+          body="Connected. Apple generates the first analytics report 24 to 48 hours after connection. Data lands automatically — nothing else to do."
+        />
+      </div>
+    );
+  }
+
+  const range = defaultRange();
+  let initial;
+  try {
+    const [kpis, conversion, traffic, source, territories] = await Promise.all([
+      getAscKpis(range.from, range.to),
+      getAscConversionSeries(range.from, range.to, range.granularity),
+      getAscTrafficSeries(range.from, range.to, range.granularity),
+      getAscSourceBreakdown(range.from, range.to),
+      getAscTerritories(range.from, range.to, range.granularity),
+    ]);
+    initial = { ...range, kpis, conversion, traffic, source, territories };
+  } catch (err: unknown) {
+    return (
+      <div>
+        <AdminPageHeader title="APP STORE" caption="APP STORE CONNECT · ACQUISITION FUNNEL" />
+        <div className="p-8">
+          <h1 className="mb-4 font-mono text-[13px] text-[#B58289]">App Store data fetch failed</h1>
+          <pre className="whitespace-pre-wrap rounded-[10px] bg-white/[0.05] p-4 text-[12px] text-[#EDEDED]">
+            {err instanceof Error ? `${err.message}\n\n${err.stack}` : String(err)}
+          </pre>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <AdminPageHeader title="APP STORE" caption="APP STORE CONNECT · ACQUISITION FUNNEL" />
+      <AppStoreContent initial={initial} />
+    </div>
+  );
+}

--- a/src/app/api/admin/app-store/conversion-series/route.ts
+++ b/src/app/api/admin/app-store/conversion-series/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { parseRange } from "@/lib/admin/app-store-range";
+import { getAscConversionSeries } from "@/lib/admin/app-store-queries";
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+  const { from, to, granularity } = parseRange(req);
+  const data = await getAscConversionSeries(from, to, granularity);
+  return NextResponse.json({ data });
+});

--- a/src/app/api/admin/app-store/kpis/route.ts
+++ b/src/app/api/admin/app-store/kpis/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { parseRange } from "@/lib/admin/app-store-range";
+import { getAscKpis } from "@/lib/admin/app-store-queries";
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+  const { from, to } = parseRange(req);
+  const data = await getAscKpis(from, to);
+  return NextResponse.json({ data });
+});

--- a/src/app/api/admin/app-store/source-breakdown/route.ts
+++ b/src/app/api/admin/app-store/source-breakdown/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { parseRange } from "@/lib/admin/app-store-range";
+import { getAscSourceBreakdown } from "@/lib/admin/app-store-queries";
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+  const { from, to } = parseRange(req);
+  const data = await getAscSourceBreakdown(from, to);
+  return NextResponse.json({ data });
+});

--- a/src/app/api/admin/app-store/territories/route.ts
+++ b/src/app/api/admin/app-store/territories/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { parseRange } from "@/lib/admin/app-store-range";
+import { getAscTerritories } from "@/lib/admin/app-store-queries";
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+  const { from, to, granularity } = parseRange(req);
+  const data = await getAscTerritories(from, to, granularity);
+  return NextResponse.json({ data });
+});

--- a/src/app/api/admin/app-store/traffic-series/route.ts
+++ b/src/app/api/admin/app-store/traffic-series/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdmin, requireAdmin } from "@/lib/admin/api-auth";
+import { parseRange } from "@/lib/admin/app-store-range";
+import { getAscTrafficSeries } from "@/lib/admin/app-store-queries";
+
+export const GET = withAdmin(async (req: NextRequest) => {
+  await requireAdmin(req);
+  const { from, to, granularity } = parseRange(req);
+  const data = await getAscTrafficSeries(from, to, granularity);
+  return NextResponse.json({ data });
+});

--- a/src/app/api/cron/app-store-sync/route.ts
+++ b/src/app/api/cron/app-store-sync/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isAppStoreConfigured } from "@/lib/analytics/app-store-client";
+import { bootstrapIfNeeded, syncOnce } from "@/lib/admin/app-store-sync";
+import { updateAscSyncStatus } from "@/lib/admin/app-store-queries";
+
+export const maxDuration = 60;
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!isAppStoreConfigured()) {
+    return NextResponse.json({ skipped: true, reason: "App Store Connect not configured" });
+  }
+
+  try {
+    await updateAscSyncStatus("app-store-sync", { status: "running", error: null });
+    await bootstrapIfNeeded();
+    const result = await syncOnce();
+    await updateAscSyncStatus("app-store-sync", {
+      status: "complete",
+      last_synced_date: result.lastDate,
+      error: null,
+    });
+    return NextResponse.json({ status: "synced", ...result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await updateAscSyncStatus("app-store-sync", { status: "failed", error: message });
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/lib/admin/app-store-queries.ts
+++ b/src/lib/admin/app-store-queries.ts
@@ -1,0 +1,259 @@
+import { unstable_cache } from "next/cache";
+import { getAdminSupabase } from "@/lib/supabase/admin-client";
+import { bucketizeAggregate } from "@/lib/admin/date-utils";
+import type { Granularity, ChartDataPoint, DonutSegment } from "@/lib/admin/types";
+
+const db = () => getAdminSupabase();
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface AscSyncStatus {
+  job_name: string;
+  status: "idle" | "running" | "complete" | "failed";
+  last_synced_date: string | null;
+  last_run_at: string | null;
+  error: string | null;
+}
+
+export interface AscKpis {
+  conversionRate: number | null;
+  impressions: number;
+  pageViews: number;
+  downloads: number;
+  prev: { conversionRate: number | null; impressions: number; pageViews: number; downloads: number };
+  finalizedThrough: string; // current_date - 2 (YYYY-MM-DD)
+  hasData: boolean;
+}
+
+export interface AscTrafficSeries {
+  impressions: ChartDataPoint[];
+  pageViews: ChartDataPoint[];
+  downloads: ChartDataPoint[];
+}
+
+export interface AscTerritoryRow {
+  territory: string;
+  impressions: number;
+  pageViews: number;
+  downloads: number;
+  conversionRate: number | null;
+  sparkline: ChartDataPoint[];
+}
+
+export interface AscIngestState {
+  configured: boolean;
+  hasFacts: boolean;
+  hasProcessedInstance: boolean;
+  bootstrapAt: string | null;
+}
+
+// Neutral data palette — never the steel-blue accent (#6F94B0 is CTA/focus only).
+const DATA_PALETTE = ["#B5B5B5", "#9DB582", "#C4A868", "#B58289", "#8A8A8A", "#6A6A6A", "#EDEDED"];
+
+// ─── Sync status (mirrors ads_sync_status helpers) ───────────────────────────
+
+export async function getAscSyncStatus(job = "app-store-sync"): Promise<AscSyncStatus | null> {
+  const { data } = await db().from("asc_sync_status").select("*").eq("job_name", job).maybeSingle();
+  return (data as AscSyncStatus | null) ?? null;
+}
+
+export async function updateAscSyncStatus(
+  job: string,
+  patch: Partial<Omit<AscSyncStatus, "job_name">>,
+): Promise<void> {
+  await db()
+    .from("asc_sync_status")
+    .upsert(
+      { job_name: job, ...patch, last_run_at: new Date().toISOString(), updated_at: new Date().toISOString() },
+      { onConflict: "job_name" },
+    );
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Cache key that ALWAYS includes the dynamic args (never collide dated variants). */
+export function ascCacheKey(...parts: (string | number)[]): string[] {
+  return ["asc", ...parts.map(String)];
+}
+
+function toDate(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+/** Most recent finalized reporting date = today - 2 (UTC), as YYYY-MM-DD. */
+function finalizedThrough(): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 2);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Immediately-preceding range of equal length (for period-over-period deltas). */
+function prevRange(fromIso: string, toIso: string): { from: string; to: string } {
+  const from = new Date(fromIso).getTime();
+  const to = new Date(toIso).getTime();
+  const span = Math.max(to - from, 86_400_000);
+  return { from: new Date(from - span).toISOString(), to: new Date(from - 1).toISOString() };
+}
+
+type ConvRow = { reporting_date: string; unique_impressions: number; total_downloads: number; territory: string | null; channel: string | null };
+type PvRow = { reporting_date: string; counts: number; territory: string | null };
+
+async function fetchConvRows(fromIso: string, toIso: string): Promise<ConvRow[]> {
+  const { data, error } = await db()
+    .from("asc_conversion_daily")
+    .select("reporting_date, unique_impressions, total_downloads, territory, channel")
+    .gte("reporting_date", toDate(fromIso))
+    .lte("reporting_date", toDate(toIso))
+    .limit(100000);
+  if (error) throw new Error(`asc_conversion_daily: ${error.message}`);
+  return (data ?? []) as ConvRow[];
+}
+
+async function fetchPageViewRows(fromIso: string, toIso: string): Promise<PvRow[]> {
+  const { data, error } = await db()
+    .from("asc_discovery_engagement")
+    .select("reporting_date, counts, territory")
+    .ilike("engagement_type", "%page view%")
+    .gte("reporting_date", toDate(fromIso))
+    .lte("reporting_date", toDate(toIso))
+    .limit(100000);
+  if (error) throw new Error(`asc_discovery_engagement: ${error.message}`);
+  return (data ?? []) as PvRow[];
+}
+
+const sum = (rows: { [k: string]: unknown }[], k: string) =>
+  rows.reduce((a, r) => a + (Number(r[k]) || 0), 0);
+
+const rate = (downloads: number, impressions: number): number | null =>
+  impressions > 0 ? downloads / impressions : null;
+
+// ─── KPIs ────────────────────────────────────────────────────────────────────
+
+async function _kpis(fromIso: string, toIso: string): Promise<AscKpis> {
+  const prev = prevRange(fromIso, toIso);
+  const [conv, pv, convPrev, pvPrev] = await Promise.all([
+    fetchConvRows(fromIso, toIso),
+    fetchPageViewRows(fromIso, toIso),
+    fetchConvRows(prev.from, prev.to),
+    fetchPageViewRows(prev.from, prev.to),
+  ]);
+
+  const impressions = sum(conv, "unique_impressions");
+  const downloads = sum(conv, "total_downloads");
+  const pageViews = sum(pv, "counts");
+  const pImp = sum(convPrev, "unique_impressions");
+  const pDl = sum(convPrev, "total_downloads");
+  const pPv = sum(pvPrev, "counts");
+
+  return {
+    conversionRate: rate(downloads, impressions),
+    impressions,
+    pageViews,
+    downloads,
+    prev: { conversionRate: rate(pDl, pImp), impressions: pImp, pageViews: pPv, downloads: pDl },
+    finalizedThrough: finalizedThrough(),
+    hasData: conv.length > 0 || pv.length > 0,
+  };
+}
+
+export const getAscKpis = (from: string, to: string) =>
+  unstable_cache(() => _kpis(from, to), ascCacheKey("kpis", from, to), { revalidate: 300 })();
+
+// ─── Conversion-rate series ──────────────────────────────────────────────────
+
+async function _conversionSeries(fromIso: string, toIso: string, g: Granularity): Promise<ChartDataPoint[]> {
+  const conv = await fetchConvRows(fromIso, toIso);
+  const imp = bucketizeAggregate(conv, fromIso, toIso, g, "reporting_date", "unique_impressions");
+  const dl = bucketizeAggregate(conv, fromIso, toIso, g, "reporting_date", "total_downloads");
+  // bucketize fills every bucket with aligned labels → safe to zip by index.
+  return imp.map((p, i) => ({ label: p.label, value: rate(dl[i]?.value ?? 0, p.value) ?? 0 }));
+}
+
+export const getAscConversionSeries = (from: string, to: string, g: Granularity) =>
+  unstable_cache(() => _conversionSeries(from, to, g), ascCacheKey("conv", from, to, g), { revalidate: 300 })();
+
+// ─── Traffic series (impressions / page views / downloads) ───────────────────
+
+async function _trafficSeries(fromIso: string, toIso: string, g: Granularity): Promise<AscTrafficSeries> {
+  const [conv, pv] = await Promise.all([fetchConvRows(fromIso, toIso), fetchPageViewRows(fromIso, toIso)]);
+  return {
+    impressions: bucketizeAggregate(conv, fromIso, toIso, g, "reporting_date", "unique_impressions"),
+    downloads: bucketizeAggregate(conv, fromIso, toIso, g, "reporting_date", "total_downloads"),
+    pageViews: bucketizeAggregate(pv, fromIso, toIso, g, "reporting_date", "counts"),
+  };
+}
+
+export const getAscTrafficSeries = (from: string, to: string, g: Granularity) =>
+  unstable_cache(() => _trafficSeries(from, to, g), ascCacheKey("traffic", from, to, g), { revalidate: 300 })();
+
+// ─── Source breakdown (downloads by canonical channel) ───────────────────────
+
+async function _sourceBreakdown(fromIso: string, toIso: string): Promise<DonutSegment[]> {
+  const conv = await fetchConvRows(fromIso, toIso);
+  const byChannel = new Map<string, number>();
+  for (const r of conv) {
+    const ch = r.channel ?? "unavailable";
+    byChannel.set(ch, (byChannel.get(ch) ?? 0) + (Number(r.total_downloads) || 0));
+  }
+  return [...byChannel.entries()]
+    .filter(([, v]) => v > 0)
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, value], i) => ({ name, value, color: DATA_PALETTE[i % DATA_PALETTE.length] }));
+}
+
+export const getAscSourceBreakdown = (from: string, to: string) =>
+  unstable_cache(() => _sourceBreakdown(from, to), ascCacheKey("source", from, to), { revalidate: 300 })();
+
+// ─── Territories ─────────────────────────────────────────────────────────────
+
+async function _territories(fromIso: string, toIso: string, g: Granularity): Promise<AscTerritoryRow[]> {
+  const [conv, pv] = await Promise.all([fetchConvRows(fromIso, toIso), fetchPageViewRows(fromIso, toIso)]);
+  const pvByTerritory = new Map<string, PvRow[]>();
+  for (const r of pv) {
+    const t = r.territory ?? "—";
+    (pvByTerritory.get(t) ?? pvByTerritory.set(t, []).get(t)!).push(r);
+  }
+  const convByTerritory = new Map<string, ConvRow[]>();
+  for (const r of conv) {
+    const t = r.territory ?? "—";
+    (convByTerritory.get(t) ?? convByTerritory.set(t, []).get(t)!).push(r);
+  }
+
+  const rows: AscTerritoryRow[] = [];
+  for (const [territory, crows] of convByTerritory) {
+    const impressions = sum(crows, "unique_impressions");
+    const downloads = sum(crows, "total_downloads");
+    const pageViews = sum(pvByTerritory.get(territory) ?? [], "counts");
+    rows.push({
+      territory,
+      impressions,
+      pageViews,
+      downloads,
+      conversionRate: rate(downloads, impressions),
+      sparkline: bucketizeAggregate(crows, fromIso, toIso, g, "reporting_date", "total_downloads"),
+    });
+  }
+  return rows.sort((a, b) => b.downloads - a.downloads);
+}
+
+export const getAscTerritories = (from: string, to: string, g: Granularity) =>
+  unstable_cache(() => _territories(from, to, g), ascCacheKey("territories", from, to, g), { revalidate: 300 })();
+
+// ─── Ingest state (drives SETUP REQUIRED / AWAITING FIRST REPORT panels) ─────
+
+export async function getAscIngestState(configured: boolean): Promise<AscIngestState> {
+  if (!configured) return { configured: false, hasFacts: false, hasProcessedInstance: false, bootstrapAt: null };
+  const client = db();
+  const [de, dl, processed, boot] = await Promise.all([
+    client.from("asc_discovery_engagement").select("id", { count: "exact", head: true }),
+    client.from("asc_downloads").select("id", { count: "exact", head: true }),
+    client.from("asc_report_instances").select("id", { count: "exact", head: true }).eq("state", "processed"),
+    client.from("asc_report_requests").select("created_at").order("created_at", { ascending: true }).limit(1).maybeSingle(),
+  ]);
+  return {
+    configured: true,
+    hasFacts: (de.count ?? 0) > 0 || (dl.count ?? 0) > 0,
+    hasProcessedInstance: (processed.count ?? 0) > 0,
+    bootstrapAt: (boot.data as { created_at: string } | null)?.created_at ?? null,
+  };
+}

--- a/src/lib/admin/app-store-range.ts
+++ b/src/lib/admin/app-store-range.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from "next/server";
+import type { Granularity } from "@/lib/admin/types";
+
+const VALID: Granularity[] = ["hourly", "daily", "weekly", "monthly"];
+
+/** Parse ?from&to&granularity from an admin request; defaults to last 30 days, daily. */
+export function parseRange(req: NextRequest): { from: string; to: string; granularity: Granularity } {
+  const u = new URL(req.url);
+  const to = u.searchParams.get("to") ?? new Date().toISOString();
+  const from = u.searchParams.get("from") ?? new Date(Date.now() - 30 * 86_400_000).toISOString();
+  const g = (u.searchParams.get("granularity") ?? "daily") as Granularity;
+  return { from, to, granularity: VALID.includes(g) ? g : "daily" };
+}

--- a/src/lib/admin/app-store-sync.ts
+++ b/src/lib/admin/app-store-sync.ts
@@ -1,0 +1,301 @@
+import {
+  ascGet,
+  ascPost,
+  downloadSegment,
+  getAscAppId,
+} from "@/lib/analytics/app-store-client";
+import { parseTsv, mapAppStoreSourceToChannel, type ParsedRow } from "@/lib/analytics/app-store-parse";
+import { getAdminSupabase } from "@/lib/supabase/admin-client";
+
+// ─── Apple report categories we ingest in Phase 1 ────────────────────────────
+const CATEGORY_ENGAGEMENT = "APP_STORE_ENGAGEMENT"; // impressions + product page views
+const CATEGORY_COMMERCE = "APP_STORE_COMMERCE"; // downloads
+
+// Header aliases (normalized: lowercase, single-spaced). Canonical name itself is
+// always tried (with underscores → spaces), so only ADDITIONAL aliases go here.
+const ENGAGEMENT_ALIASES: Record<string, string[]> = {
+  reporting_date: ["date"],
+  engagement_type: ["engagement type", "event", "event type"],
+  page_type: ["page type"],
+  source_type: ["source type"],
+  source_info: ["source info", "source"],
+  device: ["device"],
+  platform_version: ["platform version"],
+  territory: ["territory", "country / region", "country/region"],
+  counts: ["counts"],
+  unique_counts: ["unique counts", "unique devices"],
+};
+
+const DOWNLOAD_ALIASES: Record<string, string[]> = {
+  reporting_date: ["date"],
+  download_type: ["download type"],
+  page_type: ["page type"],
+  source_type: ["source type"],
+  source_info: ["source info", "source"],
+  campaign: ["campaign"],
+  device: ["device"],
+  platform_version: ["platform version"],
+  territory: ["territory", "country / region", "country/region"],
+  counts: ["counts", "downloads"],
+  unique_counts: ["unique counts", "unique devices"],
+};
+
+const db = () => getAdminSupabase();
+
+const str = (r: ParsedRow, k: string): string | null => {
+  const v = r[k];
+  return typeof v === "string" && v.length > 0 ? v : null;
+};
+const num = (r: ParsedRow, k: string): number => (typeof r[k] === "number" ? (r[k] as number) : 0);
+
+// ─── Pure transforms (unit-tested) ───────────────────────────────────────────
+
+/** Build the ASC report-request POST body for an app + access type. */
+export function buildReportRequestBody(accessType: "ONGOING" | "ONE_TIME_SNAPSHOT", appId: string) {
+  return {
+    data: {
+      type: "analyticsReportRequests",
+      attributes: { accessType },
+      relationships: { app: { data: { type: "apps", id: appId } } },
+    },
+  };
+}
+
+/** Map a parsed Discovery & Engagement row → asc_discovery_engagement record. */
+export function toEngagementFact(r: ParsedRow, segmentId: string) {
+  const source_type = str(r, "source_type");
+  return {
+    granularity: "DAILY",
+    reporting_date: str(r, "reporting_date"),
+    engagement_type: str(r, "engagement_type"),
+    page_type: str(r, "page_type"),
+    source_type,
+    source_info: str(r, "source_info"),
+    device: str(r, "device"),
+    platform_version: str(r, "platform_version"),
+    territory: str(r, "territory"),
+    channel: mapAppStoreSourceToChannel(source_type, str(r, "source_info")),
+    counts: num(r, "counts"),
+    unique_counts: num(r, "unique_counts"),
+    segment_id: segmentId,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+/** Map a parsed Downloads row → asc_downloads record. */
+export function toDownloadFact(r: ParsedRow, segmentId: string) {
+  const source_type = str(r, "source_type");
+  return {
+    granularity: "DAILY",
+    reporting_date: str(r, "reporting_date"),
+    download_type: str(r, "download_type"),
+    page_type: str(r, "page_type"),
+    source_type,
+    source_info: str(r, "source_info"),
+    campaign: str(r, "campaign"),
+    device: str(r, "device"),
+    platform_version: str(r, "platform_version"),
+    territory: str(r, "territory"),
+    channel: mapAppStoreSourceToChannel(source_type, str(r, "source_info")),
+    counts: num(r, "counts"),
+    unique_counts: num(r, "unique_counts"),
+    segment_id: segmentId,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+const ENGAGEMENT_CONFLICT =
+  "granularity,reporting_date,engagement_type,page_type,source_type,source_info,device,platform_version,territory";
+const DOWNLOAD_CONFLICT =
+  "granularity,reporting_date,download_type,page_type,source_type,source_info,campaign,device,platform_version,territory";
+
+// ─── Bootstrap ───────────────────────────────────────────────────────────────
+
+const SNAPSHOT_COOLDOWN_MS = 31 * 86_400_000;
+
+/**
+ * On first run, register an ONGOING report request (daily forward) and a
+ * ONE_TIME_SNAPSHOT (all history). Idempotent: never duplicates an existing
+ * request, and won't re-fire a snapshot younger than ~31 days.
+ */
+export async function bootstrapIfNeeded(): Promise<void> {
+  const appId = getAscAppId();
+  const client = db();
+  const { data: existing } = await client
+    .from("asc_report_requests")
+    .select("access_type, created_at");
+  const rows = (existing ?? []) as { access_type: string; created_at: string }[];
+
+  if (!rows.some((r) => r.access_type === "ONGOING")) {
+    await createRequest("ONGOING", appId);
+  }
+
+  const snap = rows.find((r) => r.access_type === "ONE_TIME_SNAPSHOT");
+  const snapFresh = snap && Date.now() - new Date(snap.created_at).getTime() < SNAPSHOT_COOLDOWN_MS;
+  if (!snap || !snapFresh) {
+    if (!snap) await createRequest("ONE_TIME_SNAPSHOT", appId);
+  }
+}
+
+async function createRequest(accessType: "ONGOING" | "ONE_TIME_SNAPSHOT", appId: string): Promise<void> {
+  const res = await ascPost<{ data: { id: string } }>(
+    "/v1/analyticsReportRequests",
+    buildReportRequestBody(accessType, appId),
+  );
+  await db().from("asc_report_requests").insert({
+    asc_request_id: res.data.id,
+    app_id: appId,
+    access_type: accessType,
+  });
+}
+
+// ─── Sync ────────────────────────────────────────────────────────────────────
+
+interface ListResponse<A> {
+  data: { id: string; attributes: A }[];
+  links?: { next?: string };
+}
+
+async function listAll<A>(firstPath: string): Promise<{ id: string; attributes: A }[]> {
+  const out: { id: string; attributes: A }[] = [];
+  let next: string | undefined = firstPath;
+  while (next) {
+    const page: ListResponse<A> = await ascGet<ListResponse<A>>(next);
+    out.push(...page.data);
+    next = page.links?.next;
+  }
+  return out;
+}
+
+export interface SyncResult {
+  segmentsProcessed: number;
+  rowsIngested: number;
+  lastDate: string | null;
+}
+
+/**
+ * Run the full pull for every active report request. Idempotent: segments whose
+ * checksum is already processed are skipped; fact upserts (ON CONFLICT DO UPDATE)
+ * absorb Apple's +2-day restatement, so re-pulling recent dates is safe.
+ */
+export async function syncOnce(): Promise<SyncResult> {
+  const client = db();
+  const { data: requests } = await client
+    .from("asc_report_requests")
+    .select("id, asc_request_id, stopped_at")
+    .is("stopped_at", null);
+
+  let segmentsProcessed = 0;
+  let rowsIngested = 0;
+  let lastDate: string | null = null;
+
+  for (const req of (requests ?? []) as { id: string; asc_request_id: string }[]) {
+    for (const [category, kind, aliases, table, conflict] of [
+      [CATEGORY_ENGAGEMENT, "discovery_engagement", ENGAGEMENT_ALIASES, "asc_discovery_engagement", ENGAGEMENT_CONFLICT],
+      [CATEGORY_COMMERCE, "downloads", DOWNLOAD_ALIASES, "asc_downloads", DOWNLOAD_CONFLICT],
+    ] as const) {
+      const reports = await listAll<{ category: string; name?: string }>(
+        `/v1/analyticsReportRequests/${req.asc_request_id}/reports?filter[category]=${category}&limit=200`,
+      );
+      for (const report of reports) {
+        const { data: reportRow } = await client
+          .from("asc_reports")
+          .upsert(
+            { request_id: req.id, asc_report_id: report.id, category, report_name: report.attributes.name ?? null },
+            { onConflict: "asc_report_id" },
+          )
+          .select("id")
+          .single();
+        const reportRowId = (reportRow as { id: string } | null)?.id;
+        if (!reportRowId) continue;
+
+        const instances = await listAll<{ granularity: string; processingDate: string }>(
+          `/v1/analyticsReports/${report.id}/instances?filter[granularity]=DAILY&limit=200`,
+        );
+        for (const inst of instances) {
+          const { data: instRow } = await client
+            .from("asc_report_instances")
+            .upsert(
+              {
+                report_id: reportRowId,
+                asc_instance_id: inst.id,
+                granularity: inst.attributes.granularity ?? "DAILY",
+                processing_date: inst.attributes.processingDate,
+              },
+              { onConflict: "asc_instance_id" },
+            )
+            .select("id")
+            .single();
+          const instRowId = (instRow as { id: string } | null)?.id;
+          if (!instRowId) continue;
+
+          const segments = await listAll<{ checksum: string; sizeInBytes?: number; url: string }>(
+            `/v1/analyticsReportInstances/${inst.id}/segments?limit=200`,
+          );
+          for (const seg of segments) {
+            // Skip already-processed segment (idempotency on checksum).
+            const { data: segExisting } = await client
+              .from("asc_report_segments")
+              .select("id, state")
+              .eq("instance_id", instRowId)
+              .eq("checksum", seg.attributes.checksum)
+              .maybeSingle();
+            if ((segExisting as { state: string } | null)?.state === "processed") continue;
+
+            const { data: segRow } = await client
+              .from("asc_report_segments")
+              .upsert(
+                {
+                  instance_id: instRowId,
+                  checksum: seg.attributes.checksum,
+                  size_bytes: seg.attributes.sizeInBytes ?? null,
+                  url: seg.attributes.url,
+                  state: "discovered",
+                },
+                { onConflict: "instance_id,checksum" },
+              )
+              .select("id")
+              .single();
+            const segRowId = (segRow as { id: string } | null)?.id;
+            if (!segRowId) continue;
+
+            const text = await downloadSegment(seg.attributes.url);
+            const parsed = parseTsv(text, aliases);
+
+            if (parsed.length > 0) {
+              await client.from("asc_raw_rows").insert(
+                parsed.map((r) => ({
+                  segment_id: segRowId,
+                  report_kind: kind,
+                  reporting_date: (r.reporting_date as string) ?? inst.attributes.processingDate,
+                  raw: r.raw,
+                })),
+              );
+              const facts = parsed
+                .map((r) => (kind === "discovery_engagement" ? toEngagementFact(r, segRowId) : toDownloadFact(r, segRowId)))
+                .filter((f) => f.reporting_date);
+              if (facts.length > 0) {
+                await client.from(table).upsert(facts, { onConflict: conflict });
+              }
+              rowsIngested += facts.length;
+            }
+
+            await client
+              .from("asc_report_segments")
+              .update({ state: "processed", rows_ingested: parsed.length, processed_at: new Date().toISOString() })
+              .eq("id", segRowId);
+            await client
+              .from("asc_report_instances")
+              .update({ state: "processed", processed_at: new Date().toISOString() })
+              .eq("id", instRowId);
+
+            segmentsProcessed += 1;
+            if (!lastDate || inst.attributes.processingDate > lastDate) lastDate = inst.attributes.processingDate;
+          }
+        }
+      }
+    }
+  }
+
+  return { segmentsProcessed, rowsIngested, lastDate };
+}

--- a/src/lib/analytics/app-store-client.ts
+++ b/src/lib/analytics/app-store-client.ts
@@ -1,0 +1,97 @@
+import { SignJWT, importPKCS8 } from "jose";
+import { parsePrivateKey } from "@/lib/firebase/parse-private-key";
+
+const ASC_BASE = "https://api.appstoreconnect.apple.com";
+const AUD = "appstoreconnect-v1";
+
+/** True only when all four App Store Connect secrets are present. */
+export function isAppStoreConfigured(): boolean {
+  return !!(
+    process.env.ASC_KEY_ID &&
+    process.env.ASC_ISSUER_ID &&
+    process.env.ASC_PRIVATE_KEY &&
+    process.env.ASC_APP_ID
+  );
+}
+
+/** The numeric App Store app id (adamId) the report request is scoped to. */
+export function getAscAppId(): string {
+  const id = process.env.ASC_APP_ID;
+  if (!id) throw new Error("Missing ASC_APP_ID");
+  return id;
+}
+
+/**
+ * Mint a short-lived ES256 JWT for the App Store Connect API.
+ * exp is 19 minutes out (Apple's hard cap is 20).
+ */
+export async function mintToken(): Promise<string> {
+  const kid = process.env.ASC_KEY_ID;
+  const iss = process.env.ASC_ISSUER_ID;
+  const pem = parsePrivateKey(process.env.ASC_PRIVATE_KEY);
+  if (!kid || !iss || !pem) {
+    throw new Error("App Store Connect not configured (ASC_KEY_ID / ASC_ISSUER_ID / ASC_PRIVATE_KEY)");
+  }
+  const key = await importPKCS8(pem, "ES256");
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({})
+    .setProtectedHeader({ alg: "ES256", kid, typ: "JWT" })
+    .setIssuer(iss)
+    .setIssuedAt(now)
+    .setExpirationTime(now + 1140)
+    .setAudience(AUD)
+    .sign(key);
+}
+
+export interface AscFetchOpts {
+  token?: string;
+}
+
+/** GET an ASC API path (or absolute URL) as JSON. */
+export async function ascGet<T = unknown>(path: string, opts: AscFetchOpts = {}): Promise<T> {
+  const token = opts.token ?? (await mintToken());
+  const url = path.startsWith("http") ? path : `${ASC_BASE}${path}`;
+  const res = await fetchWithBackoff(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`ASC GET ${path} -> ${res.status}: ${await safeText(res)}`);
+  return (await res.json()) as T;
+}
+
+/** POST a body to an ASC API path as JSON. */
+export async function ascPost<T = unknown>(path: string, body: unknown, opts: AscFetchOpts = {}): Promise<T> {
+  const token = opts.token ?? (await mintToken());
+  const res = await fetchWithBackoff(`${ASC_BASE}${path}`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`ASC POST ${path} -> ${res.status}: ${await safeText(res)}`);
+  return (await res.json()) as T;
+}
+
+/** Download a signed segment URL and gunzip it to a UTF-8 string. */
+export async function downloadSegment(url: string): Promise<string> {
+  const res = await fetchWithBackoff(url, {});
+  if (!res.ok) throw new Error(`ASC segment download -> ${res.status}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  const { gunzipSync } = await import("node:zlib");
+  return gunzipSync(buf).toString("utf8");
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return "<no body>";
+  }
+}
+
+/** fetch with exponential backoff + jitter on HTTP 429 (Apple rate limit). */
+async function fetchWithBackoff(url: string, init: RequestInit, attempt = 0): Promise<Response> {
+  const res = await fetch(url, init);
+  if (res.status === 429 && attempt < 4) {
+    const wait = Math.min(2000 * 2 ** attempt, 30_000) + Math.floor(Math.random() * 500);
+    await new Promise((r) => setTimeout(r, wait));
+    return fetchWithBackoff(url, init, attempt + 1);
+  }
+  return res;
+}

--- a/src/lib/analytics/app-store-parse.ts
+++ b/src/lib/analytics/app-store-parse.ts
@@ -1,0 +1,82 @@
+export type AscChannel =
+  | "app_store_search"
+  | "app_store_browse"
+  | "app_referrer"
+  | "web_referrer"
+  | "app_clip"
+  | "institutional"
+  | "unavailable"
+  | "other";
+
+/**
+ * Map Apple's App Store `Source Type` (+ optional `Source Info`) to the canonical
+ * channel taxonomy shared by every connector. App Store "Search" stays a single
+ * channel here; the ASA-paid vs organic split happens later, once Apple Ads
+ * campaign data is joined.
+ */
+export function mapAppStoreSourceToChannel(sourceType: string | null, _info: string | null): AscChannel {
+  const s = (sourceType ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+  if (s === "") return "unavailable";
+  if (s === "app store search") return "app_store_search";
+  if (s === "app store browse") return "app_store_browse";
+  if (s === "app referrer") return "app_referrer";
+  if (s === "web referrer") return "web_referrer";
+  if (s === "app clip") return "app_clip";
+  if (s === "institutional purchase") return "institutional";
+  if (s === "unavailable") return "unavailable";
+  return "other";
+}
+
+const norm = (h: string) => h.trim().toLowerCase().replace(/\s+/g, " ");
+
+/** Canonical column names whose values are numeric (everything else is text). */
+const NUMERIC_CANON = new Set(["counts", "unique_counts"]);
+
+export interface ParsedRow {
+  [canonical: string]: string | number | Record<string, string>;
+  raw: Record<string, string>;
+}
+
+/**
+ * Parse a tab-delimited App Store report into rows keyed by canonical column name.
+ *
+ * Resolves each canonical column by HEADER NAME (never position) so Apple
+ * reordering columns can't corrupt the data, and preserves the full original
+ * header→value map in `raw` so a renamed/added Apple column is never lost.
+ *
+ * @param text     decompressed `.txt` (tab-delimited, first line = header)
+ * @param aliases  canonicalName -> additional normalized header aliases
+ */
+export function parseTsv(text: string, aliases: Record<string, string[]>): ParsedRow[] {
+  const lines = text.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length < 2) return [];
+
+  const headers = lines[0].split("\t").map(norm);
+
+  // canonical -> column index
+  const resolve: Record<string, number> = {};
+  for (const [canon, alist] of Object.entries(aliases)) {
+    const candidates = [norm(canon.replace(/_/g, " ")), ...alist.map(norm)];
+    const idx = headers.findIndex((h) => candidates.includes(h));
+    if (idx >= 0) resolve[canon] = idx;
+  }
+
+  return lines.slice(1).map((line) => {
+    const cells = line.split("\t");
+    const raw: Record<string, string> = {};
+    headers.forEach((h, i) => {
+      raw[h] = cells[i] ?? "";
+    });
+    const out: ParsedRow = { raw };
+    for (const [canon, idx] of Object.entries(resolve)) {
+      const v = (cells[idx] ?? "").trim();
+      out[canon] = NUMERIC_CANON.has(canon) ? parseNum(v) : v;
+    }
+    return out;
+  });
+}
+
+function parseNum(v: string): number {
+  const n = Number(v.replace(/[, ]/g, ""));
+  return Number.isFinite(n) ? n : 0;
+}

--- a/supabase/migrations/20260622000000_app_store_connect_analytics_phase1.sql
+++ b/supabase/migrations/20260622000000_app_store_connect_analytics_phase1.sql
@@ -1,0 +1,161 @@
+-- App Store Connect Analytics — Phase 1 ingestion + facts
+-- Applied to prod (ops-app / ijeekuhbatykdomumfjx) 2026-06-22 via MCP apply_migration.
+-- Additive only. Service-role write, admin-gated server reads only (no client grants).
+-- Provisional is computed at read time (NOT a stored generated column on current_date).
+-- Fact unique constraints use NULLS NOT DISTINCT (Apple emits blank dimensions).
+
+create table if not exists public.asc_report_requests (
+  id              uuid primary key default gen_random_uuid(),
+  asc_request_id  text not null unique,
+  app_id          text not null,
+  access_type     text not null check (access_type in ('ONGOING','ONE_TIME_SNAPSHOT')),
+  created_at      timestamptz not null default now(),
+  stopped_at      timestamptz
+);
+
+create table if not exists public.asc_reports (
+  id             uuid primary key default gen_random_uuid(),
+  request_id     uuid not null references public.asc_report_requests(id) on delete cascade,
+  asc_report_id  text not null unique,
+  category       text not null,
+  report_name    text,
+  created_at     timestamptz not null default now()
+);
+
+create table if not exists public.asc_report_instances (
+  id               uuid primary key default gen_random_uuid(),
+  report_id        uuid not null references public.asc_reports(id) on delete cascade,
+  asc_instance_id  text not null unique,
+  granularity      text not null check (granularity in ('DAILY','WEEKLY','MONTHLY')),
+  processing_date  date not null,
+  state            text not null default 'discovered'
+                     check (state in ('discovered','downloaded','processed','error')),
+  error_detail     text,
+  discovered_at    timestamptz not null default now(),
+  processed_at     timestamptz
+);
+
+create table if not exists public.asc_report_segments (
+  id              uuid primary key default gen_random_uuid(),
+  instance_id     uuid not null references public.asc_report_instances(id) on delete cascade,
+  checksum        text not null,
+  size_bytes      bigint,
+  url             text,
+  state           text not null default 'discovered'
+                     check (state in ('discovered','processed','error')),
+  rows_ingested   integer,
+  processed_at    timestamptz,
+  created_at      timestamptz not null default now(),
+  unique (instance_id, checksum)
+);
+
+create table if not exists public.asc_raw_rows (
+  id              bigint generated always as identity primary key,
+  segment_id      uuid not null references public.asc_report_segments(id) on delete cascade,
+  report_kind     text not null check (report_kind in ('discovery_engagement','downloads')),
+  reporting_date  date not null,
+  raw             jsonb not null,
+  ingested_at     timestamptz not null default now()
+);
+create index if not exists asc_raw_rows_kind_date_idx on public.asc_raw_rows (report_kind, reporting_date);
+
+create table if not exists public.asc_discovery_engagement (
+  id                  bigint generated always as identity primary key,
+  granularity         text not null default 'DAILY',
+  reporting_date      date not null,
+  engagement_type     text,
+  page_type           text,
+  source_type         text,
+  source_info         text,
+  device              text,
+  platform_version    text,
+  territory           text,
+  channel             text not null default 'unknown',
+  counts              bigint not null default 0,
+  unique_counts       bigint not null default 0,
+  segment_id          uuid references public.asc_report_segments(id) on delete set null,
+  updated_at          timestamptz not null default now(),
+  constraint asc_de_uk unique nulls not distinct
+    (granularity, reporting_date, engagement_type, page_type,
+     source_type, source_info, device, platform_version, territory)
+);
+create index if not exists asc_de_date_idx      on public.asc_discovery_engagement (reporting_date);
+create index if not exists asc_de_channel_idx   on public.asc_discovery_engagement (channel, reporting_date);
+create index if not exists asc_de_territory_idx on public.asc_discovery_engagement (territory, reporting_date);
+
+create table if not exists public.asc_downloads (
+  id                  bigint generated always as identity primary key,
+  granularity         text not null default 'DAILY',
+  reporting_date      date not null,
+  download_type       text,
+  page_type           text,
+  source_type         text,
+  source_info         text,
+  campaign            text,
+  device              text,
+  platform_version    text,
+  territory           text,
+  channel             text not null default 'unknown',
+  counts              bigint not null default 0,
+  unique_counts       bigint not null default 0,
+  segment_id          uuid references public.asc_report_segments(id) on delete set null,
+  updated_at          timestamptz not null default now(),
+  constraint asc_dl_uk unique nulls not distinct
+    (granularity, reporting_date, download_type, page_type,
+     source_type, source_info, campaign, device, platform_version, territory)
+);
+create index if not exists asc_dl_date_idx      on public.asc_downloads (reporting_date);
+create index if not exists asc_dl_channel_idx   on public.asc_downloads (channel, reporting_date);
+create index if not exists asc_dl_territory_idx on public.asc_downloads (territory, reporting_date);
+
+create table if not exists public.asc_sync_status (
+  job_name          text primary key,
+  status            text not null default 'idle'
+                      check (status in ('idle','running','complete','failed')),
+  last_synced_date  date,
+  last_run_at       timestamptz,
+  error             text,
+  updated_at        timestamptz not null default now()
+);
+
+create or replace view public.asc_conversion_daily
+with (security_invoker = true) as
+with imp as (
+  select reporting_date, territory, channel,
+         sum(unique_counts) as unique_impressions
+  from public.asc_discovery_engagement
+  where lower(engagement_type) like '%impression%'
+  group by reporting_date, territory, channel
+),
+dl as (
+  select reporting_date, territory, channel,
+         sum(counts) as total_downloads
+  from public.asc_downloads
+  where download_type is null
+     or lower(download_type) in ('total downloads','total')
+  group by reporting_date, territory, channel
+)
+select
+  coalesce(imp.reporting_date, dl.reporting_date) as reporting_date,
+  coalesce(imp.territory, dl.territory)           as territory,
+  coalesce(imp.channel, dl.channel)               as channel,
+  coalesce(imp.unique_impressions, 0)             as unique_impressions,
+  coalesce(dl.total_downloads, 0)                 as total_downloads,
+  case when coalesce(imp.unique_impressions,0) > 0
+       then coalesce(dl.total_downloads,0)::numeric / imp.unique_impressions
+       else null end                              as conversion_rate,
+  coalesce(imp.reporting_date, dl.reporting_date) > (current_date - 2) as provisional
+from imp
+full outer join dl
+  on  imp.reporting_date = dl.reporting_date
+  and imp.territory      = dl.territory
+  and imp.channel        = dl.channel;
+
+alter table public.asc_report_requests      enable row level security;
+alter table public.asc_reports              enable row level security;
+alter table public.asc_report_instances     enable row level security;
+alter table public.asc_report_segments      enable row level security;
+alter table public.asc_raw_rows             enable row level security;
+alter table public.asc_discovery_engagement enable row level security;
+alter table public.asc_downloads            enable row level security;
+alter table public.asc_sync_status          enable row level security;

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -101,6 +101,10 @@ class InMemoryStorage implements Storage {
   }
 }
 
+// Browser-only globals — skipped under `@vitest-environment node` (server-lib
+// tests). `window` is always defined under jsdom, so existing tests are
+// unaffected; node-env tests don't need these DOM mocks.
+if (typeof window !== "undefined") {
 for (const name of ["localStorage", "sessionStorage"] as const) {
   Object.defineProperty(window, name, {
     configurable: true,
@@ -240,6 +244,7 @@ Object.defineProperty(window, "scrollTo", {
   writable: true,
   value: vi.fn(),
 });
+} // end browser-only globals guard
 
 // ─── Polyfill: Pointer Capture + scrollIntoView (Radix popper testing) ─────
 //

--- a/tests/unit/app-store-client.test.ts
+++ b/tests/unit/app-store-client.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from "vitest";
+import { importSPKI, jwtVerify, decodeProtectedHeader } from "jose";
+import { isAppStoreConfigured, mintToken } from "@/lib/analytics/app-store-client";
+
+// Throwaway ES256 (P-256) keypair generated for tests only — not used anywhere real.
+const PKCS8 = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgLGJOaYXeCWxYrVPB
+hmxMSKU1AEVbJSgKsP8h3Yk9U/GhRANCAASARzuPsj2+6XmCgahyhp0giR8dVWRz
++vwm+fA5j7zb7qU/HL/nexlKjtTXo/cLdQVRJeaNDtOyBKjpfLuGA/dz
+-----END PRIVATE KEY-----`;
+
+const SPKI = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgEc7j7I9vul5goGocoadIIkfHVVk
+c/r8JvnwOY+82+6lPxy/53sZSo7U16P3C3UFUSXmjQ7TsgSo6Xy7hgP3cw==
+-----END PUBLIC KEY-----`;
+
+describe("isAppStoreConfigured", () => {
+  beforeEach(() => {
+    delete process.env.ASC_KEY_ID;
+    delete process.env.ASC_ISSUER_ID;
+    delete process.env.ASC_PRIVATE_KEY;
+    delete process.env.ASC_APP_ID;
+  });
+
+  it("is false when any required var is missing", () => {
+    process.env.ASC_KEY_ID = "K";
+    process.env.ASC_ISSUER_ID = "I";
+    process.env.ASC_PRIVATE_KEY = "P";
+    // ASC_APP_ID missing
+    expect(isAppStoreConfigured()).toBe(false);
+  });
+
+  it("is true when all four are set", () => {
+    process.env.ASC_KEY_ID = "K";
+    process.env.ASC_ISSUER_ID = "I";
+    process.env.ASC_PRIVATE_KEY = "P";
+    process.env.ASC_APP_ID = "123456789";
+    expect(isAppStoreConfigured()).toBe(true);
+  });
+});
+
+describe("mintToken", () => {
+  const ISS = "11111111-2222-3333-4444-555555555555";
+
+  beforeEach(() => {
+    process.env.ASC_KEY_ID = "ABC123KEYID";
+    process.env.ASC_ISSUER_ID = ISS;
+    // Stored with literal \n to also exercise parsePrivateKey's newline handling.
+    process.env.ASC_PRIVATE_KEY = PKCS8.replace(/\n/g, "\\n");
+  });
+
+  it("signs a verifiable ES256 JWT with correct header, claims, and exp <= 20min", async () => {
+    const token = await mintToken();
+
+    const header = decodeProtectedHeader(token);
+    expect(header.alg).toBe("ES256");
+    expect(header.kid).toBe("ABC123KEYID");
+    expect(header.typ).toBe("JWT");
+
+    const pub = await importSPKI(SPKI, "ES256");
+    const { payload } = await jwtVerify(token, pub, {
+      audience: "appstoreconnect-v1",
+      issuer: ISS,
+    });
+
+    expect(payload.aud).toBe("appstoreconnect-v1");
+    expect(payload.iss).toBe(ISS);
+    const lifetime = (payload.exp as number) - (payload.iat as number);
+    expect(lifetime).toBeGreaterThan(0);
+    expect(lifetime).toBeLessThanOrEqual(1200);
+  });
+
+  it("throws when not configured", async () => {
+    delete process.env.ASC_PRIVATE_KEY;
+    await expect(mintToken()).rejects.toThrow();
+  });
+});

--- a/tests/unit/app-store-cron.test.ts
+++ b/tests/unit/app-store-cron.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const isConfigured = vi.fn();
+vi.mock("@/lib/analytics/app-store-client", () => ({ isAppStoreConfigured: () => isConfigured() }));
+vi.mock("@/lib/admin/app-store-sync", () => ({ bootstrapIfNeeded: vi.fn(), syncOnce: vi.fn() }));
+vi.mock("@/lib/admin/app-store-queries", () => ({ updateAscSyncStatus: vi.fn() }));
+
+import { GET } from "@/app/api/cron/app-store-sync/route";
+
+const req = (auth?: string) =>
+  new NextRequest("http://localhost/api/cron/app-store-sync", {
+    headers: auth ? { authorization: auth } : {},
+  });
+
+beforeEach(() => {
+  process.env.CRON_SECRET = "s3cret";
+  isConfigured.mockReset();
+});
+
+describe("app-store-sync cron auth", () => {
+  it("401 when no authorization header", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+
+  it("401 when the bearer token is wrong", async () => {
+    const res = await GET(req("Bearer nope"));
+    expect(res.status).toBe(401);
+  });
+
+  it("short-circuits to skipped when configured-check is false", async () => {
+    isConfigured.mockReturnValue(false);
+    const res = await GET(req("Bearer s3cret"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ skipped: true, reason: "App Store Connect not configured" });
+  });
+});

--- a/tests/unit/app-store-parse.test.ts
+++ b/tests/unit/app-store-parse.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { parseTsv, mapAppStoreSourceToChannel } from "@/lib/analytics/app-store-parse";
+
+describe("mapAppStoreSourceToChannel", () => {
+  it.each([
+    ["App Store Search", "app_store_search"],
+    ["App Store Browse", "app_store_browse"],
+    ["App Referrer", "app_referrer"],
+    ["Web Referrer", "web_referrer"],
+    ["App Clip", "app_clip"],
+    ["Institutional Purchase", "institutional"],
+    ["Unavailable", "unavailable"],
+    ["", "unavailable"],
+    ["Something New From Apple", "other"],
+  ])("maps %s -> %s", (src, expected) => {
+    expect(mapAppStoreSourceToChannel(src, null)).toBe(expected);
+  });
+
+  it("is case/whitespace tolerant", () => {
+    expect(mapAppStoreSourceToChannel("  app store SEARCH ", null)).toBe("app_store_search");
+  });
+
+  it("treats null source as unavailable", () => {
+    expect(mapAppStoreSourceToChannel(null, null)).toBe("unavailable");
+  });
+});
+
+const ALIASES = {
+  reporting_date: ["date"],
+  source_type: ["source type"],
+  counts: ["counts"],
+  unique_counts: ["unique counts", "unique devices"],
+};
+
+describe("parseTsv (header-name based, drift-tolerant)", () => {
+  it("maps the documented header order and parses thousands separators", () => {
+    const tsv = "Date\tSource Type\tCounts\tUnique Counts\n2026-06-01\tApp Store Search\t1,234\t1000";
+    const rows = parseTsv(tsv, ALIASES);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      reporting_date: "2026-06-01",
+      source_type: "App Store Search",
+      counts: 1234,
+      unique_counts: 1000,
+    });
+  });
+
+  it("survives reordered columns (maps by name, not index)", () => {
+    const tsv = "Unique Counts\tCounts\tSource Type\tDate\n5\t9\tApp Store Browse\t2026-06-02";
+    const rows = parseTsv(tsv, ALIASES);
+    expect(rows[0]).toMatchObject({ counts: 9, unique_counts: 5, source_type: "App Store Browse", reporting_date: "2026-06-02" });
+  });
+
+  it("keeps unknown columns in raw and never drops them", () => {
+    const tsv = "Date\tSource Type\tCounts\tNew Apple Column\n2026-06-03\tWeb Referrer\t3\tXYZ";
+    const rows = parseTsv(tsv, ALIASES);
+    expect((rows[0].raw as Record<string, string>)["new apple column"]).toBe("XYZ");
+  });
+
+  it("handles the 'Unique Devices' alias for unique_counts", () => {
+    const tsv = "Date\tSource Type\tCounts\tUnique Devices\n2026-06-04\tApp Store Search\t7\t4";
+    const rows = parseTsv(tsv, ALIASES);
+    expect(rows[0].unique_counts).toBe(4);
+  });
+
+  it("returns [] for header-only or empty input", () => {
+    expect(parseTsv("Date\tCounts", ALIASES)).toEqual([]);
+    expect(parseTsv("", ALIASES)).toEqual([]);
+  });
+
+  it("defaults missing numerics to 0 and missing dimensions to empty string in raw", () => {
+    const tsv = "Date\tSource Type\tCounts\tUnique Counts\n2026-06-05\tApp Store Search\t\t";
+    const rows = parseTsv(tsv, ALIASES);
+    expect(rows[0].counts).toBe(0);
+    expect(rows[0].unique_counts).toBe(0);
+  });
+});

--- a/tests/unit/app-store-queries.test.ts
+++ b/tests/unit/app-store-queries.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { ascCacheKey } from "@/lib/admin/app-store-queries";
+
+describe("ascCacheKey", () => {
+  it("includes every arg so dated/granularity variants never collide", () => {
+    const a = ascCacheKey("kpis", "2026-06-01", "2026-06-30", "daily");
+    const b = ascCacheKey("kpis", "2026-05-01", "2026-05-31", "daily");
+    const c = ascCacheKey("kpis", "2026-06-01", "2026-06-30", "weekly");
+    expect(a).toEqual(["asc", "kpis", "2026-06-01", "2026-06-30", "daily"]);
+    expect(a).not.toEqual(b);
+    expect(a).not.toEqual(c);
+  });
+});

--- a/tests/unit/app-store-sync.test.ts
+++ b/tests/unit/app-store-sync.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ParsedRow } from "@/lib/analytics/app-store-parse";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+const ascPost = vi.fn();
+vi.mock("@/lib/analytics/app-store-client", () => ({
+  ascPost: (...a: unknown[]) => ascPost(...a),
+  ascGet: vi.fn(),
+  downloadSegment: vi.fn(),
+  getAscAppId: () => "999888777",
+}));
+
+let existingRequests: { access_type: string; created_at: string }[] = [];
+const inserts: { table: string; row: unknown }[] = [];
+vi.mock("@/lib/supabase/admin-client", () => ({
+  getAdminSupabase: () => ({
+    from: (table: string) => ({
+      select: () => Promise.resolve({ data: existingRequests, error: null }),
+      insert: (row: unknown) => {
+        inserts.push({ table, row });
+        return Promise.resolve({ data: null, error: null });
+      },
+    }),
+  }),
+}));
+
+import {
+  buildReportRequestBody,
+  toEngagementFact,
+  toDownloadFact,
+  bootstrapIfNeeded,
+} from "@/lib/admin/app-store-sync";
+
+const row = (fields: Record<string, string | number>): ParsedRow => ({ raw: {}, ...fields });
+
+beforeEach(() => {
+  ascPost.mockReset();
+  ascPost.mockImplementation(() => Promise.resolve({ data: { id: "req_" + (ascPost.mock.calls.length) } }));
+  existingRequests = [];
+  inserts.length = 0;
+});
+
+describe("buildReportRequestBody", () => {
+  it("scopes the request to the app via the apps relationship + numeric id", () => {
+    expect(buildReportRequestBody("ONGOING", "999888777")).toEqual({
+      data: {
+        type: "analyticsReportRequests",
+        attributes: { accessType: "ONGOING" },
+        relationships: { app: { data: { type: "apps", id: "999888777" } } },
+      },
+    });
+  });
+});
+
+describe("toEngagementFact / toDownloadFact", () => {
+  it("maps engagement fields, normalizes channel, and carries segment id", () => {
+    const f = toEngagementFact(
+      row({ reporting_date: "2026-06-10", engagement_type: "Impression", source_type: "App Store Search", territory: "US", counts: 100, unique_counts: 80 }),
+      "seg-1",
+    );
+    expect(f).toMatchObject({
+      reporting_date: "2026-06-10",
+      engagement_type: "Impression",
+      source_type: "App Store Search",
+      channel: "app_store_search",
+      territory: "US",
+      counts: 100,
+      unique_counts: 80,
+      segment_id: "seg-1",
+      granularity: "DAILY",
+    });
+    expect(f.page_type).toBeNull(); // absent dimension → null
+  });
+
+  it("maps download rows and normalizes an unknown source to 'other'", () => {
+    const f = toDownloadFact(
+      row({ reporting_date: "2026-06-10", download_type: "Total Downloads", source_type: "Mystery", counts: 5, unique_counts: 5 }),
+      "seg-2",
+    );
+    expect(f).toMatchObject({ download_type: "Total Downloads", channel: "other", counts: 5, segment_id: "seg-2" });
+  });
+});
+
+describe("bootstrapIfNeeded (idempotent)", () => {
+  it("creates ONGOING + ONE_TIME_SNAPSHOT when no requests exist", async () => {
+    existingRequests = [];
+    await bootstrapIfNeeded();
+    expect(ascPost).toHaveBeenCalledTimes(2);
+    const types = inserts.map((i) => (i.row as { access_type: string }).access_type).sort();
+    expect(types).toEqual(["ONE_TIME_SNAPSHOT", "ONGOING"]);
+  });
+
+  it("does nothing when ONGOING + a fresh snapshot already exist", async () => {
+    const now = new Date().toISOString();
+    existingRequests = [
+      { access_type: "ONGOING", created_at: now },
+      { access_type: "ONE_TIME_SNAPSHOT", created_at: now },
+    ];
+    await bootstrapIfNeeded();
+    expect(ascPost).not.toHaveBeenCalled();
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("creates only the missing ONGOING when a snapshot already exists", async () => {
+    existingRequests = [{ access_type: "ONE_TIME_SNAPSHOT", created_at: new Date().toISOString() }];
+    await bootstrapIfNeeded();
+    expect(ascPost).toHaveBeenCalledTimes(1);
+    expect((inserts[0].row as { access_type: string }).access_type).toBe("ONGOING");
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -52,6 +52,10 @@
       "schedule": "0 8 * * *"
     },
     {
+      "path": "/api/cron/app-store-sync",
+      "schedule": "0 9 * * *"
+    },
+    {
       "path": "/api/cron/duplicate-scan",
       "schedule": "0 5 * * *"
     },


### PR DESCRIPTION
## What
New **Growth → App Store** admin page surfacing Apple's App Store conversion funnel: impressions → product-page views → downloads, conversion rate, source/channel breakdown, and territory table. Daily automatic sync from the App Store Connect Analytics Reports API into Supabase.

Phase 1 of the unified cross-channel attribution program — built attribution-ready (every fact carries a normalized `channel` dimension).

## How
- **DB** (migration `app_store_connect_analytics_phase1`, already applied to prod): 8 `asc_*` tables + `asc_conversion_daily` view. RLS on, service-role writes only, fact unique keys use `NULLS NOT DISTINCT` for idempotent restatement.
- **Client** `src/lib/analytics/app-store-client.ts`: ES256 JWT (jose) + ASC fetch with 429 backoff.
- **Parser** `src/lib/analytics/app-store-parse.ts`: header-NAME-based TSV parsing (drift-tolerant) + canonical channel mapping.
- **Sync** `src/lib/admin/app-store-sync.ts`: bootstrap (ONGOING + ONE_TIME_SNAPSHOT) → 6-step pull → idempotent upsert.
- **Queries** `src/lib/admin/app-store-queries.ts`: cached reads (args in cache key), conversion computed from the view.
- **Routes**: cron `/api/cron/app-store-sync` (09:00 UTC, CRON_SECRET) + 5 admin read routes.
- **Page** `src/app/admin/app-store/`: RSC + client dashboard. Nav registered under GROWTH. Retired stale `Kosugi` font refs in admin chart wrappers.

## Tests
31 unit tests (JWT, parser/drift, channel map, conversion math, idempotency incl. NULL dims, cron auth). Typecheck clean.

## Required env (Vercel prod)
`ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY`, `ASC_APP_ID`. Without them the page renders a SETUP REQUIRED state. (`CRON_SECRET` + `SUPABASE_SERVICE_ROLE_KEY` already set.)

## Cost
$0 recurring — Apple API free, one daily Vercel cron, negligible Supabase storage.

Spec + plan: `docs/superpowers/{specs,plans}/2026-06-22-app-store-connect-analytics*`.