### PR TITLE
fix(qbo): type-guard fix so the QBO mapper fixes build on prod

### DIFF
--- a/src/lib/api/services/qbo-normalize.ts
+++ b/src/lib/api/services/qbo-normalize.ts
@@ -212,7 +212,9 @@ export interface CustomerShape {
  * the parent client (nulling it). Requiring a distinct contact keeps email/phone
  * on the parent — which the outbound mapper reads — so the round-trip is stable.
  */
-function hasDistinctContact(c: CustomerShape): boolean {
+function hasDistinctContact(
+  c: CustomerShape,
+): c is CustomerShape & { company_name: string; contact_name: string } {
   return (
     !!c.company_name &&
     !!c.contact_name &&


### PR DESCRIPTION
Fix-forward: PR #104's inbound-mapping refactor lost type narrowing (TS2322 in `next build`), so that deploy failed and prod stayed on the prior good build. Declares `hasDistinctContact` as a type guard; type-clean now, 55 mapper/normalize tests green.