### PR TITLE
fix(qbo): customer name/address mapping + schedule the push-queue worker

### DIFF
--- a/src/lib/api/services/__tests__/qbo-push-mappers.test.ts
+++ b/src/lib/api/services/__tests__/qbo-push-mappers.test.ts
@@ -34,11 +34,136 @@ describe("QBO push mappers", () => {
       expect.objectContaining({
         CompanyName: "Maverick Projects",
         DisplayName: "Maverick Projects",
+        GivenName: "Alex",
+        FamilyName: "Maverick",
         PrimaryEmailAddr: { Address: "alex@maverick.test" },
         PrimaryPhone: { FreeFormNumber: "778-555-0199" },
         BillAddr: { Line1: "12 Yard Rd" },
       }),
     );
+  });
+
+  it("derives GivenName and FamilyName from the client name when no contact exists", () => {
+    const payload = mapClientToQboCustomer({
+      client: {
+        id: "client-1",
+        name: "Charlie Blackwood",
+        email: "cblackwood@email.com",
+        phoneNumber: null,
+        address: null,
+        qbId: null,
+        syncToken: null,
+      },
+    });
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        DisplayName: "Charlie Blackwood",
+        GivenName: "Charlie",
+        FamilyName: "Blackwood",
+      }),
+    );
+  });
+
+  it("prefers the primary contact name over the client name for GivenName/FamilyName", () => {
+    const payload = mapClientToQboCustomer({
+      client: {
+        id: "client-1",
+        name: "Maverick Projects",
+        qbId: null,
+        syncToken: null,
+      },
+      primaryContact: {
+        firstName: "Dana",
+        lastName: "Cole",
+        email: null,
+        phoneNumber: null,
+      },
+    });
+
+    expect(payload).toEqual(
+      expect.objectContaining({ GivenName: "Dana", FamilyName: "Cole" }),
+    );
+  });
+
+  it("emits GivenName only for a single-token client name", () => {
+    const payload = mapClientToQboCustomer({
+      client: { id: "client-1", name: "Cher", qbId: null, syncToken: null },
+    });
+
+    expect(payload.GivenName).toBe("Cher");
+    expect(payload).not.toHaveProperty("FamilyName");
+  });
+
+  it("parses a comma-separated US address into structured BillAddr fields", () => {
+    const payload = mapClientToQboCustomer({
+      client: {
+        id: "client-1",
+        name: "Charlie Blackwood",
+        address: "10452 Scripps Ranch Blvd, San Diego, CA, United States",
+        qbId: null,
+        syncToken: null,
+      },
+    });
+
+    expect(payload.BillAddr).toEqual({
+      Line1: "10452 Scripps Ranch Blvd",
+      City: "San Diego",
+      CountrySubDivisionCode: "CA",
+      Country: "United States",
+    });
+  });
+
+  it("parses a Canadian address, classifying the trailing token as a postal code", () => {
+    const payload = mapClientToQboCustomer({
+      client: {
+        id: "client-1",
+        name: "Saanich Client",
+        address: "3912 Lancaster Rd, Saanich, BC, V8X 2B3",
+        qbId: null,
+        syncToken: null,
+      },
+    });
+
+    expect(payload.BillAddr).toEqual({
+      Line1: "3912 Lancaster Rd",
+      City: "Saanich",
+      CountrySubDivisionCode: "BC",
+      PostalCode: "V8X 2B3",
+    });
+  });
+
+  it("splits a combined 'STATE ZIP' trailing token into state and postal code", () => {
+    const payload = mapClientToQboCustomer({
+      client: {
+        id: "client-1",
+        name: "Springfield Client",
+        address: "742 Evergreen Terrace, Springfield, IL 62704",
+        qbId: null,
+        syncToken: null,
+      },
+    });
+
+    expect(payload.BillAddr).toEqual({
+      Line1: "742 Evergreen Terrace",
+      City: "Springfield",
+      CountrySubDivisionCode: "IL",
+      PostalCode: "62704",
+    });
+  });
+
+  it("keeps a single-line street address as BillAddr.Line1 only", () => {
+    const payload = mapClientToQboCustomer({
+      client: {
+        id: "client-1",
+        name: "Test Client",
+        address: "123 OPS Test St",
+        qbId: null,
+        syncToken: null,
+      },
+    });
+
+    expect(payload.BillAddr).toEqual({ Line1: "123 OPS Test St" });
   });
 
   it("omits optional empty email and phone fields instead of emitting empty strings", () => {

--- a/src/lib/api/services/qbo-push-mappers.ts
+++ b/src/lib/api/services/qbo-push-mappers.ts
@@ -232,6 +232,100 @@ export function assertQboRef(
   return cleaned;
 }
 
+function splitPersonName(name: string | null | undefined): {
+  given?: string;
+  family?: string;
+} {
+  const cleaned = cleanString(name);
+  if (!cleaned) return {};
+  const [first, ...rest] = cleaned.split(/\s+/);
+  return {
+    given: first,
+    family: rest.length > 0 ? rest.join(" ") : undefined,
+  };
+}
+
+const KNOWN_COUNTRIES = new Set([
+  "united states",
+  "united states of america",
+  "usa",
+  "canada",
+]);
+
+function isKnownCountry(token: string): boolean {
+  return KNOWN_COUNTRIES.has(token.trim().toLowerCase());
+}
+
+const US_ZIP = /^\d{5}(-\d{4})?$/;
+const CA_POSTAL = /^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d$/;
+
+function isPostalCode(token: string): boolean {
+  return US_ZIP.test(token) || CA_POSTAL.test(token);
+}
+
+/**
+ * Parse a free-form OPS address string into a structured QuickBooks BillAddr.
+ *
+ * OPS stores the address as a single text field with no guaranteed shape, so
+ * this classifies trailing tokens (country → postal code → state/province)
+ * rather than relying on fixed positions, and falls back to Line1-only when a
+ * component can't be confidently identified. The full street always lands in
+ * Line1, so nothing is ever dropped.
+ */
+function parseQboBillAddr(
+  address: string | null | undefined,
+): QboPayload | undefined {
+  const cleaned = cleanString(address);
+  if (!cleaned) return undefined;
+
+  const parts = cleaned
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  if (parts.length === 0) return undefined;
+  if (parts.length === 1) return { Line1: parts[0] };
+
+  const line1 = parts[0];
+  const rest = parts.slice(1);
+
+  let country: string | undefined;
+  let postalCode: string | undefined;
+  let state: string | undefined;
+
+  if (rest.length > 0 && isKnownCountry(rest[rest.length - 1])) {
+    country = rest.pop();
+  }
+
+  if (rest.length > 0) {
+    const last = rest[rest.length - 1];
+    const combined = /^([A-Za-z]{2})\s+(.+)$/.exec(last);
+    if (combined && isPostalCode(combined[2])) {
+      // A single trailing token carrying both region and postal, e.g. "IL 62704".
+      state = combined[1].toUpperCase();
+      postalCode = combined[2];
+      rest.pop();
+    } else if (isPostalCode(last)) {
+      postalCode = last;
+      rest.pop();
+      if (rest.length > 0 && /^[A-Za-z]{2}$/.test(rest[rest.length - 1])) {
+        state = rest.pop()!.toUpperCase();
+      }
+    } else if (/^[A-Za-z]{2}$/.test(last)) {
+      state = last.toUpperCase();
+      rest.pop();
+    }
+  }
+
+  const city = rest.length > 0 ? rest.join(", ") : undefined;
+
+  const billAddr: QboPayload = { Line1: line1 };
+  addDefined(billAddr, "City", city);
+  addDefined(billAddr, "CountrySubDivisionCode", state);
+  addDefined(billAddr, "PostalCode", postalCode);
+  addDefined(billAddr, "Country", country);
+  return billAddr;
+}
+
 export function mapClientToQboCustomer(input: {
   client: OpsClientForQbo;
   primaryContact?: OpsContactForQbo | null;
@@ -241,19 +335,31 @@ export function mapClientToQboCustomer(input: {
   const phone =
     cleanString(input.primaryContact?.phoneNumber) ??
     cleanString(input.client.phoneNumber);
-  const address = cleanString(input.client.address);
+
+  // Prefer the human contact for the person fields; fall back to splitting the
+  // client's own name so individual clients (no separate contact) still get a
+  // first/last name in QuickBooks instead of a bare display name.
+  const contactGiven = cleanString(input.primaryContact?.firstName);
+  const contactFamily = cleanString(input.primaryContact?.lastName);
+  const nameParts =
+    contactGiven || contactFamily
+      ? { given: contactGiven, family: contactFamily }
+      : splitPersonName(input.client.name);
+
   const payload: QboPayload = {
     CompanyName: input.client.name,
     DisplayName: input.client.name,
   };
 
+  addDefined(payload, "GivenName", nameParts.given);
+  addDefined(payload, "FamilyName", nameParts.family);
   addDefined(payload, "PrimaryEmailAddr", email ? { Address: email } : undefined);
   addDefined(
     payload,
     "PrimaryPhone",
     phone ? { FreeFormNumber: phone } : undefined,
   );
-  addDefined(payload, "BillAddr", address ? { Line1: address } : undefined);
+  addDefined(payload, "BillAddr", parseQboBillAddr(input.client.address));
   addUpdateFields(payload, input.client);
 
   return payload;

--- a/tests/integration/qbo-import-apply-route.test.ts
+++ b/tests/integration/qbo-import-apply-route.test.ts
@@ -94,7 +94,7 @@ describe("POST /api/integrations/quickbooks/import/apply", () => {
     const note = notificationInsert.mock.calls[0][0];
     expect(note.user_id).toBe("user-1");
     expect(note.company_id).toBe(CO);
-    expect(note.action_url).toBe("/accounting");
+    expect(note.action_url).toBe("/books?segment=sync&view=import");
     expect(note.persistent).toBe(false);
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -170,6 +170,10 @@
     {
       "path": "/api/cron/lead-lifecycle",
       "schedule": "0 13 * * *"
+    },
+    {
+      "path": "/api/cron/accounting/quickbooks/push-queue",
+      "schedule": "*/5 13-23,0-4 * * *"
     }
   ]
 }


### PR DESCRIPTION
## What this does

Three atomic fixes to the OPS→QuickBooks outbound sync, surfaced while investigating Maverick (Charlie Blackwood: invoices missing in QB + customer record missing personal info).

1. **`fix(qbo)` — customer first/last name + structured billing address.** `mapClientToQboCustomer` now emits `GivenName`/`FamilyName` (from the primary contact, or split from the client name when there's no contact) and parses the free-form OPS address into structured `BillAddr` (Line1/City/CountrySubDivisionCode/PostalCode/Country). Previously only `DisplayName`/`CompanyName` + a single unparsed address line were sent — so synced QB customers had blank first/last name and no structured address.
2. **`feat(qbo)` — schedule the push-queue worker.** The `accounting_sync_queue` drainer route existed but was never registered in `vercel.json`, so queued OPS→QB pushes never ran automatically (last sync activity was June 7). Registered on the active-window 5-minute cadence. **Still gated by `ACCOUNTING_WRITE_ENABLED`** — inert until writes are deliberately enabled.
3. **`test(qbo)` — stale assertion.** Import-apply notification deep-link moved `/accounting` → `/books?segment=sync&view=import` in the accounting→books rename; updated the assertion.

## Verification

- Full QBO/accounting suite green: **457/457 tests across 67 files**.
- New mapper tests assert the exact fix against Charlie's real data shape (name split + US/Canadian/combined address parsing).

## ⚠️ Not ready for production merge

This is a **draft** pending a live sandbox round-trip. Before merging to `main` (which auto-deploys prod), the sandbox needs:
- QuickBooks **reconnected** (token expired June 15).
- Vercel env: `QB_SANDBOX_FALLBACK_SERVICE_ITEM_ID`, `QB_SANDBOX_TAX_CODE_TAXABLE_ID`, `QB_SANDBOX_TAX_CODE_NONTAXABLE_ID`, `ACCOUNTING_WRITE_ENABLED=true`.
- A historical **backfill** of pre-connection invoices (Charlie's predate the connection; 23/44 Maverick invoices have no `qb_id`).