### PR TITLE
feat(expenses): surface no-project reason to the approver

### DIFF
--- a/src/components/expenses/expense-line-item-table.tsx
+++ b/src/components/expenses/expense-line-item-table.tsx
@@ -55,6 +55,19 @@ function noReceiptReasonLabel(code: string | null): string {
   return NO_RECEIPT_REASON_LABELS[code] ?? "No receipt";
 }
 
+// Mirrors the iOS NoProjectReason labels. A project-less line with a reason was
+// deliberate (overhead, shop supplies) — not an omission.
+const NO_PROJECT_REASON_LABELS: Record<string, string> = {
+  overhead: "Overhead — not job-specific",
+  general: "General / shop supplies",
+  other: "Other",
+};
+
+function noProjectReasonLabel(code: string | null): string {
+  if (!code) return "No project";
+  return NO_PROJECT_REASON_LABELS[code] ?? "No project";
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function ExpenseLineItemTable({
@@ -218,9 +231,20 @@ export function ExpenseLineItemTable({
                     <span className="font-mono text-micro text-text-mute uppercase tracking-wider block">
                       PROJECT
                     </span>
-                    <span className="font-mono text-caption-sm text-text-2">
-                      {expense.projectId || "—"}
-                    </span>
+                    {expense.projectId ? (
+                      <span className="font-mono text-caption-sm text-text-2">
+                        {expense.projectId}
+                      </span>
+                    ) : expense.projectMissingReason ? (
+                      <span className="font-mono text-caption-sm text-ops-amber">
+                        {noProjectReasonLabel(expense.projectMissingReason)}
+                        {expense.projectMissingNote
+                          ? ` · ${expense.projectMissingNote}`
+                          : ""}
+                      </span>
+                    ) : (
+                      <span className="font-mono text-caption-sm text-text-2">—</span>
+                    )}
                   </div>
 
                   {/* Payment Method */}

--- a/src/lib/api/services/expense-approval-service.ts
+++ b/src/lib/api/services/expense-approval-service.ts
@@ -85,6 +85,8 @@ function mapExpenseFromDb(row: Record<string, unknown>): ExpenseLineItem {
     receiptThumbnailUrl: (row.receipt_thumbnail_url as string) ?? null,
     receiptMissingReason: (row.receipt_missing_reason as string) ?? null,
     receiptMissingNote: (row.receipt_missing_note as string) ?? null,
+    projectMissingReason: (row.project_missing_reason as string) ?? null,
+    projectMissingNote: (row.project_missing_note as string) ?? null,
     ocrRawData: row.ocr_raw_data ?? null,
     ocrConfidence: row.ocr_confidence != null ? Number(row.ocr_confidence) : null,
     approvedBy: (row.approved_by as string) ?? null,

--- a/src/lib/types/expense-approval.ts
+++ b/src/lib/types/expense-approval.ts
@@ -107,6 +107,9 @@ export interface ExpenseLineItem {
   /** Why an expense has no receipt photo (require_receipt_photo escape hatch). */
   receiptMissingReason: string | null;
   receiptMissingNote: string | null;
+  /** Why an expense has no project (require_project_assignment escape hatch). */
+  projectMissingReason: string | null;
+  projectMissingNote: string | null;
   ocrRawData: unknown | null;
   ocrConfidence: number | null;
   approvedBy: string | null;


### PR DESCRIPTION
Mirror of PR #109 for the require_project_assignment escape hatch. Shows the crew's 'no project available' reason (overhead / shop supplies / other) + note in the expanded PROJECT field of the review table, so a project-less line reads as a deliberate, explained choice.

- Map `project_missing_reason`/`project_missing_note` into `ExpenseLineItem`.
- Expanded PROJECT field: reason label (ops-amber) + note when no project.

Read-only; web is approval-only. Backs the iOS require_project_assignment enforcement (branch feat/expense-receipt-required, ships via App Store). Dormant until iOS ships. DB columns already applied (additive). Type-clean for changed files.