### PR TITLE
fix(qbo): GET handler so the Vercel cron runs the push-queue worker

### DIFF
--- a/src/app/api/cron/accounting/quickbooks/push-queue/route.ts
+++ b/src/app/api/cron/accounting/quickbooks/push-queue/route.ts
@@ -1127,3 +1127,11 @@ export async function POST(request: Request) {
 
   return NextResponse.json(summarize(workerId, results));
 }
+
+// Vercel Cron invokes a scheduled endpoint with a GET request, so the schedule
+// registered in vercel.json must reach a GET handler — a POST-only route is
+// silently answered with 405 and the queue never drains. Delegate to the POST
+// implementation; manual operators and the test harness still call POST.
+export async function GET(request: Request) {
+  return POST(request);
+}

--- a/tests/integration/qbo-push-queue-route.test.ts
+++ b/tests/integration/qbo-push-queue-route.test.ts
@@ -261,6 +261,17 @@ async function loadPost() {
   return (await import("@/app/api/cron/accounting/quickbooks/push-queue/route")).POST;
 }
 
+async function loadGet() {
+  return (await import("@/app/api/cron/accounting/quickbooks/push-queue/route")).GET;
+}
+
+function authorizedGetRequest(secret = "cron-secret") {
+  return new Request("http://localhost/api/cron/accounting/quickbooks/push-queue", {
+    method: "GET",
+    headers: { authorization: `Bearer ${secret}` },
+  }) as never;
+}
+
 describe("POST /api/cron/accounting/quickbooks/push-queue", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -1409,6 +1420,32 @@ describe("POST /api/cron/accounting/quickbooks/push-queue", () => {
       "QuickBooks estimate void requires operator review",
       expect.anything(),
     );
+  });
+
+  // Vercel Cron invokes a scheduled endpoint with GET. A POST-only route is
+  // answered 405 and the queue silently never drains, so the GET handler must
+  // reach the same worker as POST. [regression: cron worker never ran]
+  it("GET (the Vercel cron invocation) reaches the worker and claims rows when the write gate is true", async () => {
+    process.env.ACCOUNTING_WRITE_ENABLED = "true";
+    const GET = await loadGet();
+    const res = await GET(authorizedGetRequest());
+
+    expect(res.status).toBe(200);
+    expect(claimDue).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "quickbooks", limit: 25 }),
+    );
+  });
+
+  it("GET returns 401 for unauthorized requests and does not claim", async () => {
+    const GET = await loadGet();
+    const res = await GET(
+      new Request("http://localhost/api/cron/accounting/quickbooks/push-queue", {
+        method: "GET",
+      }) as never,
+    );
+
+    expect(res.status).toBe(401);
+    expect(claimDue).not.toHaveBeenCalled();
   });
 
   it("deletes linked estimates in QuickBooks with the current SyncToken", async () => {


### PR DESCRIPTION
Vercel Cron invokes scheduled endpoints with a GET request, but the push-queue route exported only POST — so the every-5-min cron hit a 405 and the accounting_sync_queue never drained (no OPS→QuickBooks pushes ran). Adds a GET handler that delegates to the POST worker (manual operators + the test harness still call POST). 459 QBO tests green, incl. 2 new regression tests asserting the cron's GET invocation reaches the worker.

Verified live: manually triggering the worker drained Maverick's sandbox queue — 4/4 succeeded (2 customers, 2 estimates).