### PR TITLE
feat(expenses): surface no-receipt reason to the approver

### DIFF
--- a/src/components/expenses/expense-line-item-table.tsx
+++ b/src/components/expenses/expense-line-item-table.tsx
@@ -7,6 +7,7 @@ import {
   Flag,
   FlagOff,
   Image as ImageIcon,
+  ImageOff,
 } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import type { ExpenseLineItem } from "@/lib/types/expense-approval";
@@ -37,6 +38,21 @@ function formatDate(dateStr: string | null): string {
     month: "short",
     day: "numeric",
   });
+}
+
+// Mirrors the iOS NoReceiptReason labels so a reason reads the same on both
+// surfaces. A photo-less line with a reason was a deliberate, explained choice
+// — not a missing upload.
+const NO_RECEIPT_REASON_LABELS: Record<string, string> = {
+  lost: "Lost or misplaced",
+  cash: "Cash — no receipt given",
+  digital: "Digital or emailed",
+  other: "Other",
+};
+
+function noReceiptReasonLabel(code: string | null): string {
+  if (!code) return "No receipt";
+  return NO_RECEIPT_REASON_LABELS[code] ?? "No receipt";
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -168,6 +184,13 @@ export function ExpenseLineItemTable({
                       className="w-full h-full object-cover"
                     />
                   </button>
+                ) : expense.receiptMissingReason ? (
+                  <span
+                    title={noReceiptReasonLabel(expense.receiptMissingReason)}
+                    className="w-[32px] h-[32px] rounded border border-ops-amber flex items-center justify-center"
+                  >
+                    <ImageOff className="w-[12px] h-[12px] text-ops-amber" />
+                  </span>
                 ) : (
                   <span className="w-[32px] h-[32px] rounded border border-border flex items-center justify-center">
                     <ImageIcon className="w-[12px] h-[12px] text-text-mute" />
@@ -235,8 +258,8 @@ export function ExpenseLineItemTable({
                   </div>
                 )}
 
-                {/* Receipt image (larger) */}
-                {(expense.receiptImageUrl || expense.receiptThumbnailUrl) && (
+                {/* Receipt image (larger) — or the no-receipt reason when absent */}
+                {expense.receiptImageUrl || expense.receiptThumbnailUrl ? (
                   <div className="mb-3">
                     <span className="font-mono text-micro text-text-mute uppercase tracking-wider block mb-1">
                       RECEIPT
@@ -256,7 +279,21 @@ export function ExpenseLineItemTable({
                       />
                     </button>
                   </div>
-                )}
+                ) : expense.receiptMissingReason ? (
+                  <div className="mb-3">
+                    <span className="font-mono text-micro text-text-mute uppercase tracking-wider block mb-1">
+                      NO RECEIPT
+                    </span>
+                    <span className="font-mono text-caption-sm text-ops-amber block">
+                      {noReceiptReasonLabel(expense.receiptMissingReason)}
+                    </span>
+                    {expense.receiptMissingNote && (
+                      <span className="font-mono text-caption-sm text-text-3 block mt-0.5">
+                        {expense.receiptMissingNote}
+                      </span>
+                    )}
+                  </div>
+                ) : null}
 
                 {/* Flag section */}
                 {canReview && (

--- a/src/lib/api/services/expense-approval-service.ts
+++ b/src/lib/api/services/expense-approval-service.ts
@@ -83,6 +83,8 @@ function mapExpenseFromDb(row: Record<string, unknown>): ExpenseLineItem {
     paymentMethod: (row.payment_method as string) ?? null,
     receiptImageUrl: (row.receipt_image_url as string) ?? null,
     receiptThumbnailUrl: (row.receipt_thumbnail_url as string) ?? null,
+    receiptMissingReason: (row.receipt_missing_reason as string) ?? null,
+    receiptMissingNote: (row.receipt_missing_note as string) ?? null,
     ocrRawData: row.ocr_raw_data ?? null,
     ocrConfidence: row.ocr_confidence != null ? Number(row.ocr_confidence) : null,
     approvedBy: (row.approved_by as string) ?? null,

--- a/src/lib/types/expense-approval.ts
+++ b/src/lib/types/expense-approval.ts
@@ -104,6 +104,9 @@ export interface ExpenseLineItem {
   paymentMethod: string | null;
   receiptImageUrl: string | null;
   receiptThumbnailUrl: string | null;
+  /** Why an expense has no receipt photo (require_receipt_photo escape hatch). */
+  receiptMissingReason: string | null;
+  receiptMissingNote: string | null;
   ocrRawData: unknown | null;
   ocrConfidence: number | null;
   approvedBy: string | null;


### PR DESCRIPTION
Shows the crew's 'no receipt available' reason on the web review table so a photo-less line reads as a deliberate, explained choice — not a missing upload.

- Map `receipt_missing_reason`/`receipt_missing_note` into `ExpenseLineItem`.
- Row: tan `ops-amber` no-receipt indicator (vs the neutral placeholder that still marks legacy photo-less lines).
- Expanded detail: `NO RECEIPT` block with the reason label + note.

Read-only; web is approval-only for expenses. Backs the iOS require_receipt_photo enforcement (branch feat/expense-receipt-required, ships via App Store). Dormant until iOS ships — no row carries a reason yet. DB columns already applied (additive). Type-clean for changed files.