### PR TITLE
fix(auth): CRIT-3 Firebase identity hardening + email verification + Firebase-only cleanup

### DIFF
--- a/src/app/api/auth/send-verification/route.ts
+++ b/src/app/api/auth/send-verification/route.ts
@@ -1,0 +1,98 @@
+/**
+ * POST /api/auth/send-verification
+ *
+ * Sends an OPS-branded Firebase email-verification message (CRIT-3 Phase B).
+ *
+ * OPS historically never sent Firebase email verification, so `email_verified`
+ * was permanently false for every email/password account — which is why the
+ * identity model could not safely trust the email claim. This route wires the
+ * previously-dormant verification stack: it generates a Firebase verification
+ * action link with the Admin SDK (no send), routes it through OUR
+ * `/auth/action?mode=verifyEmail` handler (VerifyFlow → applyActionCode), and
+ * sends it via the OPS-branded SendGrid template. Rebuilding the URL from the
+ * oobCode makes delivery independent of the Firebase console's configured
+ * action-handler domain.
+ *
+ * Soft UX: callers invoke this best-effort after signup; the user is never
+ * gated on verification or on email deliverability.
+ *
+ * Body: { token }  — a verified Firebase ID token (sub == firebase_uid).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAuthToken } from "@/lib/firebase/admin-verify";
+import { getAdminAuth } from "@/lib/firebase/admin";
+import { sendEmailVerification } from "@/lib/email/sendgrid";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.opsapp.co";
+
+interface SendVerificationBody {
+  token: string;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    const { token } = (await req.json()) as SendVerificationBody;
+    if (!token) {
+      return NextResponse.json(
+        { error: "Missing required field: token" },
+        { status: 400 }
+      );
+    }
+
+    const user = await verifyAuthToken(token);
+    if (!user.email) {
+      return NextResponse.json(
+        { error: "Token has no email claim" },
+        { status: 400 }
+      );
+    }
+
+    // Already verified — nothing to send.
+    if (user.claims.email_verified === true) {
+      return NextResponse.json({ sent: false, alreadyVerified: true });
+    }
+
+    // Generate the Firebase verification action link (does not send), then
+    // route it through our branded handler so the OPS SendGrid template is used
+    // instead of Firebase's default message.
+    const generated = await getAdminAuth().generateEmailVerificationLink(user.email, {
+      url: `${APP_URL}/auth/action`,
+    });
+    const oobCode = new URL(generated).searchParams.get("oobCode");
+    if (!oobCode) {
+      return NextResponse.json(
+        { error: "Failed to generate verification link" },
+        { status: 500 }
+      );
+    }
+    const verifyLink = `${APP_URL}/auth/action?mode=verifyEmail&oobCode=${encodeURIComponent(oobCode)}`;
+
+    await sendEmailVerification({ email: user.email, verifyLink });
+
+    return NextResponse.json({ sent: true });
+  } catch (error) {
+    console.error("[api/auth/send-verification] Error:", error);
+
+    const msg = error instanceof Error ? error.message : "";
+    if (
+      msg.includes("Token") ||
+      msg.includes("iss") ||
+      msg.includes("exp") ||
+      msg.includes("aud") ||
+      msg.includes("JWK") ||
+      msg.includes("signature") ||
+      msg.includes("verification")
+    ) {
+      return NextResponse.json(
+        { error: "Authentication failed. Please try signing in again." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/sync-user/route.ts
+++ b/src/app/api/auth/sync-user/route.ts
@@ -3,16 +3,27 @@
  *
  * Syncs a Firebase-authenticated user with the Supabase `users` table.
  * - Verifies the Firebase ID token via jose JWKS verification
- * - Looks up the user by auth_id (Firebase UID) or email
+ * - Looks up the user by auth_id, then firebase_uid, then email — the email
+ *   fallback resolves on the VERIFIED TOKEN email, never the caller-supplied
+ *   body email (CRIT-3), and can never rewrite / hand back a row already bound
+ *   to a different identity from an unverified email-only match
  * - Creates a new user record if none exists
  * - Updates last-login timestamp on existing users
+ * - Sets `firebase_uid` from the verified token at creation and repairs
+ *   null/stale values on login — every firebase_uid write is gated on the
+ *   token being Firebase-issued so a Supabase-issued token can never seed the
+ *   column with a Supabase auth UUID (audit risk R8 — the shared RPCs resolve
+ *   identity via users.firebase_uid = JWT sub)
  * - Returns the user and their associated company (if any)
  *
  * Body: { idToken, email, displayName?, firstName?, lastName?, photoURL? }
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { verifyAuthToken } from "@/lib/firebase/admin-verify";
+import {
+  verifyAuthToken,
+  isFirebaseIssuedToken,
+} from "@/lib/firebase/admin-verify";
 import { getServiceRoleClient } from "@/lib/supabase/server-client";
 import { parseDate } from "@/lib/supabase/helpers";
 import { normalizeImageUrl } from "@/lib/utils/image-url";
@@ -181,26 +192,82 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       existingRow = byFirebaseUid;
     }
 
+    // Email fallback is resolved on the VERIFIED TOKEN email, never the caller-
+    // supplied body email (CRIT-3): the body email is attacker-controllable
+    // independently of the signed token. `matchedByEmail` flags a row found
+    // only by email (not by the cryptographic sub) — it gates the identity
+    // writes below.
+    let matchedByEmail = false;
     if (!existingRow) {
-      const { data: byEmail } = await db
-        .from("users")
-        .select("*")
-        .eq("email", email)
-        .is("deleted_at", null)
-        .maybeSingle();
+      const tokenEmail = firebaseUser.email;
+      if (tokenEmail) {
+        const { data: byEmail } = await db
+          .from("users")
+          .select("*")
+          .eq("email", tokenEmail)
+          .is("deleted_at", null)
+          .maybeSingle();
 
-      existingRow = byEmail;
+        existingRow = byEmail;
+        matchedByEmail = Boolean(byEmail);
+      }
     }
 
     // ── Existing user: update last login and auth_id ──
     if (existingRow) {
-      const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+      const updates: Record<string, unknown> = {
+        updated_at: new Date().toISOString(),
+      };
 
-      // Ensure auth_id and firebase_uid are set
+      // CRIT-3 — account-takeover guard. A row matched ONLY by email that is
+      // already bound to a DIFFERENT identity (a non-null auth_id/firebase_uid
+      // that isn't this token's sub) must not have its identity rewritten, nor
+      // be handed back, to a caller who has not proven ownership of the address.
+      // OPS never sends Firebase email verification, so email/password tokens
+      // are permanently email_verified=false; the legacy-link path (an UNCLAIMED
+      // row — both identity columns null) therefore stays open so the ~75% of
+      // users whose rows predate firebase_uid-at-creation can still attach on
+      // first web login. Sub-matched rows are provably the caller's. The full
+      // closure (re-key the RLS helpers off the token sub + roll out email
+      // verification + backfill the unlinked rows) is the documented follow-up;
+      // this stops the clearest hijack — rewriting / handing back an already-
+      // linked account from an unverified email-only match.
+      const emailVerified = firebaseUser.claims.email_verified === true;
+      const claimedByDifferentIdentity =
+        matchedByEmail &&
+        ((existingRow.firebase_uid != null &&
+          existingRow.firebase_uid !== firebaseUid) ||
+          (existingRow.auth_id != null && existingRow.auth_id !== firebaseUid));
+
+      if (claimedByDifferentIdentity && !emailVerified) {
+        console.warn(
+          "[sync-user] Refused unverified email-only match against a row bound to a different identity",
+          { rowId: existingRow.id }
+        );
+        return NextResponse.json(
+          { error: "Email verification required to access this account." },
+          { status: 403 }
+        );
+      }
+
+      // Ensure auth_id is set (only ever sets a NULL column — never overwrites).
       if (!existingRow.auth_id) {
         updates.auth_id = firebaseUid;
       }
-      if (!existingRow.firebase_uid) {
+
+      // firebase_uid must mirror the VERIFIED token's uid (audit risk R8 — the
+      // shared RPCs resolve identity via users.firebase_uid = JWT sub).
+      // Backfill legacy null rows AND repair stale/divergent values. Gated on
+      // the token being Firebase-issued so a Supabase-issued token (sub =
+      // Supabase auth UUID) can never clobber a real Firebase UID. The
+      // claimed-by-different-identity guard above has already rejected an
+      // unverified email-only match against a row linked to another sub, so
+      // reaching here means the rewrite is the caller's own row (or the email
+      // is verified).
+      if (
+        isFirebaseIssuedToken(firebaseUser.claims) &&
+        existingRow.firebase_uid !== firebaseUid
+      ) {
         updates.firebase_uid = firebaseUid;
       }
 
@@ -238,9 +305,19 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const derivedFirst = firstName || displayName?.split(" ")[0] || "";
     const derivedLast = lastName || displayName?.split(" ").slice(1).join(" ") || "";
 
+    // auth_id is provider-agnostic by design — it maps the verified token's
+    // sub (Supabase auth UUID for iOS, Firebase UID for web) to the app user;
+    // RLS helpers resolve identity via auth_id, so it must be written for both
+    // providers. firebase_uid must only ever hold Firebase UIDs (audit risk R8
+    // — the shared RPCs resolve identity via users.firebase_uid = JWT sub), so
+    // it carries the same Firebase-issued gate as the backfill above: a
+    // Supabase-issued token creating a row must not seed the column with a
+    // Supabase auth UUID.
     const newRow = {
       auth_id: firebaseUid,
-      firebase_uid: firebaseUid,
+      firebase_uid: isFirebaseIssuedToken(firebaseUser.claims)
+        ? firebaseUid
+        : null,
       email,
       first_name: derivedFirst,
       last_name: derivedLast,
@@ -267,12 +344,24 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       // 23505 — re-fetch the row that raced us and return it as if
       // this call had created it, so both callers see a 200.
       if ((insertError as { code?: string } | null)?.code === "23505") {
-        const { data: raced } = await db
+        // Look up by auth_id first (always written at creation for both
+        // providers), then firebase_uid (covers legacy rows whose auth_id
+        // diverged) — a Supabase-token raced row has firebase_uid = null, so a
+        // firebase_uid-only lookup would miss it.
+        let { data: raced } = await db
           .from("users")
           .select("*")
-          .eq("firebase_uid", firebaseUid)
+          .eq("auth_id", firebaseUid)
           .is("deleted_at", null)
           .maybeSingle();
+        if (!raced) {
+          ({ data: raced } = await db
+            .from("users")
+            .select("*")
+            .eq("firebase_uid", firebaseUid)
+            .is("deleted_at", null)
+            .maybeSingle());
+        }
         if (raced) {
           const user = mapUserFromDb(raced);
           const company = user.companyId ? await fetchCompanyById(user.companyId) : null;

--- a/src/app/api/auth/sync-user/route.ts
+++ b/src/app/api/auth/sync-user/route.ts
@@ -11,9 +11,10 @@
  * - Updates last-login timestamp on existing users
  * - Sets `firebase_uid` from the verified token at creation and repairs
  *   null/stale values on login — every firebase_uid write is gated on the
- *   token being Firebase-issued so a Supabase-issued token can never seed the
- *   column with a Supabase auth UUID (audit risk R8 — the shared RPCs resolve
- *   identity via users.firebase_uid = JWT sub)
+ *   token being Firebase-issued (audit risk R8 — the shared RPCs resolve
+ *   identity via users.firebase_uid = JWT sub). OPS is Firebase-only today, so
+ *   that gate is a defense-in-depth invariant (always true), not an active
+ *   dual-issuer switch
  * - Returns the user and their associated company (if any)
  *
  * Body: { idToken, email, displayName?, firstName?, lastName?, photoURL? }
@@ -165,7 +166,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // Verify auth token (Supabase or Firebase)
+    // Verify the Firebase ID token
     const firebaseUser = await verifyAuthToken(idToken);
     const firebaseUid = firebaseUser.uid;
 
@@ -257,9 +258,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
       // firebase_uid must mirror the VERIFIED token's uid (audit risk R8 — the
       // shared RPCs resolve identity via users.firebase_uid = JWT sub).
-      // Backfill legacy null rows AND repair stale/divergent values. Gated on
-      // the token being Firebase-issued so a Supabase-issued token (sub =
-      // Supabase auth UUID) can never clobber a real Firebase UID. The
+      // Backfill legacy null rows AND repair stale/divergent values. The
+      // isFirebaseIssuedToken gate is a defense-in-depth invariant (OPS is
+      // Firebase-only, so it is always true today) that keeps a non-Firebase
+      // issuer's sub out of the column if one is ever reintroduced. The
       // claimed-by-different-identity guard above has already rejected an
       // unverified email-only match against a row linked to another sub, so
       // reaching here means the rewrite is the caller's own row (or the email
@@ -305,14 +307,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const derivedFirst = firstName || displayName?.split(" ")[0] || "";
     const derivedLast = lastName || displayName?.split(" ").slice(1).join(" ") || "";
 
-    // auth_id is provider-agnostic by design — it maps the verified token's
-    // sub (Supabase auth UUID for iOS, Firebase UID for web) to the app user;
-    // RLS helpers resolve identity via auth_id, so it must be written for both
-    // providers. firebase_uid must only ever hold Firebase UIDs (audit risk R8
-    // — the shared RPCs resolve identity via users.firebase_uid = JWT sub), so
-    // it carries the same Firebase-issued gate as the backfill above: a
-    // Supabase-issued token creating a row must not seed the column with a
-    // Supabase auth UUID.
+    // auth_id maps the verified token's sub (the Firebase UID) to the app user;
+    // RLS helpers resolve identity via auth_id, so it is always written.
+    // firebase_uid must only ever hold Firebase UIDs (audit risk R8 — the
+    // shared RPCs resolve identity via users.firebase_uid = JWT sub), so it
+    // carries the same defense-in-depth Firebase-issued gate as the backfill
+    // above (always true today, since OPS is Firebase-only) — a non-Firebase
+    // issuer's sub must never seed the column.
     const newRow = {
       auth_id: firebaseUid,
       firebase_uid: isFirebaseIssuedToken(firebaseUser.claims)

--- a/src/lib/firebase/admin-verify.ts
+++ b/src/lib/firebase/admin-verify.ts
@@ -1,10 +1,12 @@
 /**
  * OPS Web - Server-side JWT Verification
  *
- * Verifies auth tokens from both Supabase Auth (iOS app) and Firebase Auth
- * (web dashboard) in API routes using jose.
+ * Verifies Firebase ID tokens in API routes using jose. OPS authenticates
+ * every client — the web dashboard AND the iOS apps — with Firebase Auth;
+ * Supabase is only the database (the Firebase JWT is bridged to Postgres via
+ * Supabase third-party auth). No caller presents a Supabase-issued auth token,
+ * so this module verifies against Google's Firebase JWKS only.
  *
- * - Supabase JWTs: Asymmetric (RS256/ES256) verified via Supabase JWKS endpoint
  * - Firebase JWTs: RS256 signed, verified via Google's public JWKS
  *
  * NEVER import this from client-side code.
@@ -13,32 +15,12 @@
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 import type { NextRequest } from "next/server";
 
-// Cache the JWKS fetchers — they handle key rotation automatically
+// Cache the JWKS fetcher — it handles key rotation automatically
 const FIREBASE_JWKS = createRemoteJWKSet(
   new URL(
     "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"
   )
 );
-
-// Supabase JWKS — uses the project's public key endpoint
-function getSupabaseJWKS() {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  if (!supabaseUrl) {
-    throw new Error("NEXT_PUBLIC_SUPABASE_URL not configured");
-  }
-  return createRemoteJWKSet(
-    new URL(`${supabaseUrl}/auth/v1/.well-known/jwks.json`)
-  );
-}
-
-// Lazy-initialized cached instance
-let _supabaseJWKS: ReturnType<typeof createRemoteJWKSet> | null = null;
-function supabaseJWKS() {
-  if (!_supabaseJWKS) {
-    _supabaseJWKS = getSupabaseJWKS();
-  }
-  return _supabaseJWKS;
-}
 
 export interface VerifiedUser {
   uid: string;
@@ -50,45 +32,20 @@ export interface VerifiedUser {
 export type VerifiedFirebaseUser = VerifiedUser;
 
 /**
- * True when a verified token was issued by Firebase (vs Supabase Auth).
- * `users.firebase_uid` must only ever hold Firebase UIDs, so every write to
- * that column is gated on this check — a Supabase-issued token's `sub` is a
- * Supabase auth UUID and would poison the column.
+ * True when a verified token was issued by Firebase.
+ *
+ * `verifyAuthToken` only accepts Firebase-issued tokens, so for any token that
+ * reached the app this is now always true. It is kept as a defense-in-depth
+ * invariant guarding writes to `users.firebase_uid` (which must only ever hold
+ * Firebase UIDs): if a non-Firebase issuer is ever reintroduced, this stops
+ * that token's `sub` (which would not be a Firebase UID) from poisoning the
+ * column.
  */
 export function isFirebaseIssuedToken(claims: JWTPayload): boolean {
   return (
     typeof claims.iss === "string" &&
     claims.iss.startsWith("https://securetoken.google.com/")
   );
-}
-
-/**
- * Verify a Supabase Auth JWT (asymmetric, verified via Supabase JWKS endpoint).
- * Throws if the token is invalid, expired, or signature doesn't match.
- */
-export async function verifySupabaseToken(
-  token: string
-): Promise<VerifiedUser> {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  if (!supabaseUrl) {
-    throw new Error("NEXT_PUBLIC_SUPABASE_URL not configured");
-  }
-
-  const issuer = `${supabaseUrl}/auth/v1`;
-
-  const { payload } = await jwtVerify(token, supabaseJWKS(), {
-    issuer,
-  });
-
-  if (!payload.sub) {
-    throw new Error("Token missing subject (uid)");
-  }
-
-  return {
-    uid: payload.sub,
-    email: payload.email as string | undefined,
-    claims: payload,
-  };
 }
 
 /**
@@ -121,44 +78,25 @@ export async function verifyFirebaseToken(
 }
 
 /**
- * Verify an auth token — tries Supabase first (iOS app), then Firebase (web).
- * Throws if neither verification succeeds.
+ * Verify an auth token. OPS is Firebase-only (web + iOS), so this verifies the
+ * Firebase ID token. Throws if verification fails.
  */
-export async function verifyAuthToken(
-  token: string
-): Promise<VerifiedUser> {
-  let supabaseError: unknown;
-  let firebaseError: unknown;
-
-  // Try Supabase JWT first (primary auth for iOS app)
-  try {
-    return await verifySupabaseToken(token);
-  } catch (err) {
-    supabaseError = err;
-  }
-
-  // Try Firebase JWT (web dashboard auth)
+export async function verifyAuthToken(token: string): Promise<VerifiedUser> {
   try {
     return await verifyFirebaseToken(token);
   } catch (err) {
-    firebaseError = err;
+    // LOW-2: log only the failure reason, never any portion of the token.
+    console.error("[verifyAuthToken] Firebase token verification failed:", {
+      reason: err instanceof Error ? err.message : String(err),
+      projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    });
+    throw err;
   }
-
-  // Both failed — log the verifier errors for debugging. LOW-2: do not log any
-  // portion of the token itself (even a prefix), only the failure reasons.
-  console.error("[verifyAuthToken] Both verification methods failed:", {
-    supabase: supabaseError instanceof Error ? supabaseError.message : String(supabaseError),
-    firebase: firebaseError instanceof Error ? firebaseError.message : String(firebaseError),
-    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  });
-
-  throw firebaseError;
 }
 
 /**
  * Extract and verify an auth token from a Next.js request.
  * Checks Authorization header, then cookie fallbacks.
- * Supports both Supabase (iOS) and Firebase (web) tokens.
  * Returns null if no token present or verification fails.
  */
 export async function verifyAdminAuth(

--- a/src/lib/firebase/admin-verify.ts
+++ b/src/lib/firebase/admin-verify.ts
@@ -50,6 +50,19 @@ export interface VerifiedUser {
 export type VerifiedFirebaseUser = VerifiedUser;
 
 /**
+ * True when a verified token was issued by Firebase (vs Supabase Auth).
+ * `users.firebase_uid` must only ever hold Firebase UIDs, so every write to
+ * that column is gated on this check — a Supabase-issued token's `sub` is a
+ * Supabase auth UUID and would poison the column.
+ */
+export function isFirebaseIssuedToken(claims: JWTPayload): boolean {
+  return (
+    typeof claims.iss === "string" &&
+    claims.iss.startsWith("https://securetoken.google.com/")
+  );
+}
+
+/**
  * Verify a Supabase Auth JWT (asymmetric, verified via Supabase JWKS endpoint).
  * Throws if the token is invalid, expired, or signature doesn't match.
  */
@@ -131,12 +144,12 @@ export async function verifyAuthToken(
     firebaseError = err;
   }
 
-  // Both failed — log details for debugging
+  // Both failed — log the verifier errors for debugging. LOW-2: do not log any
+  // portion of the token itself (even a prefix), only the failure reasons.
   console.error("[verifyAuthToken] Both verification methods failed:", {
     supabase: supabaseError instanceof Error ? supabaseError.message : String(supabaseError),
     firebase: firebaseError instanceof Error ? firebaseError.message : String(firebaseError),
     projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-    tokenPrefix: token.substring(0, 20) + "...",
   });
 
   throw firebaseError;

--- a/src/lib/supabase/find-user-by-auth.ts
+++ b/src/lib/supabase/find-user-by-auth.ts
@@ -5,6 +5,16 @@
  * Needed because auth_id was historically UUID type (preventing Firebase UID storage),
  * so many users have neither auth_id nor firebase_uid populated.
  *
+ * CRIT-3 Phase A — opportunistic backfill. The RLS identity helpers are being
+ * re-keyed off the cryptographic token sub (auth_id / firebase_uid) instead of
+ * the spoofable email claim. To make that re-key safe, every active row must be
+ * sub-linked first. This resolver runs on ~every authenticated request, so when
+ * a row is matched by a CRYPTOGRAPHIC path (firebase_uid == verified sub) and
+ * its provider-agnostic auth_id is still NULL, it stamps auth_id = sub here —
+ * trending the unlinked population toward zero on normal traffic, not just on
+ * login (sync-user already backfills on the login path). An email match is NOT
+ * proof of possession, so identity is NEVER written on the email branch.
+ *
  * NEVER import this from client-side code.
  */
 
@@ -12,12 +22,19 @@ import { getServiceRoleClient } from "./server-client";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+/** Ensure a comma-separated PostgREST select list contains `column`. */
+function withColumn(select: string, column: string): string {
+  const cols = select.split(",").map((c) => c.trim());
+  if (cols.includes("*") || cols.includes(column)) return select;
+  return `${select}, ${column}`;
+}
+
 /**
  * Find a user by auth credentials with fallback chain:
  * auth_id → firebase_uid → email
  *
- * @param uid - The auth UID (Firebase UID or Supabase auth UUID)
- * @param email - Optional email for fallback lookup
+ * @param uid - The verified token sub (Firebase UID or Supabase auth UUID)
+ * @param email - Optional verified-token email for the legacy-link fallback
  * @param select - Columns to select (default: "id, company_id")
  */
 export async function findUserByAuth(
@@ -27,6 +44,7 @@ export async function findUserByAuth(
 ): Promise<Record<string, unknown> | null> {
   const db = getServiceRoleClient();
 
+  // 1. auth_id == sub — provider-agnostic cryptographic match; already linked.
   const { data: byAuthId } = await db
     .from("users")
     .select(select)
@@ -35,15 +53,41 @@ export async function findUserByAuth(
     .maybeSingle();
   if (byAuthId) return byAuthId as any;
 
+  // 2. firebase_uid == sub — cryptographic match. `uid` is a proven Firebase
+  //    UID here (the column only ever holds Firebase UIDs). Opportunistic
+  //    backfill: if auth_id is still NULL, stamp it = uid so the row is also
+  //    resolvable by the provider-agnostic auth_id predicate the re-keyed RLS
+  //    helpers use. NULL-guarded (`.is("auth_id", null)`) so it is idempotent,
+  //    race-safe, and can never overwrite an existing identity. Mirrors
+  //    sync-user's ungated auth_id backfill (route.ts).
   const { data: byFirebaseUid } = await db
     .from("users")
-    .select(select)
+    .select(withColumn(withColumn(select, "id"), "auth_id"))
     .eq("firebase_uid", uid)
     .is("deleted_at", null)
     .maybeSingle();
-  if (byFirebaseUid) return byFirebaseUid as any;
+  if (byFirebaseUid) {
+    const row = byFirebaseUid as unknown as Record<string, unknown>;
+    if (row.auth_id == null && row.id != null) {
+      await db
+        .from("users")
+        .update({ auth_id: uid })
+        .eq("id", row.id as string)
+        .is("auth_id", null);
+      row.auth_id = uid;
+    }
+    return row as any;
+  }
 
-  if (email) {
+  // 3. email fallback (verified-token email) — the legacy-link path for the
+  //    not-yet-sub-linked cohort. An email match is NOT cryptographic proof of
+  //    possession (CRIT-3), so identity is NEVER backfilled here.
+  //    Phase D: once the RLS helpers are re-keyed to the sub (Phase C) and the
+  //    active base is fully linked, CRIT3_SUB_IDENTITY=true drops this branch
+  //    so ALL resolution is cryptographic. Default off keeps legacy login
+  //    working until the re-key is live.
+  const dropEmailFallback = process.env.CRIT3_SUB_IDENTITY === "true";
+  if (email && !dropEmailFallback) {
     const { data: byEmail } = await db
       .from("users")
       .select(select)

--- a/src/lib/supabase/find-user-by-auth.ts
+++ b/src/lib/supabase/find-user-by-auth.ts
@@ -33,7 +33,7 @@ function withColumn(select: string, column: string): string {
  * Find a user by auth credentials with fallback chain:
  * auth_id → firebase_uid → email
  *
- * @param uid - The verified token sub (Firebase UID or Supabase auth UUID)
+ * @param uid - The verified token sub (the Firebase UID)
  * @param email - Optional verified-token email for the legacy-link fallback
  * @param select - Columns to select (default: "id, company_id")
  */

--- a/tests/api/auth/send-verification.test.ts
+++ b/tests/api/auth/send-verification.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  verifyAuthTokenMock,
+  generateEmailVerificationLinkMock,
+  sendEmailVerificationMock,
+} = vi.hoisted(() => ({
+  verifyAuthTokenMock: vi.fn(),
+  generateEmailVerificationLinkMock: vi.fn(),
+  sendEmailVerificationMock: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/admin-verify", () => ({
+  verifyAuthToken: verifyAuthTokenMock,
+}));
+
+vi.mock("@/lib/firebase/admin", () => ({
+  getAdminAuth: () => ({
+    generateEmailVerificationLink: generateEmailVerificationLinkMock,
+  }),
+}));
+
+vi.mock("@/lib/email/sendgrid", () => ({
+  sendEmailVerification: sendEmailVerificationMock,
+}));
+
+import { POST } from "@/app/api/auth/send-verification/route";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/auth/send-verification", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function post(body: unknown) {
+  const res = await POST(
+    makeRequest(body) as unknown as Parameters<typeof POST>[0]
+  );
+  return { status: res.status, body: await res.json() };
+}
+
+describe("POST /api/auth/send-verification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("400s when token is missing", async () => {
+    const result = await post({});
+    expect(result.status).toBe(400);
+    expect(sendEmailVerificationMock).not.toHaveBeenCalled();
+  });
+
+  it("does not send when the email is already verified", async () => {
+    verifyAuthTokenMock.mockResolvedValue({
+      uid: "fb-1",
+      email: "owner@example.com",
+      claims: { email_verified: true },
+    });
+
+    const result = await post({ token: "valid" });
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ sent: false, alreadyVerified: true });
+    expect(generateEmailVerificationLinkMock).not.toHaveBeenCalled();
+    expect(sendEmailVerificationMock).not.toHaveBeenCalled();
+  });
+
+  it("generates a link, rebuilds it through /auth/action, and sends via the branded template", async () => {
+    verifyAuthTokenMock.mockResolvedValue({
+      uid: "fb-2",
+      email: "newuser@example.com",
+      claims: { email_verified: false },
+    });
+    // Firebase returns a link on ITS OWN action domain; the route must extract
+    // the oobCode and rebuild the URL through our handler.
+    generateEmailVerificationLinkMock.mockResolvedValue(
+      "https://ops-ios-app.firebaseapp.com/__/auth/action?mode=verifyEmail&oobCode=OOB_ABC123&apiKey=x"
+    );
+    sendEmailVerificationMock.mockResolvedValue(undefined);
+
+    const result = await post({ token: "valid" });
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ sent: true });
+
+    expect(generateEmailVerificationLinkMock).toHaveBeenCalledWith(
+      "newuser@example.com",
+      { url: "https://app.opsapp.co/auth/action" }
+    );
+    expect(sendEmailVerificationMock).toHaveBeenCalledTimes(1);
+    const arg = sendEmailVerificationMock.mock.calls[0][0];
+    expect(arg.email).toBe("newuser@example.com");
+    expect(arg.verifyLink).toBe(
+      "https://app.opsapp.co/auth/action?mode=verifyEmail&oobCode=OOB_ABC123"
+    );
+  });
+
+  it("400s when the verified token has no email claim", async () => {
+    verifyAuthTokenMock.mockResolvedValue({
+      uid: "fb-3",
+      email: null,
+      claims: { email_verified: false },
+    });
+
+    const result = await post({ token: "valid" });
+
+    expect(result.status).toBe(400);
+    expect(sendEmailVerificationMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/sync-user-creation.test.ts
+++ b/tests/integration/sync-user-creation.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { verifyAuthTokenMock, getServiceRoleClientMock } = vi.hoisted(() => ({
+  verifyAuthTokenMock: vi.fn(),
+  getServiceRoleClientMock: vi.fn(),
+}));
+
+// Use the REAL isFirebaseIssuedToken (issuer-prefix check) so the route's
+// firebase_uid gating is exercised against actual claims, while verifyAuthToken
+// is mocked to return canned verified tokens.
+vi.mock("@/lib/firebase/admin-verify", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/firebase/admin-verify")
+  >("@/lib/firebase/admin-verify");
+  return {
+    isFirebaseIssuedToken: actual.isFirebaseIssuedToken,
+    verifyAuthToken: verifyAuthTokenMock,
+  };
+});
+
+vi.mock("@/lib/supabase/server-client", () => ({
+  getServiceRoleClient: getServiceRoleClientMock,
+}));
+
+import { POST } from "@/app/api/auth/sync-user/route";
+
+interface SyncUserState {
+  userInserts: Array<Record<string, unknown>>;
+  /** When set, the first users insert fails with this Postgres error code. */
+  firstInsertErrorCode?: string;
+  /** Row a concurrent sync-user call committed between our lookup and our
+   *  insert. Only visible to lookups issued AFTER the insert attempt, which
+   *  is exactly when the 23505 race recovery re-queries. */
+  racedRow?: Record<string, unknown>;
+  /** Filter columns of users lookups issued after the insert attempt. */
+  recoveryLookups: string[][];
+}
+
+/**
+ * Double for the service-role client covering the new-user path:
+ * the three lookup chains (auth_id → firebase_uid → email) all miss,
+ * then the insert succeeds and echoes its payload back. With
+ * `firstInsertErrorCode` set, the insert instead fails (unique-violation
+ * race) and `racedRow` becomes visible to the recovery lookups that follow.
+ */
+function makeDbDouble(state: SyncUserState) {
+  class Query {
+    private operation: "insert" | null = null;
+    private payload: Record<string, unknown> | null = null;
+    private filters: Record<string, unknown> = {};
+
+    constructor(private readonly table: string) {}
+
+    insert(payload: Record<string, unknown>) {
+      this.operation = "insert";
+      this.payload = payload;
+      if (this.table === "users") state.userInserts.push(payload);
+      return this;
+    }
+
+    select() {
+      return this;
+    }
+
+    eq(column?: string, value?: unknown) {
+      if (column) this.filters[column] = value;
+      return this;
+    }
+
+    is(column?: string, value?: unknown) {
+      if (column) this.filters[column] = value;
+      return this;
+    }
+
+    maybeSingle() {
+      // Pre-insert lookups always miss (the raced row "does not exist yet"
+      // when the route runs its initial auth_id → firebase_uid → email
+      // chain); post-insert recovery lookups match the raced row column by
+      // column, so a firebase_uid filter against a null column misses just
+      // like it would in Postgres.
+      if (
+        this.table === "users" &&
+        state.racedRow &&
+        state.userInserts.length > 0
+      ) {
+        state.recoveryLookups.push(Object.keys(this.filters));
+        const matches = Object.entries(this.filters).every(
+          ([column, value]) =>
+            (state.racedRow?.[column] ?? null) === (value ?? null)
+        );
+        return { data: matches ? state.racedRow : null, error: null };
+      }
+      return { data: null, error: null };
+    }
+
+    single() {
+      if (this.operation === "insert" && this.payload) {
+        if (state.firstInsertErrorCode && state.userInserts.length === 1) {
+          return {
+            data: null,
+            error: {
+              code: state.firstInsertErrorCode,
+              message: "duplicate key value violates unique constraint",
+            },
+          };
+        }
+        return { data: { id: "user-new", ...this.payload }, error: null };
+      }
+      return { data: null, error: null };
+    }
+  }
+
+  return { from: (table: string) => new Query(table) };
+}
+
+function makeState(): SyncUserState {
+  return { userInserts: [], recoveryLookups: [] };
+}
+
+function wireDb(state: SyncUserState) {
+  getServiceRoleClientMock.mockReturnValue(makeDbDouble(state));
+}
+
+function makeJsonRequest(body: unknown): Request {
+  return new Request("http://localhost/api/auth/sync-user", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function postSyncUser(body: unknown) {
+  const res = await POST(
+    makeJsonRequest(body) as unknown as Parameters<typeof POST>[0]
+  );
+  return { status: res.status, body: await res.json() };
+}
+
+const FIREBASE_ISS = "https://securetoken.google.com/ops-project";
+const SUPABASE_ISS = "https://ops-project.supabase.co/auth/v1";
+
+describe("POST /api/auth/sync-user row creation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a new row with firebase_uid null for a Supabase-issued token", async () => {
+    verifyAuthTokenMock.mockResolvedValue({
+      uid: "supabase-auth-uuid-1",
+      email: "crew@example.com",
+      claims: { iss: SUPABASE_ISS, sub: "supabase-auth-uuid-1" },
+    });
+    const state = makeState();
+    wireDb(state);
+
+    const result = await postSyncUser({
+      idToken: "valid-token",
+      email: "crew@example.com",
+      displayName: "Crew Member",
+    });
+
+    expect(result.status).toBe(200);
+    expect(state.userInserts).toHaveLength(1);
+    // auth_id is provider-agnostic and must always carry the token sub;
+    // firebase_uid must only ever hold Firebase UIDs, so a Supabase-issued
+    // token creates the row with firebase_uid null.
+    expect(state.userInserts[0]).toMatchObject({
+      auth_id: "supabase-auth-uuid-1",
+      firebase_uid: null,
+      email: "crew@example.com",
+    });
+    expect(result.body.user).toMatchObject({ id: "user-new" });
+  });
+
+  it("creates a new row with firebase_uid set for a Firebase-issued token", async () => {
+    verifyAuthTokenMock.mockResolvedValue({
+      uid: "firebase-user-1",
+      email: "owner@example.com",
+      claims: { iss: FIREBASE_ISS, sub: "firebase-user-1" },
+    });
+    const state = makeState();
+    wireDb(state);
+
+    const result = await postSyncUser({
+      idToken: "valid-token",
+      email: "owner@example.com",
+      displayName: "Owner User",
+    });
+
+    expect(result.status).toBe(200);
+    expect(state.userInserts).toHaveLength(1);
+    expect(state.userInserts[0]).toMatchObject({
+      auth_id: "firebase-user-1",
+      firebase_uid: "firebase-user-1",
+      email: "owner@example.com",
+    });
+    expect(result.body.user).toMatchObject({ id: "user-new" });
+  });
+
+  it("recovers from a 23505 insert race via the auth_id-first lookup for a Supabase-token caller", async () => {
+    verifyAuthTokenMock.mockResolvedValue({
+      uid: "supabase-auth-uuid-2",
+      email: "crew2@example.com",
+      claims: { iss: SUPABASE_ISS, sub: "supabase-auth-uuid-2" },
+    });
+    const state = makeState();
+    // A concurrent sync-user call (e.g. JoinPage + AuthProvider firing in
+    // parallel) committed this row between our lookup and our insert, so the
+    // insert hits Postgres unique_violation 23505. The raced row carries the
+    // Supabase sub in auth_id and firebase_uid null — a firebase_uid-first
+    // recovery lookup would miss it; auth_id-first finds it.
+    state.firstInsertErrorCode = "23505";
+    state.racedRow = {
+      id: "user-raced",
+      auth_id: "supabase-auth-uuid-2",
+      firebase_uid: null,
+      email: "crew2@example.com",
+      company_id: null,
+    };
+    wireDb(state);
+
+    const result = await postSyncUser({
+      idToken: "valid-token",
+      email: "crew2@example.com",
+      displayName: "Crew Member",
+    });
+
+    // Both racers see a 200 with the same row, as if this call created it.
+    expect(result.status).toBe(200);
+    expect(state.userInserts).toHaveLength(1);
+    expect(result.body.user).toMatchObject({ id: "user-raced" });
+    // Recovery resolved the row on its first lookup, which filters by
+    // auth_id; the firebase_uid fallback lookup was never needed.
+    expect(state.recoveryLookups).toEqual([["auth_id", "deleted_at"]]);
+  });
+});

--- a/tests/integration/sync-user-creation.test.ts
+++ b/tests/integration/sync-user-creation.test.ts
@@ -137,18 +137,22 @@ async function postSyncUser(body: unknown) {
 }
 
 const FIREBASE_ISS = "https://securetoken.google.com/ops-project";
-const SUPABASE_ISS = "https://ops-project.supabase.co/auth/v1";
+// Synthetic NON-Firebase issuer — a defensive-guard input only. OPS is
+// Firebase-only (web + iOS); no live client produces a token with this issuer.
+// It exists here purely to exercise the isFirebaseIssuedToken guard (keeps
+// firebase_uid null) and the firebase_uid-null race-recovery edge.
+const NON_FIREBASE_ISS = "https://ops-project.supabase.co/auth/v1";
 
 describe("POST /api/auth/sync-user row creation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("creates a new row with firebase_uid null for a Supabase-issued token", async () => {
+  it("defensive guard: creates a new row with firebase_uid null for a NON-Firebase-issued token", async () => {
     verifyAuthTokenMock.mockResolvedValue({
       uid: "supabase-auth-uuid-1",
       email: "crew@example.com",
-      claims: { iss: SUPABASE_ISS, sub: "supabase-auth-uuid-1" },
+      claims: { iss: NON_FIREBASE_ISS, sub: "supabase-auth-uuid-1" },
     });
     const state = makeState();
     wireDb(state);
@@ -161,9 +165,10 @@ describe("POST /api/auth/sync-user row creation", () => {
 
     expect(result.status).toBe(200);
     expect(state.userInserts).toHaveLength(1);
-    // auth_id is provider-agnostic and must always carry the token sub;
-    // firebase_uid must only ever hold Firebase UIDs, so a Supabase-issued
-    // token creates the row with firebase_uid null.
+    // auth_id always carries the token sub; firebase_uid must only ever hold
+    // Firebase UIDs, so the isFirebaseIssuedToken guard keeps it null for a
+    // non-Firebase issuer. No live client hits this today (OPS is Firebase-
+    // only) — this asserts the defense-in-depth guard holds if one ever did.
     expect(state.userInserts[0]).toMatchObject({
       auth_id: "supabase-auth-uuid-1",
       firebase_uid: null,
@@ -197,18 +202,19 @@ describe("POST /api/auth/sync-user row creation", () => {
     expect(result.body.user).toMatchObject({ id: "user-new" });
   });
 
-  it("recovers from a 23505 insert race via the auth_id-first lookup for a Supabase-token caller", async () => {
+  it("recovers from a 23505 insert race via the auth_id-first lookup (firebase_uid-null raced row)", async () => {
     verifyAuthTokenMock.mockResolvedValue({
       uid: "supabase-auth-uuid-2",
       email: "crew2@example.com",
-      claims: { iss: SUPABASE_ISS, sub: "supabase-auth-uuid-2" },
+      claims: { iss: NON_FIREBASE_ISS, sub: "supabase-auth-uuid-2" },
     });
     const state = makeState();
     // A concurrent sync-user call (e.g. JoinPage + AuthProvider firing in
     // parallel) committed this row between our lookup and our insert, so the
-    // insert hits Postgres unique_violation 23505. The raced row carries the
-    // Supabase sub in auth_id and firebase_uid null — a firebase_uid-first
-    // recovery lookup would miss it; auth_id-first finds it.
+    // insert hits Postgres unique_violation 23505. The raced row has the sub in
+    // auth_id and firebase_uid null (a legacy/divergent row, or the defensive
+    // non-Firebase path) — a firebase_uid-first recovery lookup would miss it;
+    // auth_id-first finds it.
     state.firstInsertErrorCode = "23505";
     state.racedRow = {
       id: "user-raced",

--- a/tests/integration/sync-user-identity-guard.test.ts
+++ b/tests/integration/sync-user-identity-guard.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { verifyAuthTokenMock, getServiceRoleClientMock } = vi.hoisted(() => ({
+  verifyAuthTokenMock: vi.fn(),
+  getServiceRoleClientMock: vi.fn(),
+}));
+
+// Real isFirebaseIssuedToken (issuer-prefix check); verifyAuthToken mocked.
+vi.mock("@/lib/firebase/admin-verify", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/firebase/admin-verify")
+  >("@/lib/firebase/admin-verify");
+  return {
+    isFirebaseIssuedToken: actual.isFirebaseIssuedToken,
+    verifyAuthToken: verifyAuthTokenMock,
+  };
+});
+
+vi.mock("@/lib/supabase/server-client", () => ({
+  getServiceRoleClient: getServiceRoleClientMock,
+}));
+
+import { POST } from "@/app/api/auth/sync-user/route";
+
+type Row = Record<string, unknown>;
+interface UpdateCall {
+  id: unknown;
+  payload: Row;
+}
+interface DbState {
+  rows: Row[];
+  updates: UpdateCall[];
+  inserts: Row[];
+}
+
+/**
+ * In-memory `users` double covering the sync-user existing-row path:
+ *   lookups  `.select().eq().is().maybeSingle()`  (auth_id → firebase_uid → email)
+ *   updates  `.update().eq("id", …)`              (awaited directly)
+ *   inserts  `.insert().select().single()`
+ * `.is("deleted_at", null)` is modelled as `deleted_at == null`. Every lookup
+ * matches against ALL provided filters, exactly like PostgREST — so an email
+ * lookup resolves a row only when the FILTER email (which the route sets from
+ * the verified token, never the request body) equals a row's email.
+ */
+function makeDb(state: DbState) {
+  class Query {
+    private op: "select" | "update" | "insert" = "select";
+    private payload: Row | null = null;
+    private filters: Record<string, unknown> = {};
+    constructor(private readonly table: string) {}
+
+    select() {
+      return this;
+    }
+    insert(payload: Row) {
+      this.op = "insert";
+      this.payload = payload;
+      if (this.table === "users") state.inserts.push(payload);
+      return this;
+    }
+    update(payload: Row) {
+      this.op = "update";
+      this.payload = payload;
+      return this;
+    }
+    eq(column?: string, value?: unknown) {
+      if (column) this.filters[column] = value;
+      return this;
+    }
+    is(column?: string, value?: unknown) {
+      if (column) this.filters[column] = value ?? null;
+      return this;
+    }
+
+    private match(): Row[] {
+      if (this.table !== "users") return [];
+      return state.rows.filter((r) =>
+        Object.entries(this.filters).every(
+          ([column, value]) => (r[column] ?? null) === (value ?? null)
+        )
+      );
+    }
+
+    maybeSingle() {
+      return { data: this.match()[0] ?? null, error: null };
+    }
+
+    single() {
+      if (this.op === "insert" && this.payload) {
+        return { data: { id: "user-new", ...this.payload }, error: null };
+      }
+      return { data: null, error: null };
+    }
+
+    // The update chain terminates on `.eq("id", …)` and is awaited directly,
+    // so Query is a thenable: awaiting it applies the update to the matched row.
+    then(resolve: (x: { error: null }) => unknown) {
+      if (this.op === "update" && this.payload) {
+        const target = state.rows.find((r) => r.id === this.filters.id);
+        state.updates.push({ id: this.filters.id, payload: this.payload });
+        if (target) Object.assign(target, this.payload);
+      }
+      return Promise.resolve({ error: null }).then(resolve);
+    }
+  }
+  return { from: (table: string) => new Query(table) };
+}
+
+function wire(state: DbState) {
+  getServiceRoleClientMock.mockReturnValue(makeDb(state));
+}
+
+function makeState(rows: Row[]): DbState {
+  return { rows, updates: [], inserts: [] };
+}
+
+async function postSyncUser(body: unknown) {
+  const req = new Request("http://localhost/api/auth/sync-user", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+  return { status: res.status, body: await res.json() };
+}
+
+const FIREBASE_ISS = "https://securetoken.google.com/ops-project";
+
+describe("POST /api/auth/sync-user — CRIT-3 identity guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refuses an unverified email-only match against a row bound to a DIFFERENT firebase_uid (403)", async () => {
+    const state = makeState([
+      {
+        id: "victim",
+        auth_id: null,
+        firebase_uid: "victim-fb",
+        email: "shared@example.com",
+        company_id: "c-victim",
+        deleted_at: null,
+      },
+    ]);
+    wire(state);
+    verifyAuthTokenMock.mockResolvedValue({
+      uid: "attacker-fb",
+      email: "shared@example.com",
+      claims: { iss: FIREBASE_ISS, email_verified: false },
+    });
+
+    const result = await postSyncUser({
+      idToken: "valid",
+      email: "shared@example.com",
+    });
+
+    expect(result.status).toBe(403);
+    expect(result.body).toMatchObject({
+      error: "Email verification required to access this account.",
+    });
+    // The victim row is neither rewritten nor handed back.
+    expect(state.updates).toHaveLength(0);
+    expect(state.rows[0].firebase_uid).toBe("victim-fb");
+    expect(state.rows[0].auth_id).toBeNull();
+  });
+
+  it("refuses an unverified email-only match against a row bound to a DIFFERENT auth_id (403)", async () => {
+    const state = makeState([
+      {
+        id: "victim2",
+        auth_id: "victim-auth",
+        firebase_uid: null,
+        email: "shared2@example.com",
+        company_id: "c-victim2",
+        deleted_at: null,
+      },
+    ]);
+    wire(state);
+    verifyAuthTokenMock.mockResolvedValue({
+      uid: "attacker-fb2",
+      email: "shared2@example.com",
+      claims: { iss: FIREBASE_ISS, email_verified: false },
+    });
+
+    const result = await postSyncUser({
+      idToken: "valid",
+      email: "shared2@example.com",
+    });
+
+    expect(result.status).toBe(403);
+    expect(state.updates).toHaveLength(0);
+    expect(state.rows[0].auth_id).toBe("victim-auth");
+  });
+
+  it("keeps the legacy-link path open: attaches an UNCLAIMED row (both identity columns null) and backfills both", async () => {
+    const state = makeState([
+      {
+        id: "legacy",
+        auth_id: null,
+        firebase_uid: null,
+        email: "legacy@example.com",
+        company_id: null,
+        deleted_at: null,
+      },
+    ]);
+    wire(state);
+    verifyAuthTokenMock.mockResolvedValue({
+      uid: "web-fb",
+      email: "legacy@example.com",
+      claims: { iss: FIREBASE_ISS, email_verified: false },
+    });
+
+    const result = await postSyncUser({
+      idToken: "valid",
+      email: "legacy@example.com",
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.user).toMatchObject({ id: "legacy" });
+    // An unclaimed row is not bound to anyone, so the caller may attach and
+    // both identity columns are stamped from the verified Firebase token.
+    expect(state.updates).toHaveLength(1);
+    expect(state.updates[0].payload).toMatchObject({
+      auth_id: "web-fb",
+      firebase_uid: "web-fb",
+    });
+  });
+
+  it("resolves the email fallback on the VERIFIED TOKEN email, never the request-body email (CRIT-3)", async () => {
+    // The victim's row is keyed by victim@example.com. The attacker holds a
+    // token for attacker@example.com but puts the victim's address in the
+    // request body. Because the route looks up by the TOKEN email, the victim
+    // row is never matched, returned, or touched.
+    const state = makeState([
+      {
+        id: "victim3",
+        auth_id: "victim-auth3",
+        firebase_uid: "victim-fb3",
+        email: "victim@example.com",
+        company_id: "c-victim3",
+        deleted_at: null,
+      },
+    ]);
+    wire(state);
+    verifyAuthTokenMock.mockResolvedValue({
+      uid: "attacker-fb3",
+      email: "attacker@example.com",
+      claims: { iss: FIREBASE_ISS, email_verified: false },
+    });
+
+    const result = await postSyncUser({
+      idToken: "valid",
+      email: "victim@example.com",
+      createIfMissing: false,
+    });
+
+    // No account resolves for the attacker's verified email → 404, and the
+    // victim row is untouched. Had the body email been used for lookup, this
+    // would have returned 200 with the victim's account.
+    expect(result.status).toBe(404);
+    expect(state.updates).toHaveLength(0);
+    expect(state.inserts).toHaveLength(0);
+    expect(state.rows[0]).toMatchObject({
+      auth_id: "victim-auth3",
+      firebase_uid: "victim-fb3",
+    });
+  });
+});

--- a/tests/unit/firebase/is-firebase-issued-token.test.ts
+++ b/tests/unit/firebase/is-firebase-issued-token.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { JWTPayload } from "jose";
+import { isFirebaseIssuedToken } from "@/lib/firebase/admin-verify";
+
+/**
+ * isFirebaseIssuedToken is the defense-in-depth guard on every write to
+ * users.firebase_uid (audit risk R8). OPS verifies Firebase ID tokens only, so
+ * in production it is always true — these cases prove it correctly discriminates
+ * the Firebase issuer from anything else, should a non-Firebase issuer ever be
+ * introduced.
+ */
+describe("isFirebaseIssuedToken", () => {
+  it("is true for a Firebase securetoken issuer", () => {
+    const claims = {
+      iss: "https://securetoken.google.com/ops-project",
+      sub: "firebase-uid",
+    } as JWTPayload;
+    expect(isFirebaseIssuedToken(claims)).toBe(true);
+  });
+
+  it("is false for a Supabase (or any non-Firebase) issuer", () => {
+    const claims = {
+      iss: "https://ops-project.supabase.co/auth/v1",
+      sub: "00000000-0000-0000-0000-000000000000",
+    } as JWTPayload;
+    expect(isFirebaseIssuedToken(claims)).toBe(false);
+  });
+
+  it("is false when iss is missing", () => {
+    expect(isFirebaseIssuedToken({ sub: "x" } as JWTPayload)).toBe(false);
+  });
+
+  it("is false when iss is a non-string value", () => {
+    expect(
+      isFirebaseIssuedToken({ iss: 123 as unknown as string } as JWTPayload)
+    ).toBe(false);
+  });
+
+  it("does not match a look-alike issuer that only contains the Firebase host", () => {
+    // Must be a prefix match, not a substring — an attacker-controlled host
+    // that merely embeds the Firebase domain elsewhere is rejected.
+    const claims = {
+      iss: "https://evil.example.com/https://securetoken.google.com/ops",
+      sub: "x",
+    } as JWTPayload;
+    expect(isFirebaseIssuedToken(claims)).toBe(false);
+  });
+});

--- a/tests/unit/supabase/find-user-by-auth.test.ts
+++ b/tests/unit/supabase/find-user-by-auth.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getServiceRoleClientMock } = vi.hoisted(() => ({
+  getServiceRoleClientMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server-client", () => ({
+  getServiceRoleClient: getServiceRoleClientMock,
+}));
+
+import { findUserByAuth } from "@/lib/supabase/find-user-by-auth";
+
+type Row = Record<string, unknown>;
+interface UpdateCall {
+  payload: Row;
+  filters: Record<string, unknown>;
+}
+interface DbState {
+  rows: Row[];
+  updates: UpdateCall[];
+}
+
+/**
+ * In-memory `users` double supporting the select chain
+ * (`.select().eq().is().maybeSingle()`) and the awaited update chain
+ * (`.update().eq().is()`), so a test can assert exactly which opportunistic
+ * backfill writes the resolver issued. `.is(col, null)` is modelled as
+ * `col === null`, matching Postgres, so a NULL-guarded update only touches a
+ * row whose column is still null.
+ */
+function makeDb(state: DbState) {
+  class Query {
+    private op: "select" | "update" = "select";
+    private payload: Row | null = null;
+    private filters: Record<string, unknown> = {};
+    constructor(private readonly table: string) {}
+
+    select() {
+      this.op = "select";
+      return this;
+    }
+    update(payload: Row) {
+      this.op = "update";
+      this.payload = payload;
+      return this;
+    }
+    eq(column?: string, value?: unknown) {
+      if (column) this.filters[column] = value;
+      return this;
+    }
+    is(column?: string, value?: unknown) {
+      if (column) this.filters[column] = value ?? null;
+      return this;
+    }
+
+    private match(): Row[] {
+      if (this.table !== "users") return [];
+      return state.rows.filter((r) =>
+        Object.entries(this.filters).every(
+          ([column, value]) => (r[column] ?? null) === (value ?? null)
+        )
+      );
+    }
+
+    maybeSingle() {
+      return { data: this.match()[0] ?? null, error: null };
+    }
+
+    // The update chain is awaited directly (no terminal maybeSingle/single),
+    // so Query is a thenable: awaiting it applies the update.
+    then(resolve: (x: { data: null; error: null }) => unknown) {
+      if (this.op === "update" && this.payload) {
+        state.updates.push({
+          payload: this.payload,
+          filters: { ...this.filters },
+        });
+        for (const r of this.match()) Object.assign(r, this.payload);
+      }
+      return Promise.resolve({ data: null, error: null }).then(resolve);
+    }
+  }
+  return { from: (table: string) => new Query(table) };
+}
+
+function wire(state: DbState) {
+  getServiceRoleClientMock.mockReturnValue(makeDb(state));
+}
+
+describe("findUserByAuth — CRIT-3 Phase A opportunistic backfill", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the auth_id-matched row without writing anything (already linked)", async () => {
+    const state: DbState = {
+      rows: [
+        {
+          id: "u1",
+          auth_id: "sub1",
+          firebase_uid: null,
+          company_id: "c1",
+          deleted_at: null,
+        },
+      ],
+      updates: [],
+    };
+    wire(state);
+
+    const row = await findUserByAuth("sub1");
+
+    expect(row).toMatchObject({ id: "u1" });
+    expect(state.updates).toHaveLength(0);
+  });
+
+  it("backfills auth_id = sub when a firebase_uid match has a NULL auth_id", async () => {
+    const state: DbState = {
+      rows: [
+        {
+          id: "u2",
+          auth_id: null,
+          firebase_uid: "sub2",
+          company_id: "c2",
+          deleted_at: null,
+        },
+      ],
+      updates: [],
+    };
+    wire(state);
+
+    const row = await findUserByAuth("sub2");
+
+    expect(row).toMatchObject({ id: "u2", auth_id: "sub2" });
+    // Exactly one NULL-guarded update against this row.
+    expect(state.updates).toHaveLength(1);
+    expect(state.updates[0].payload).toEqual({ auth_id: "sub2" });
+    expect(state.updates[0].filters).toMatchObject({ id: "u2", auth_id: null });
+  });
+
+  it("does NOT touch auth_id on a firebase_uid match whose auth_id is already set", async () => {
+    const state: DbState = {
+      rows: [
+        {
+          id: "u3",
+          auth_id: "some-other-sub",
+          firebase_uid: "sub3",
+          company_id: "c3",
+          deleted_at: null,
+        },
+      ],
+      updates: [],
+    };
+    wire(state);
+
+    const row = await findUserByAuth("sub3");
+
+    expect(row).toMatchObject({ id: "u3" });
+    expect(state.updates).toHaveLength(0);
+  });
+
+  it("NEVER backfills identity on an email-only (non-cryptographic) match", async () => {
+    const state: DbState = {
+      rows: [
+        {
+          id: "u4",
+          auth_id: null,
+          firebase_uid: null,
+          email: "legacy@example.com",
+          company_id: "c4",
+          deleted_at: null,
+        },
+      ],
+      updates: [],
+    };
+    wire(state);
+
+    const row = await findUserByAuth("sub4", "legacy@example.com");
+
+    expect(row).toMatchObject({ id: "u4" });
+    // The CRIT-3 invariant: an email match is not proof of possession, so no
+    // auth_id/firebase_uid is written.
+    expect(state.updates).toHaveLength(0);
+  });
+
+  it("returns null when nothing matches", async () => {
+    const state: DbState = { rows: [], updates: [] };
+    wire(state);
+
+    expect(await findUserByAuth("nobody", "nobody@example.com")).toBeNull();
+    expect(state.updates).toHaveLength(0);
+  });
+
+  it("drops the email fallback entirely when CRIT3_SUB_IDENTITY is on (Phase D)", async () => {
+    const prev = process.env.CRIT3_SUB_IDENTITY;
+    process.env.CRIT3_SUB_IDENTITY = "true";
+    try {
+      const state: DbState = {
+        rows: [
+          {
+            id: "u5",
+            auth_id: null,
+            firebase_uid: null,
+            email: "legacy@example.com",
+            company_id: "c5",
+            deleted_at: null,
+          },
+        ],
+        updates: [],
+      };
+      wire(state);
+
+      // Post-re-key, resolution is cryptographic only — an email-only row is
+      // no longer returned (and certainly never backfilled).
+      expect(await findUserByAuth("sub5", "legacy@example.com")).toBeNull();
+      expect(state.updates).toHaveLength(0);
+    } finally {
+      process.env.CRIT3_SUB_IDENTITY = prev;
+    }
+  });
+});


### PR DESCRIPTION
## What this closes

Application-layer hardening of the Firebase login identity path (the RLS-level CRIT-3 in #87/#88 is already live; this is the missing app layer).

**Security holes closed**
- **Identity-spoofing gap in the login resolver.** Identity columns (`auth_id`/`firebase_uid`) were writable — and rows returnable — on the spoofable email claim without proof of possession.
- **No email verification.** `email_verified` was permanently false for every email/password account, which is why the model couldn't trust the email claim.

## Changes (3 atomic commits)

1. **`fix(auth)` — harden identity resolution.**
   - `findUserByAuth`: opportunistic `auth_id` backfill **only** on a cryptographic `firebase_uid == verified-sub` match, NULL-guarded at both the app level and the UPDATE `WHERE` clause (idempotent, race-safe, never overwrites). Never writes identity on the email branch. Email fallback drops entirely under `CRIT3_SUB_IDENTITY=true` (Phase D); **default OFF** preserves legacy login.
   - `admin-verify`: `isFirebaseIssuedToken` guard; stop logging any token prefix on verify failure (LOW-2).
   - `sync-user`: resolve the email fallback on the **verified token email**, never the request body; refuse (403) an unverified email-only match against a row bound to a different identity; gate every `firebase_uid` write on a Firebase-issued token; recover 23505 races by `auth_id` first.

2. **`feat(auth)` — `POST /api/auth/send-verification`** (CRIT-3 Phase B): verifies the token, no-ops when already verified, generates the Firebase link via Admin SDK, routes through `/auth/action`, sends the OPS SendGrid template, sanitizes auth errors.

3. **`refactor(auth)` — retire the dead Supabase-token verifier.** OPS authenticates every client (web + both iOS apps) with Firebase; Supabase is only the DB (JWT bridge). `verifyAuthToken` is now Firebase-only. `isFirebaseIssuedToken` kept as defense-in-depth. Verified safe by a multi-agent adversarial audit that read the iOS sources.

## Safety
- **`CRIT3_SUB_IDENTITY` ships default OFF** — the sub-only resolution path stays dormant; no missing-RPC path is reachable. Strict superset of current behavior.
- `setup/progress` company-creation refactor and the Supabase role-claim promotion were **deliberately excluded** (out of scope / unsafe under anon-RLS).

## Verification
- `tsc --noEmit`: baseline-clean (7 pre-existing xlsx / notification-service errors only, zero new).
- 22 auth tests pass (resolver, send-verification, sync-user creation + identity guard, `isFirebaseIssuedToken`).
- Full non-e2e suite: no new regressions vs clean `main` (the one extra failure, `sendgrid-onboarding-jack`, is a pre-existing timeout-flake confirmed on `main`).