### PR TITLE
Nightly Bug Sweep — web — 2026-07-17 — Batch 01

### DIFF
--- a/src/components/expenses/expense-filters.tsx
+++ b/src/components/expenses/expense-filters.tsx
@@ -18,6 +18,8 @@ interface ExpenseFiltersProps {
   onPeriodChange: (period: string) => void;
   /** Count of batches needing review (for badge) */
   reviewCount: number;
+  /** Period keys that have at least one batch awaiting review (drives the pill marker) */
+  periodsNeedingReview: Set<string>;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -29,6 +31,7 @@ export function ExpenseFilters({
   activePeriod,
   onPeriodChange,
   reviewCount,
+  periodsNeedingReview,
 }: ExpenseFiltersProps) {
   return (
     <div className="space-y-2">
@@ -66,20 +69,33 @@ export function ExpenseFilters({
       {/* Period pills — horizontal scroll */}
       {periods.length > 0 && (
         <div className="flex gap-1.5 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
-          {periods.map((period) => (
-            <button
-              key={period}
-              onClick={() => onPeriodChange(period)}
-              className={cn(
-                "px-2.5 py-1 rounded font-mono text-[11px] uppercase tracking-wider whitespace-nowrap shrink-0 transition-colors border",
-                activePeriod === period
-                  ? "bg-[rgba(255,255,255,0.08)] text-text border-[rgba(255,255,255,0.15)]"
-                  : "text-text-3 border-transparent hover:text-text-2 hover:border-border"
-              )}
-            >
-              {formatPeriodDisplay(period)}
-            </button>
-          ))}
+          {periods.map((period) => {
+            const needsReview = periodsNeedingReview.has(period);
+            return (
+              <button
+                key={period}
+                onClick={() => onPeriodChange(period)}
+                title={needsReview ? "Has expenses to review" : undefined}
+                className={cn(
+                  "inline-flex items-center gap-1.5 px-2.5 py-1 rounded font-mono text-[11px] uppercase tracking-wider whitespace-nowrap shrink-0 transition-colors border",
+                  activePeriod === period
+                    ? "bg-[rgba(255,255,255,0.08)] text-text border-[rgba(255,255,255,0.15)]"
+                    : "text-text-3 border-transparent hover:text-text-2 hover:border-border"
+                )}
+              >
+                {needsReview && (
+                  <span
+                    className="h-1.5 w-1.5 shrink-0 rounded-full bg-[#D99A3E]"
+                    aria-hidden="true"
+                  />
+                )}
+                {formatPeriodDisplay(period)}
+                {needsReview && (
+                  <span className="sr-only"> — has expenses to review</span>
+                )}
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/expenses/expense-review-dashboard.tsx
+++ b/src/components/expenses/expense-review-dashboard.tsx
@@ -41,6 +41,18 @@ export function ExpenseReviewDashboard() {
     return [...keys].sort().reverse();
   }, [batches]);
 
+  // Period keys that have at least one batch awaiting review — drives the
+  // amber marker on the month pills so unreviewed months are visible at a glance.
+  const periodsNeedingReview = useMemo(() => {
+    const keys = new Set<string>();
+    for (const b of batches) {
+      if (!isBatchNeedsReview(b.status)) continue;
+      const key = periodKeyFromBatch(b);
+      if (key && key !== "unknown") keys.add(key);
+    }
+    return keys;
+  }, [batches]);
+
   // Auto-select latest period if none selected
   const effectivePeriod = activePeriod || periods[0] || "";
 
@@ -154,6 +166,7 @@ export function ExpenseReviewDashboard() {
           setSelectedBatchId(null);
         }}
         reviewCount={reviewBatches.length}
+        periodsNeedingReview={periodsNeedingReview}
       />
 
       {/* Period summary */}


### PR DESCRIPTION
Automated nightly bug sweep — web — Batch 01.

## Bugs in this batch

- [x] **26afeaba-ae68-42eb-8626-d85c5f6c8705** — category: bug
  - Summary: Books > Expenses months tab needs markers for which months have expenses to be reviewed.
  - Fix: The month pills in the Expenses review hub now show an amber marker dot (and a screen-reader label) on any month that has at least one expense batch awaiting review (status `pending_review` / `submitted`). Computed a Set of "needs review" period keys in `expense-review-dashboard.tsx` and passed it to `ExpenseFilters` (`expense-filters.tsx`), which renders the marker using the app-wide needs-review color `#D99A3E`. Data stays company-scoped via the existing `useExpenseBatches` query (RLS) and the same permission gating as the rest of the Expenses area.

## Build status

- Next.js production build: passes clean with this change.
- `tsc --noEmit` reports 2 pre-existing type errors in `tests/unit/api/services/notification-service.test.ts` — present on clean `main`, unrelated to this change, and in a directory the nightly agent must not modify. The changed source files compile cleanly.