### PR TITLE
fix(inbox): stop reciting attachment contents back to the customer

### DIFF
--- a/src/lib/api/services/conversation-state/draft-context.ts
+++ b/src/lib/api/services/conversation-state/draft-context.ts
@@ -70,21 +70,29 @@ export function buildDraftStateContext(state: ConversationState): DraftStateCont
           .join("\n")}`
       : "";
 
-  // Attachments the customer sent — acknowledge receipt, and (Phase 2) describe
-  // what each one actually IS using the cached vision summary so the drafter can
-  // reference the content, not just the filename. A failed/empty inspection
-  // degrades gracefully to just the filename.
+  // Attachments the customer sent — tell the drafter they exist (and whether one
+  // is a signed estimate, which shapes the reply's intent) so it can acknowledge
+  // them naturally. It must NOT recite the vision summary back: narrating an
+  // image's contents ("your photo of the back deck with wood boards and a
+  // hand-drawn sketch") reads as robotic "look, I can see it" filler and adds
+  // nothing to the conversation. The vision verdict stays INTERNAL — it still
+  // drives the signed-estimate→Won path and the held-for-review-if-unreadable
+  // gate; it just no longer leaks descriptions into customer-facing text.
+  const attachments = state.attachmentsRequiringInspection;
+  const hasSignedEstimate = attachments.some(
+    (a) => a.inspection?.isSignedEstimate === true
+  );
+  const attachmentAck = hasSignedEstimate
+    ? "thanks for the signed estimate — I'll get you on the schedule"
+    : "thanks for sending those over";
   const attachmentBlock =
-    state.attachmentsRequiringInspection.length > 0
-      ? `THE CUSTOMER ATTACHED THE FOLLOWING — acknowledge receipt naturally and reference what each one shows; never claim you cannot see attachments:\n${state.attachmentsRequiringInspection
-          .map((a) => {
-            const summary = a.inspection?.summary?.trim();
-            return summary
-              ? `- ${a.filename} (${a.kind}): ${summary}`
-              : `- ${a.filename} (${a.kind})`;
-          })
-          .join("\n")}`
-      : "";
+    attachments.length === 0
+      ? ""
+      : `THE CUSTOMER SENT ${attachments.length} ATTACHMENT${
+          attachments.length > 1 ? "S" : ""
+        }${
+          hasSignedEstimate ? " (one is a signed estimate)" : ""
+        }. Acknowledge receipt in ONE short, natural phrase (e.g. "${attachmentAck}"). Do NOT describe or itemize what the attachments show — no play-by-play of the images. Never claim you cannot see them.`;
 
   return {
     recipientName,

--- a/tests/unit/inbox/conversation-state/draft-context.test.ts
+++ b/tests/unit/inbox/conversation-state/draft-context.test.ts
@@ -107,14 +107,14 @@ describe("buildDraftStateContext — sent ledger (no restate)", () => {
 });
 
 describe("buildDraftStateContext — attachment awareness", () => {
-  it("lists customer attachments and tells the drafter to acknowledge them", () => {
+  it("tells the drafter attachments were sent and to acknowledge them naturally", () => {
     const att: AttachmentRef = {
       filename: "deck-sketch.jpg", mimeType: "image/jpeg", sizeBytes: 1000, kind: "image", requiresInspection: true, inspection: null,
     };
     const ctx = buildDraftStateContext(state({ attachmentsRequiringInspection: [att] }));
     expect(ctx.attachmentBlock).not.toBe("");
-    expect(ctx.attachmentBlock).toContain("deck-sketch.jpg");
-    expect(ctx.attachmentBlock.toLowerCase()).toMatch(/acknowledge|attached/);
+    expect(ctx.attachmentBlock.toLowerCase()).toMatch(/acknowledge/);
+    expect(ctx.attachmentBlock.toLowerCase()).toMatch(/do not describe|no play-by-play/);
   });
 
   it("returns an empty attachment block when there are none", () => {
@@ -122,7 +122,7 @@ describe("buildDraftStateContext — attachment awareness", () => {
     expect(ctx.attachmentBlock).toBe("");
   });
 
-  it("surfaces the vision inspection summary so the drafter describes what was sent", () => {
+  it("does NOT recite the vision summary or filename into the customer-facing draft", () => {
     const att: AttachmentRef = {
       filename: "fence-damage.jpg",
       mimeType: "image/jpeg",
@@ -132,14 +132,38 @@ describe("buildDraftStateContext — attachment awareness", () => {
       inspection: {
         summary: "Photo of storm-damaged cedar fence, ~3 sections leaning",
         isSignedEstimate: false,
-        facts: {},
+        facts: { sections: 3 },
         model: "gpt-5.4",
       },
     };
     const ctx = buildDraftStateContext(state({ attachmentsRequiringInspection: [att] }));
-    expect(ctx.attachmentBlock).toContain("fence-damage.jpg");
-    // The drafter must see the actual content of the photo, not just its name.
-    expect(ctx.attachmentBlock).toContain("storm-damaged cedar fence");
+    // The vision verdict is INTERNAL — it must never leak into the draft as
+    // robotic content narration.
+    expect(ctx.attachmentBlock).not.toContain("storm-damaged cedar fence");
+    expect(ctx.attachmentBlock).not.toContain("fence-damage.jpg");
+    // …but the drafter is still told the attachment exists and to acknowledge it.
+    expect(ctx.attachmentBlock.toLowerCase()).toMatch(/acknowledge/);
+  });
+
+  it("flags a signed estimate by TYPE (for tone) without reciting its parsed contents", () => {
+    const att: AttachmentRef = {
+      filename: "estimate-1042-signed.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 88_000,
+      kind: "pdf",
+      requiresInspection: true,
+      inspection: {
+        summary: "signed estimate #1042, total $8,400",
+        isSignedEstimate: true,
+        facts: { total: 8400, estimateNumber: "1042" },
+        model: "gpt-5.4",
+      },
+    };
+    const ctx = buildDraftStateContext(state({ attachmentsRequiringInspection: [att] }));
+    expect(ctx.attachmentBlock.toLowerCase()).toContain("signed estimate");
+    // Still no recitation of the parsed figures or filename.
+    expect(ctx.attachmentBlock).not.toContain("8,400");
+    expect(ctx.attachmentBlock).not.toContain("estimate-1042-signed.pdf");
   });
 });
 


### PR DESCRIPTION
## Fixes the robotic "look, I can see it" drafts

The Phase-2 attachment path injected the vision **summary** into the draft prompt and instructed the drafter to *"reference what each one shows; never claim you cannot see attachments."* Result: drafts that narrate the image back to the sender — *"thanks for the photo of the back deck with the wood boards and the hand-drawn sketch."* Describing pixels back to the person who sent them adds nothing and reads as showing off that the AI can see the image.

## Change
`conversation-state/draft-context.ts` — the attachment block now:
- tells the drafter attachments were sent (and whether **one is a signed estimate**, which shapes the reply's intent),
- instructs a **single natural acknowledgement** ("thanks for sending those over" / "thanks for the signed estimate — I'll get you on the schedule"),
- **forbids describing or itemizing** the contents.

The vision verdict stays **internal** — it still drives the signed-estimate→Won path and the held-for-review-if-unreadable gate. It just no longer leaks descriptions into customer-facing text.

## Proof
- `draft-context.test.ts`: rewrote the two tests that asserted the old *recite-the-summary* behavior; new tests assert the block never contains the summary/filename and does acknowledge naturally. **9/9 pass**, conversation-state suite **148/148**.
- `tsc --noEmit`: only the 7 pre-existing baseline errors, zero new.

Separately, the real capability (drawing → takeoff → priced draft) is being designed under the "VISION ESTIMATING" initiative — this PR is just removing the robotic narration in the meantime.

⚠️ Merging auto-deploys to prod (Canpro's live mailbox) — holding for your go-ahead.