### PR TITLE
fix(qbo): back-fillable line-less invoices + keep phone on parent client

### DIFF
--- a/src/lib/api/services/__tests__/qbo-normalize.test.ts
+++ b/src/lib/api/services/__tests__/qbo-normalize.test.ts
@@ -285,4 +285,9 @@ describe("clientFieldsFromCustomer / subClientFieldsFromCustomer", () => {
   it("QB Job → no sub_client even with company+contact", () => {
     expect(subClientFieldsFromCustomer({ ...company, is_job: true })).toBeNull();
   });
+  it("individual pushed as CompanyName=name (contact_name === company_name) → email/phone stay on the client, no sub_client [regression: round-trip nulled parent phone]", () => {
+    const c = { company_name: "Geoff Shera", contact_name: "Geoff Shera", display_name: "Geoff Shera", email: "geoff@x.com", phone: "(778) 555-0000", address: "3912 Lancaster Rd", is_job: false };
+    expect(clientFieldsFromCustomer(c)).toEqual({ name: "Geoff Shera", email: "geoff@x.com", phone_number: "(778) 555-0000", address: "3912 Lancaster Rd" });
+    expect(subClientFieldsFromCustomer(c)).toBeNull();
+  });
 });

--- a/src/lib/api/services/__tests__/qbo-push-mappers.test.ts
+++ b/src/lib/api/services/__tests__/qbo-push-mappers.test.ts
@@ -262,6 +262,59 @@ describe("QBO push mappers", () => {
     ]);
   });
 
+  it("synthesizes one non-taxable fallback line from the total when an invoice has no line items", () => {
+    const payload = mapInvoiceToQboInvoice({
+      invoice: {
+        id: "inv-legacy",
+        qbId: null,
+        docNumber: "INV-2025-00009",
+        total: 8500,
+        issueDate: "2025-10-12",
+        dueDate: "2025-11-12",
+      },
+      client: { id: "client-1", qbId: "44", name: "Maverick Projects" },
+      lineItems: [],
+      fallbackServiceItem,
+      taxCodeRefs: { nonTaxable: "NON" },
+    });
+
+    expect(payload.Line).toEqual([
+      expect.objectContaining({
+        DetailType: "SalesItemLineDetail",
+        Amount: 8500,
+        SalesItemLineDetail: expect.objectContaining({
+          ItemRef: { value: "1", name: "OPS Service" },
+          Qty: 1,
+          UnitPrice: 8500,
+          TaxCodeRef: { value: "NON" },
+        }),
+      }),
+    ]);
+  });
+
+  it("synthesizes one fallback line from the total when an estimate has no line items", () => {
+    const payload = mapEstimateToQboEstimate({
+      estimate: {
+        id: "est-legacy",
+        qbId: null,
+        docNumber: "EST-1",
+        total: 250,
+        issueDate: "2026-06-05",
+        expirationDate: "2026-07-05",
+      },
+      client: { id: "client-1", qbId: "44", name: "Maverick Projects" },
+      lineItems: [],
+      fallbackServiceItem,
+    });
+
+    expect(payload.Line).toEqual([
+      expect.objectContaining({
+        Amount: 250,
+        SalesItemLineDetail: expect.objectContaining({ ItemRef: { value: "1", name: "OPS Service" } }),
+      }),
+    ]);
+  });
+
   it("blocks invoice fallback lines when no concrete service item ref is available", () => {
     expect(() =>
       mapInvoiceToQboInvoice({

--- a/src/lib/api/services/qbo-normalize.ts
+++ b/src/lib/api/services/qbo-normalize.ts
@@ -204,6 +204,23 @@ export interface CustomerShape {
  * here); a contact-less company keeps them. Individuals are unchanged. BillAddr
  * stays on the billing entity either way.
  */
+/**
+ * True only for a company with a SEPARATE, distinctly-named contact person.
+ * When contact_name equals company_name the customer is really an individual —
+ * the outbound mapper sets CompanyName = the client's own name, so a round-trip
+ * would otherwise look like a company-with-contact and migrate email/phone off
+ * the parent client (nulling it). Requiring a distinct contact keeps email/phone
+ * on the parent — which the outbound mapper reads — so the round-trip is stable.
+ */
+function hasDistinctContact(c: CustomerShape): boolean {
+  return (
+    !!c.company_name &&
+    !!c.contact_name &&
+    c.contact_name !== c.company_name &&
+    c.is_job !== true
+  );
+}
+
 export function clientFieldsFromCustomer(c: CustomerShape): {
   name: string;
   email: string | null;
@@ -211,7 +228,7 @@ export function clientFieldsFromCustomer(c: CustomerShape): {
   address: string | null;
 } {
   const isCompany = !!c.company_name;
-  const hasContact = isCompany && !!c.contact_name && c.is_job !== true;
+  const hasContact = hasDistinctContact(c);
   return {
     name: isCompany ? (c.company_name as string) : (c.display_name ?? "QuickBooks customer"),
     email: hasContact ? null : (c.email ?? null),
@@ -231,7 +248,7 @@ export function subClientFieldsFromCustomer(c: CustomerShape): {
   phone_number: string | null;
   address: string | null;
 } | null {
-  if (!c.company_name || !c.contact_name || c.is_job === true) return null;
+  if (!hasDistinctContact(c)) return null;
   return {
     name: c.contact_name,
     title: null, // QB has no contact job-title (Title is a salutation) — deliberately null.

--- a/src/lib/api/services/qbo-push-mappers.ts
+++ b/src/lib/api/services/qbo-push-mappers.ts
@@ -210,6 +210,41 @@ function mapSalesLine(
   };
 }
 
+/**
+ * Build the QuickBooks `Line` array for an invoice/estimate. When the OPS
+ * record has no itemized line items (legacy total-only imports), synthesize a
+ * single line for the whole total using the fallback service item, marked
+ * non-taxable so QuickBooks records the total exactly (no tax added on top).
+ * QuickBooks rejects a transaction with an empty Line array, so this is what
+ * lets historical total-only records back-fill.
+ */
+function buildSalesLines(input: {
+  lineItems: OpsLineItemForQbo[];
+  total: number | string | null | undefined;
+  entityId: string;
+  fallbackServiceItem?: QboFallbackServiceItemRef | null;
+  taxCodeRefs?: QboTaxCodeRefs | null;
+}): QboPayload[] {
+  if (input.lineItems.length > 0) {
+    return input.lineItems.map((line) =>
+      mapSalesLine(line, input.fallbackServiceItem, input.taxCodeRefs),
+    );
+  }
+  return [
+    mapSalesLine(
+      {
+        id: `${input.entityId}:total`,
+        name: "Total",
+        amount: input.total ?? 0,
+        quantity: 1,
+        isTaxable: false,
+      },
+      input.fallbackServiceItem,
+      input.taxCodeRefs,
+    ),
+  ];
+}
+
 function addUpdateFields(
   payload: QboPayload,
   entity: { qbId?: string | null; syncToken?: string | null },
@@ -376,9 +411,13 @@ export function mapInvoiceToQboInvoice(input: {
     CustomerRef: {
       value: assertQboRef(input.client.qbId, "QuickBooks customer link"),
     },
-    Line: input.lineItems.map((line) =>
-      mapSalesLine(line, input.fallbackServiceItem, input.taxCodeRefs),
-    ),
+    Line: buildSalesLines({
+      lineItems: input.lineItems,
+      total: input.invoice.total,
+      entityId: input.invoice.id,
+      fallbackServiceItem: input.fallbackServiceItem,
+      taxCodeRefs: input.taxCodeRefs,
+    }),
   };
 
   addDefined(
@@ -404,9 +443,13 @@ export function mapEstimateToQboEstimate(input: {
     CustomerRef: {
       value: assertQboRef(input.client.qbId, "QuickBooks customer link"),
     },
-    Line: input.lineItems.map((line) =>
-      mapSalesLine(line, input.fallbackServiceItem, input.taxCodeRefs),
-    ),
+    Line: buildSalesLines({
+      lineItems: input.lineItems,
+      total: input.estimate.total,
+      entityId: input.estimate.id,
+      fallbackServiceItem: input.fallbackServiceItem,
+      taxCodeRefs: input.taxCodeRefs,
+    }),
   };
 
   addDefined(


### PR DESCRIPTION
Two fixes surfaced while backfilling Maverick's pre-connection records to QuickBooks:

1. **Line-less invoices/estimates** — legacy imports with only a total (no itemized lines) produced an empty QB `Line` array (QB rejects with [2020]). Synthesize one non-taxable fallback line for the total so they post cleanly with the total preserved. Unblocks 16 backfill invoices (incl. 3 of Charlie's).
2. **Inbound phone→parent client** — QB→OPS apply migrated a customer's email/phone to a sub_client contact whenever the QB customer had CompanyName+contact, but the outbound mapper sets CompanyName = the client's own name, so individuals round-tripped and lost their parent phone. Only treat as company-with-contact when the contact name is DISTINCT from the company.

462 QBO tests green (2 new). Verified live against the QB sandbox during the backfill.